### PR TITLE
Feature/catch duplicate fragment

### DIFF
--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -48,6 +48,14 @@ ERS_DECLARE_ISSUE_BASE(dfmodules,
                        ((std::string)name),
                        ((std::string)dataSet)((std::string)filename))
 
+ERS_DECLARE_ISSUE_BASE(dfmodules,
+                       HDF5DataSetError,
+                       appfwk::GeneralDAQModuleIssue,
+                       "DataSet exception from HighFive library for DataSet name \"" << dataSet
+                       << "\", exception message is \"" << msgText << "\"",
+                       ((std::string)name),
+                       ((std::string)dataSet)((std::string)msgText))
+
 namespace dfmodules {
 
 /**
@@ -175,7 +183,7 @@ public:
         throw InvalidHDF5Dataset(ERS_HERE, get_name(), dataset_name, filePtr->getName());
       } 
     } catch (HighFive::DataSetException const& excpt) {
-      ERS_LOG("DataSetException: " << excpt.what());
+      ers::error(HDF5DataSetError(ERS_HERE, get_name(), dataset_name, excpt.what()));
     } catch (HighFive::Exception const& excpt) {
       ERS_LOG("Exception: " << excpt.what());
     }

--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -167,13 +167,18 @@ public:
     HighFive::DataSetCreateProps dataCProps_;
     HighFive::DataSetAccessProps dataAProps_;
 
-    auto theDataSet = subGroup.createDataSet<char>(dataset_name, theDataSpace, dataCProps_, dataAProps_);
-    if (theDataSet.isValid()) {
-      theDataSet.write_raw(static_cast<const char*>(dataBlock.getDataStart()));
-    } else {
-      throw InvalidHDF5Dataset(ERS_HERE, get_name(), dataset_name, filePtr->getName());
-    } 
-
+    try {
+      auto theDataSet = subGroup.createDataSet<char>(dataset_name, theDataSpace, dataCProps_, dataAProps_);
+      if (theDataSet.isValid()) {
+        theDataSet.write_raw(static_cast<const char*>(dataBlock.getDataStart()));
+      } else {
+        throw InvalidHDF5Dataset(ERS_HERE, get_name(), dataset_name, filePtr->getName());
+      } 
+    } catch (HighFive::DataSetException const& excpt) {
+      ERS_LOG("DataSetException: " << excpt.what());
+    } catch (HighFive::Exception const& excpt) {
+      ERS_LOG("Exception: " << excpt.what());
+    }
 
     filePtr->flush();
     recorded_size_ += dataBlock.data_size; 


### PR DESCRIPTION
Creating a pull request for this branch, to keep track. 

I tested the branch and the feature works on my side. I manage to catch the error for duplicated datasets.
```
2021-Jan-15 16:08:15,374 ERROR [dunedaq::dfmodules::HDF5DataStore::write(...) at /afs/cern.ch/user/a/aabedabu/work_public/miniDAQ/development/sourcecode/dfmodules/unittest/../plugins/HDF5DataStore.hpp:183] DataSet exception from HighFive library for DataSet name "Link01", exception message is "Unable to create the dataset "Link01": (Links) Object already exists" DAQModule: tempWriter
```
I reproduced the error by modifying the HDF5Write unit test and creating another block with the same key. 