### PR TITLE
Nested HDF5 groups in Utils

### DIFF
--- a/include/dfmodules/KeyedDataBlock.hpp
+++ b/include/dfmodules/KeyedDataBlock.hpp
@@ -29,6 +29,11 @@ public:
   const void* unowned_data_start;
   std::unique_ptr<char> owned_data_start;
 
+  // size_t trh_size;
+  //const void* unowned_trigger_record_header;
+  //std::unique_ptr<char> owned_trigger_record_header;
+
+
   explicit KeyedDataBlock(const StorageKey& theKey)
     : data_key(theKey)
   {}
@@ -42,7 +47,19 @@ public:
     }
   }
 
+/*
+  const void* getTriggerRecordHeader() const
+  {
+    if (owned_trigger_record_header.get() != nullptr) {
+      return static_cast<const void*>(owned_trigger_record_header.get());
+    } else {
+      return unowned_trigger_record_header;
+    }
+  }
+*/
+
   size_t getDataSizeBytes() const { return data_size; }
+  //size_t getTriggerRecordHeaderSizeBytes() const {return trh_size}
 };
 
 } // namespace dfmodules

--- a/plugins/DataGenerator.hpp
+++ b/plugins/DataGenerator.hpp
@@ -12,6 +12,7 @@
 #ifndef DFMODULES_SRC_DATAGENERATOR_HPP_
 #define DFMODULES_SRC_DATAGENERATOR_HPP_
 
+#include "dfmodules/CommonIssues.hpp"
 #include "dfmodules/DataStore.hpp"
 
 #include <appfwk/DAQModule.hpp>
@@ -70,13 +71,6 @@ private:
   std::unique_ptr<DataStore> dataWriter_;
 };
 } // namespace dfmodules
-
-ERS_DECLARE_ISSUE_BASE(dfmodules,
-                       ProgressUpdate,
-                       appfwk::GeneralDAQModuleIssue,
-                       message,
-                       ((std::string)name),
-                       ((std::string)message))
 
 ERS_DECLARE_ISSUE_BASE(dfmodules,
                        InvalidDataWriterError,

--- a/plugins/DataWriter.cpp
+++ b/plugins/DataWriter.cpp
@@ -170,6 +170,9 @@ DataWriter::do_work(std::atomic<bool>& running_flag)
       KeyedDataBlock data_block(fragment_skey);
       data_block.unowned_data_start = frag_ptr->get_storage_location();
       data_block.data_size = frag_ptr->get_size();
+
+      //data_block.unowned_trigger_record_header = 
+      //data_block.trh_size =
       data_writer_->write(data_block);
     }
 

--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -215,6 +215,7 @@ public:
     const std::string detectorType = group_and_dataset_path_elements[1];
     const std::string apagroup_name = group_and_dataset_path_elements[2];
     const std::string dataset_name = group_and_dataset_path_elements[3];
+    const std::string trh_dataset_name = "TriggerRecordHeader";
 
     // Check if a HDF5 group exists and if not create one
     if (!filePtr->exist(datagroup_name)) {
@@ -225,6 +226,20 @@ public:
     if (!theGroup.isValid()) {
       throw InvalidHDF5Group(ERS_HERE, get_name(), datagroup_name, filePtr->getName());
     } else {
+
+      // Create TriggerRecordHeader dataset 
+      /*
+      HighFive::DataSpace trh_theDataSpace = HighFive::DataSpace({ dataBlock.data_size, 1 });
+      HighFive::DataSetCreateProps trh_dataCProps_;
+      HighFive::DataSetAccessProps trh_dataAProps_;
+
+      auto trh_theDataSet = theGroup.createDataSet<char>(trh_dataset_name, trh_theDataSpace, trg_dataCProps_, trh_dataAProps_);
+      if (trh_theDataSet.isValid()) {
+        trh_theDataSet.write_raw(static_cast<const char*>(dataBlock.getTriggerRecordHeader()));
+      } else {
+        throw InvalidHDF5Dataset(ERS_HERE, get_name(), trh_dataset_name, filePtr->getName());
+      } // TriggerRecordHeader
+      */
  
       // Create detector type group
       HighFive::Group detectorTypeGroup = HDF5FileUtils::addSubGroup(theGroup, datagroup_name, detectorType);

--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -123,7 +123,7 @@ public:
 
     KeyedDataBlock dataBlock(key);
 
-    HighFive::Group theGroup = HDF5FileUtils::getSubGroup(filePtr, group_and_dataset_path_elements);
+    HighFive::Group theGroup = HDF5FileUtils::getSubGroup(filePtr, group_and_dataset_path_elements, false);
 
     try { // to determine if the dataset exists in the group and copy it to membuffer
       HighFive::DataSet theDataSet = theGroup.getDataSet(datasetName);
@@ -167,7 +167,7 @@ public:
     const std::string dataset_name = group_and_dataset_path_elements[3];
     const std::string trh_dataset_name = "TriggerRecordHeader";
 
-    HighFive::Group theGroup = HDF5FileUtils::addSubGroup(filePtr, group_and_dataset_path_elements, true);
+    HighFive::Group theGroup = HDF5FileUtils::getSubGroup(filePtr, group_and_dataset_path_elements, true);
 
     // Create dataset
     HighFive::DataSpace theDataSpace = HighFive::DataSpace({ dataBlock.data_size, 1 });

--- a/plugins/HDF5FileUtils.hpp
+++ b/plugins/HDF5FileUtils.hpp
@@ -12,6 +12,8 @@
  */
 
 #include <ers/ers.h>
+//#include "dfmodules/CommonIssues.hpp"
+
 #include <highfive/H5File.hpp>
 
 #include <filesystem>
@@ -26,8 +28,24 @@
 
 namespace dunedaq {
 namespace dfmodules {
-
 namespace HDF5FileUtils {
+/**
+ * @brief Retrieve top HDF5 group
+ */
+HighFive::Group
+getTopGroup(std::unique_ptr<HighFive::File> &filePtr, const std::vector<std::string>& group_dataset)
+{
+  std::string topLevelGroupName = group_dataset[0];
+  HighFive::Group topGroup = filePtr->getGroup(topLevelGroupName);
+  if (!topGroup.isValid()) {
+    //throw "Error in HDFFileHelper::getGroupFromPath: top-level group " + topLevelGroupName + " not found";
+    //throw InvalidHDF5Group(ERS_HERE, topLevelGroupName, topLevelGroupName, topLevelGroupName);
+  }
+  
+  return topGroup;
+}
+
+
 /**
  * @brief Recursive function to create HDF5 sub-groups
  */
@@ -41,6 +59,7 @@ getSubGroup(std::unique_ptr<HighFive::File> &filePtr, const std::vector<std::str
   HighFive::Group workingGroup = filePtr->getGroup(topLevelGroupName);
   if (! workingGroup.isValid()) {
     throw "Error in HDFFileHelper::getGroupFromPath: top-level group " + topLevelGroupName + " not found";
+    //throw InvalidHDF5Group(ERS_HERE, topLevelGroupName, topLevelGroupName, topLevelGroupName);
   }
   // Create the remaining subgroups
   for (size_t idx = 1; idx < group_dataset.size(); ++idx) {

--- a/plugins/HDF5FileUtils.hpp
+++ b/plugins/HDF5FileUtils.hpp
@@ -28,7 +28,24 @@ namespace dunedaq {
 namespace dfmodules {
 
 namespace HDF5FileUtils {
-
+/**
+ * @brief Check the valididty of an HDF5 SUB-group and, if not existing, create the group
+ */
+HighFive::Group
+addSubGroup(HighFive::Group parentGroup, const std::string& parentGroupName, const std::string& subGroupName)
+{
+  // Check if group exists and if not create one
+  if (!parentGroup.exist(subGroupName)) {
+    parentGroup.createGroup(subGroupName);
+  }
+  if (!parentGroup.isValid()) {
+    // AAA: throw error or define issue 
+    //throw ErrorHDF5Group(ERS_HERE, parentGroupName, subGroupName);
+  } else {
+    HighFive::Group subGroup = parentGroup.getGroup(subGroupName);
+    return subGroup;
+  }
+}
 /**
  * @brief This is a recursive function that adds the 'paths' to all of the DataSets
  * contained within the specified Group to the specified path list.  This function

--- a/plugins/HDF5FileUtils.hpp
+++ b/plugins/HDF5FileUtils.hpp
@@ -12,7 +12,7 @@
  */
 
 #include <ers/ers.h>
-//#include "dfmodules/CommonIssues.hpp"
+#include "dfmodules/CommonIssues.hpp"
 
 #include <highfive/H5File.hpp>
 
@@ -39,7 +39,8 @@ getTopGroup(std::unique_ptr<HighFive::File> &filePtr, const std::vector<std::str
   HighFive::Group topGroup = filePtr->getGroup(topLevelGroupName);
   if (!topGroup.isValid()) {
     //throw "Error in HDFFileHelper::getGroupFromPath: top-level group " + topLevelGroupName + " not found";
-    //throw InvalidHDF5Group(ERS_HERE, topLevelGroupName, topLevelGroupName, topLevelGroupName);
+    throw InvalidHDF5Group(ERS_HERE, topLevelGroupName, topLevelGroupName, topLevelGroupName);
+    //throw InvalidHDF5Group(ERS_HERE, get_name(), topLevelGroupName, topLevelGroupName);
   }
   
   return topGroup;

--- a/plugins/HDF5FileUtils.hpp
+++ b/plugins/HDF5FileUtils.hpp
@@ -11,8 +11,9 @@
  * received with this code.
  */
 
-#include <ers/ers.h>
 #include "dfmodules/CommonIssues.hpp"
+#include "TRACE/trace.h"
+#include <ers/ers.h>
 
 #include <highfive/H5File.hpp>
 
@@ -38,9 +39,8 @@ getTopGroup(std::unique_ptr<HighFive::File> &filePtr, const std::vector<std::str
   std::string topLevelGroupName = group_dataset[0];
   HighFive::Group topGroup = filePtr->getGroup(topLevelGroupName);
   if (!topGroup.isValid()) {
-    //throw "Error in HDFFileHelper::getGroupFromPath: top-level group " + topLevelGroupName + " not found";
-    throw InvalidHDF5Group(ERS_HERE, topLevelGroupName, topLevelGroupName, topLevelGroupName);
-    //throw InvalidHDF5Group(ERS_HERE, get_name(), topLevelGroupName, topLevelGroupName);
+    //throw InvalidHDF5Group(ERS_HERE, get_name(), topLevelGroupName);
+    throw InvalidHDF5Group(ERS_HERE, topLevelGroupName, topLevelGroupName);
   }
   
   return topGroup;
@@ -59,21 +59,20 @@ getSubGroup(std::unique_ptr<HighFive::File> &filePtr, const std::vector<std::str
   }
   HighFive::Group workingGroup = filePtr->getGroup(topLevelGroupName);
   if (! workingGroup.isValid()) {
-    throw "Error in HDFFileHelper::getGroupFromPath: top-level group " + topLevelGroupName + " not found";
-    //throw InvalidHDF5Group(ERS_HERE, topLevelGroupName, topLevelGroupName, topLevelGroupName);
+    throw InvalidHDF5Group(ERS_HERE, topLevelGroupName, topLevelGroupName);
   }
   // Create the remaining subgroups
   for (size_t idx = 1; idx < group_dataset.size(); ++idx) {
     std::string childGroupName = group_dataset[idx];
     if (childGroupName.empty()) {
-      throw "Error: child group name is an empty string";
+      throw InvalidHDF5Group(ERS_HERE, childGroupName, childGroupName);
     }
     if (createIfNeeded && !workingGroup.exist(childGroupName)) {
       workingGroup.createGroup(childGroupName);
     }
     HighFive::Group childGroup = workingGroup.getGroup(childGroupName);
     if (! childGroup.isValid()) {
-      throw "Error: child group " + childGroupName + " not found ";
+      throw InvalidHDF5Group(ERS_HERE, childGroupName, childGroupName);
     }
     workingGroup = childGroup;
   }

--- a/plugins/HDF5FileUtils.hpp
+++ b/plugins/HDF5FileUtils.hpp
@@ -29,38 +29,10 @@ namespace dfmodules {
 
 namespace HDF5FileUtils {
 /**
- * @brief Recursive function to retrieve the last HDF5 sub-group
- */
-HighFive::Group
-getSubGroup(std::unique_ptr<HighFive::File> &filePtr, const std::vector<std::string>& group_dataset)
-{
-  std::string topLevelGroupName = group_dataset[0];
-  HighFive::Group workingGroup = filePtr->getGroup(topLevelGroupName);
-  if (! workingGroup.isValid()) {
-    throw "Error: top-level group " + topLevelGroupName + " not found";
-  }
-  // Retrieve the remaining subgroups
-  for (size_t idx = 1; idx < group_dataset.size(); ++idx) {
-    std::string childGroupName = group_dataset[idx];
-    if (childGroupName.empty()) {
-      throw "Error: child group name is an empty string";
-    }
-    HighFive::Group childGroup = workingGroup.getGroup(childGroupName);
-    if (! childGroup.isValid()) {
-      throw "Error: child group " + childGroupName + " not found ";
-    }
-    workingGroup = childGroup;
-  }
-  
-  return workingGroup;
-}
-
-
-/**
  * @brief Recursive function to create HDF5 sub-groups
  */
 HighFive::Group
-addSubGroup(std::unique_ptr<HighFive::File> &filePtr, const std::vector<std::string>& group_dataset, bool createIfNeeded)
+getSubGroup(std::unique_ptr<HighFive::File> &filePtr, const std::vector<std::string>& group_dataset, bool createIfNeeded)
 {
   std::string topLevelGroupName = group_dataset[0];
   if (createIfNeeded && ! filePtr->exist(topLevelGroupName)) {

--- a/src/dfmodules/CommonIssues.hpp
+++ b/src/dfmodules/CommonIssues.hpp
@@ -36,10 +36,9 @@ ERS_DECLARE_ISSUE_BASE(dfmodules,
 ERS_DECLARE_ISSUE_BASE(dfmodules,
                        InvalidHDF5Group,
                        appfwk::GeneralDAQModuleIssue,
-                       "The HDF5 Group associated with name \"" << groupName << "\" is invalid. (file = " << filename
-                                                                << ")",
+                       "The HDF5 Group associated with name \"" << groupName << "\" is invalid. ",
                        ((std::string)name),
-                       ((std::string)groupName)((std::string)filename))
+                       ((std::string)groupName))
 
 
 } // namespace dunedaq

--- a/src/dfmodules/CommonIssues.hpp
+++ b/src/dfmodules/CommonIssues.hpp
@@ -33,6 +33,15 @@ ERS_DECLARE_ISSUE_BASE(dfmodules,
                        ((std::string)name),
                        ((std::string)queueType))
 
+ERS_DECLARE_ISSUE_BASE(dfmodules,
+                       InvalidHDF5Group,
+                       appfwk::GeneralDAQModuleIssue,
+                       "The HDF5 Group associated with name \"" << groupName << "\" is invalid. (file = " << filename
+                                                                << ")",
+                       ((std::string)name),
+                       ((std::string)groupName)((std::string)filename))
+
+
 } // namespace dunedaq
 
 #endif // DFMODULES_SRC_COMMONISSUES_HPP_

--- a/unittest/HDF5Write_test.cxx
+++ b/unittest/HDF5Write_test.cxx
@@ -154,10 +154,10 @@ BOOST_AUTO_TEST_CASE(WriteOneFile)
 
   const int DUMMYDATA_SIZE = 7;  
   const int RUN_NUMBER = 52;
-  const int TRIGGER_COUNT = 10;
+  const int TRIGGER_COUNT = 5;
   const std::string DETECTOR = "FELIX";
-  const int APA_COUNT = 5;
-  const int LINK_COUNT = 10;
+  const int APA_COUNT = 3;
+  const int LINK_COUNT = 1;
  
   // delete any pre-existing files so that we start with a clean slate
   std::string deletePattern = filePrefix + ".*.hdf5";

--- a/unittest/HDF5Write_test.cxx
+++ b/unittest/HDF5Write_test.cxx
@@ -58,94 +58,138 @@ deleteFilesMatchingPattern(const std::string& path, const std::string& pattern)
 
 BOOST_AUTO_TEST_SUITE(HDF5Write_test)
 
-/*
 BOOST_AUTO_TEST_CASE(WriteFragmentFiles)
 {
   std::string filePath(std::filesystem::temp_directory_path());
   std::string filePrefix = "demo" + std::to_string(getpid());
-  const int EVENT_COUNT = 7;
-  const int GEOLOC_COUNT = 4;
-  const int DUMMYDATA_SIZE = 100;
 
+  const int DUMMYDATA_SIZE = 7;  
+  const int RUN_NUMBER = 52;
+  const int TRIGGER_COUNT = 5;
+  const std::string DETECTOR = "FELIX";
+  const int APA_COUNT = 3;
+  const int LINK_COUNT = 1;
+ 
   // delete any pre-existing files so that we start with a clean slate
-  std::string deletePattern = filePrefix + ".*.hdf5";
+  //std::string deletePattern = filePrefix + ".*.hdf5";
+  std::string deletePattern = ".*.hdf5";
   deleteFilesMatchingPattern(filePath, deletePattern);
 
+
+  // create the DataStore
+  //nlohmann::json conf ;
+  //conf["name"] = "tempWriter" ;
+  //conf["filename_prefix"] = filePrefix ; 
+  //conf["directory_path"] = filePath ; 
+  //conf["mode"] = "one-fragment-per-file" ;
+  
   // create the DataStore
   nlohmann::json conf ;
   conf["name"] = "tempWriter" ;
-  conf["filename_prefix"] = filePrefix ; 
   conf["directory_path"] = filePath ; 
   conf["mode"] = "one-fragment-per-file" ;
-  
+  nlohmann::json subconf ;
+  subconf["overall_prefix"] = filePrefix ; 
+  conf["filename_parameters"] = subconf ;
   std::unique_ptr<HDF5DataStore> dsPtr(new HDF5DataStore(conf));
-
+ 
   // write several events, each with several fragments
   char dummyData[DUMMYDATA_SIZE];
-  for (int eventID = 1; eventID <= EVENT_COUNT; ++eventID) {
-    for (int geoLoc = 0; geoLoc < GEOLOC_COUNT; ++geoLoc) {
-      StorageKey key(eventID, StorageKey::INVALID_DETECTORID, geoLoc);
-      KeyedDataBlock dataBlock(key);
-      dataBlock.unowned_data_start = static_cast<void*>(&dummyData[0]);
-      dataBlock.data_size = DUMMYDATA_SIZE;
-      dsPtr->write(dataBlock);
-    }
-  }
+  for (int triggerNumber = 1; triggerNumber <= TRIGGER_COUNT; ++triggerNumber) {
+    for (int apaNumber = 1; apaNumber <= APA_COUNT; ++apaNumber) {
+      for (int linkNumber = 1; linkNumber <= LINK_COUNT; ++linkNumber) {
+        StorageKey key(RUN_NUMBER, triggerNumber, DETECTOR, apaNumber, linkNumber);
+        KeyedDataBlock dataBlock(key);
+        dataBlock.unowned_data_start = static_cast<void*>(&dummyData[0]);
+        dataBlock.data_size = DUMMYDATA_SIZE;
+        dsPtr->write(dataBlock);
+      } //link number
+    } // apa number
+  } // trigger number
   dsPtr.reset(); // explicit destruction
 
+
+
   // check that the expected number of files was created
-  std::string searchPattern = filePrefix + ".*event.*geoID.*.hdf5";
+  //std::string searchPattern = filePrefix+"_trigger_number*_apa_number_*.hdf5";
+  std::string searchPattern = ".*.hdf5";
   std::vector<std::string> fileList = getFilesMatchingPattern(filePath, searchPattern);
-  BOOST_REQUIRE_EQUAL(fileList.size(), (EVENT_COUNT * GEOLOC_COUNT));
+  BOOST_REQUIRE_EQUAL(fileList.size(), (TRIGGER_COUNT * APA_COUNT));
 
   // clean up the files that were created
   fileList = deleteFilesMatchingPattern(filePath, deletePattern);
-  BOOST_REQUIRE_EQUAL(fileList.size(), (EVENT_COUNT * GEOLOC_COUNT));
+  BOOST_REQUIRE_EQUAL(fileList.size(), (TRIGGER_COUNT * APA_COUNT));
+
 }
+
+
 
 BOOST_AUTO_TEST_CASE(WriteEventFiles)
 {
   std::string filePath(std::filesystem::temp_directory_path());
   std::string filePrefix = "demo" + std::to_string(getpid());
-  const int EVENT_COUNT = 7;
-  const int GEOLOC_COUNT = 4;
-  const int DUMMYDATA_SIZE = 100;
 
+  const int DUMMYDATA_SIZE = 7;  
+  const int RUN_NUMBER = 52;
+  const int TRIGGER_COUNT = 5;
+  const std::string DETECTOR = "FELIX";
+  const int APA_COUNT = 3;
+  const int LINK_COUNT = 1;
+ 
   // delete any pre-existing files so that we start with a clean slate
-  std::string deletePattern = filePrefix + ".*.hdf5";
+  //std::string deletePattern = filePrefix + ".*.hdf5";
+  std::string deletePattern = ".*.hdf5";
   deleteFilesMatchingPattern(filePath, deletePattern);
+
+
+
+  // create the DataStore
+  //nlohmann::json conf ;
+  //conf["name"] = "tempWriter" ;
+  //conf["filename_prefix"] = filePrefix ; 
+  //conf["directory_path"] = filePath ; 
+  //conf["mode"] = "one-event-per-file" ;
+  //std::unique_ptr<HDF5DataStore> dsPtr(new HDF5DataStore(conf));
+   
 
   // create the DataStore
   nlohmann::json conf ;
   conf["name"] = "tempWriter" ;
-  conf["filename_prefix"] = filePrefix ; 
   conf["directory_path"] = filePath ; 
   conf["mode"] = "one-event-per-file" ;
+  nlohmann::json subconf ;
+  subconf["overall_prefix"] = filePrefix ; 
+  conf["filename_parameters"] = subconf ;
   std::unique_ptr<HDF5DataStore> dsPtr(new HDF5DataStore(conf));
+ 
 
   // write several events, each with several fragments
   char dummyData[DUMMYDATA_SIZE];
-  for (int eventID = 1; eventID <= EVENT_COUNT; ++eventID) {
-    for (int geoLoc = 0; geoLoc < GEOLOC_COUNT; ++geoLoc) {
-      StorageKey key(eventID, StorageKey::INVALID_DETECTORID, geoLoc);
-      KeyedDataBlock dataBlock(key);
-      dataBlock.unowned_data_start = static_cast<void*>(&dummyData[0]);
-      dataBlock.data_size = DUMMYDATA_SIZE;
-      dsPtr->write(dataBlock);
-    }
-  }
+  for (int triggerNumber = 1; triggerNumber <= TRIGGER_COUNT; ++triggerNumber) {
+    for (int apaNumber = 1; apaNumber <= APA_COUNT; ++apaNumber) {
+      for (int linkNumber = 1; linkNumber <= LINK_COUNT; ++linkNumber) {
+        StorageKey key(RUN_NUMBER, triggerNumber, DETECTOR, apaNumber, linkNumber);
+        KeyedDataBlock dataBlock(key);
+        dataBlock.unowned_data_start = static_cast<void*>(&dummyData[0]);
+        dataBlock.data_size = DUMMYDATA_SIZE;
+        dsPtr->write(dataBlock);
+      } //link number
+    } // apa number
+  } // trigger number
   dsPtr.reset(); // explicit destruction
 
+
   // check that the expected number of files was created
-  std::string searchPattern = filePrefix + ".*event.*.hdf5";
+  std::string searchPattern =  ".*.hdf5";
+  //std::string searchPattern = filePrefix + "trigger_number*.hdf5";
   std::vector<std::string> fileList = getFilesMatchingPattern(filePath, searchPattern);
-  BOOST_REQUIRE_EQUAL(fileList.size(), EVENT_COUNT);
+  BOOST_REQUIRE_EQUAL(fileList.size(), TRIGGER_COUNT);
 
   // clean up the files that were created
   fileList = deleteFilesMatchingPattern(filePath, deletePattern);
-  BOOST_REQUIRE_EQUAL(fileList.size(), EVENT_COUNT);
+  BOOST_REQUIRE_EQUAL(fileList.size(), TRIGGER_COUNT);
 }
-*/
+
 
 BOOST_AUTO_TEST_CASE(WriteOneFile)
 {
@@ -208,8 +252,7 @@ BOOST_AUTO_TEST_CASE(WriteOneFile)
   BOOST_REQUIRE_EQUAL(fileList.size(), 1);
 
   // clean up the files that were created
-  //fileList = deleteFilesMatchingPattern(filePath, deletePattern);
-  //BOOST_REQUIRE_EQUAL(fileList.size(), 1);
+  fileList = deleteFilesMatchingPattern(filePath, deletePattern);
+  BOOST_REQUIRE_EQUAL(fileList.size(), 1);
 }
-
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Hello! 

I pushed to the branch "NestedGroups" the SubGroup method in HDF5FileUtils. 
I also modified the write method of the HDF5DataStore and checked with the unit tests that everything was working fine.
These changes can also be added to the read method but I would prefer to wait and restore the read unittest. 

When implementing this feature I also thought one can also do something similar for datasets which would be useful for the TriggerRecordHeader. What do you think? 