### PR TITLE
Build against dunedaq-v2.1.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,19 @@ daq_add_plugin( FakeTrigDecEmu     duneDAQModule SCHEMA LINK_LIBRARIES dfmodules
 ##############################################################################
 #daq_add_unit_test( StorageKey_test          LINK_LIBRARIES dfmodules )
 #daq_add_unit_test( KeyedDataBlock_test      LINK_LIBRARIES dfmodules )
+
 daq_add_unit_test( HDF5KeyTranslator_test   LINK_LIBRARIES dfmodules )
+add_dependencies(  HDF5KeyTranslator_test dfmodules_HDF5DataStore_duneDataStore)
+
 #daq_add_unit_test( HDF5FileUtils_test       LINK_LIBRARIES dfmodules )
+
 daq_add_unit_test( HDF5Write_test           LINK_LIBRARIES dfmodules )
+add_dependencies(  HDF5Write_test dfmodules_HDF5DataStore_duneDataStore)
+
 daq_add_unit_test( HDF5Read_test            LINK_LIBRARIES dfmodules )
 daq_add_unit_test( TriggerRecordHeader_test  LINK_LIBRARIES dfmodules )
+add_dependencies(  TriggerRecordHeader_test dfmodules_HDF5DataStore_duneDataStore)
+
 #daq_add_unit_test( HDF5GetAllKeys_test      LINK_LIBRARIES dfmodules )
 #daq_add_unit_test( HDF5Combiner_test        LINK_LIBRARIES dfmodules )
 #daq_add_unit_test( DataStoreFactory_test    LINK_LIBRARIES dfmodules )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,8 @@ daq_add_unit_test( HDF5Write_test           LINK_LIBRARIES dfmodules )
 add_dependencies(  HDF5Write_test dfmodules_HDF5DataStore_duneDataStore)
 
 daq_add_unit_test( HDF5Read_test            LINK_LIBRARIES dfmodules )
+add_dependencies(  HDF5Read_test dfmodules_HDF5DataStore_duneDataStore)
+
 daq_add_unit_test( TriggerRecordHeader_test  LINK_LIBRARIES dfmodules )
 add_dependencies(  TriggerRecordHeader_test dfmodules_HDF5DataStore_duneDataStore)
 

--- a/unittest/HDF5Combiner_test.cxx
+++ b/unittest/HDF5Combiner_test.cxx
@@ -8,7 +8,7 @@
  * received with this code.
  */
 
-#include "../plugins/HDF5DataStore.hpp"
+#include "HDF5DataStore.hpp"
 
 #include "ers/ers.h"
 

--- a/unittest/HDF5FileUtils_test.cxx
+++ b/unittest/HDF5FileUtils_test.cxx
@@ -7,7 +7,7 @@
  * received with this code.
  */
 
-#include "../plugins/HDF5FileUtils.hpp"
+#include "HDF5FileUtils.hpp"
 
 #include "ers/ers.h"
 

--- a/unittest/HDF5GetAllKeys_test.cxx
+++ b/unittest/HDF5GetAllKeys_test.cxx
@@ -7,7 +7,7 @@
  * received with this code.
  */
 
-#include "../plugins/HDF5DataStore.hpp"
+#include "HDF5DataStore.hpp"
 
 #include "ers/ers.h"
 

--- a/unittest/HDF5KeyTranslator_test.cxx
+++ b/unittest/HDF5KeyTranslator_test.cxx
@@ -7,8 +7,8 @@
  * received with this code.
  */
 
-#include "../plugins/HDF5KeyTranslator.hpp"
-#include "../src/dfmodules/hdf5datastore/Structs.hpp"
+#include "HDF5KeyTranslator.hpp"
+#include "dfmodules/hdf5datastore/Structs.hpp"
 
 #include "ers/ers.h"
 

--- a/unittest/HDF5Read_test.cxx
+++ b/unittest/HDF5Read_test.cxx
@@ -7,7 +7,7 @@
  * received with this code.
  */
 
-#include "../plugins/HDF5DataStore.hpp"
+#include "HDF5DataStore.hpp"
 
 #include "ers/ers.h"
 

--- a/unittest/HDF5Write_test.cxx
+++ b/unittest/HDF5Write_test.cxx
@@ -10,7 +10,7 @@
 //#include "dfmodules/DataStore.hpp"
 //#include "dfmodules/hdf5datastore/Nljs.hpp"
 //#include "dfmodules/hdf5datastore/Structs.hpp"
-#include "../plugins/HDF5DataStore.hpp"
+#include "HDF5DataStore.hpp"
 
 #include "ers/ers.h"
 

--- a/unittest/TriggerRecordHeader_test.cxx
+++ b/unittest/TriggerRecordHeader_test.cxx
@@ -10,7 +10,7 @@
 //#include "dfmodules/DataStore.hpp"
 //#include "dfmodules/hdf5datastore/Nljs.hpp"
 //#include "dfmodules/hdf5datastore/Structs.hpp"
-#include "../plugins/HDF5DataStore.hpp"
+#include "HDF5DataStore.hpp"
 
 #include "ers/ers.h"
 


### PR DESCRIPTION
Updates CMakeLists.txt and unittest's include paths to build against the `dunedaq-v2.1.0` release.