### PR TITLE
Avoid crash in HDF5DataStore::write at beginning of second run in a MDApp instance

### DIFF
--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -349,7 +349,8 @@ private:
   void open_file_if_needed(const std::string& file_name, unsigned open_flags = HighFive::File::ReadOnly)
   {
 
-    if (m_basic_name_of_open_file.compare(file_name) || m_open_flags_of_open_file != open_flags) {
+    if (m_file_ptr.get() == nullptr || m_basic_name_of_open_file.compare(file_name) ||
+        m_open_flags_of_open_file != open_flags) {
 
       // 04-Feb-2021, KAB: adding unique substrings to the filename
       std::string unique_filename = file_name;


### PR DESCRIPTION
Giovanna and I both have seen crashes of the MDApp in the DataWriter when starting a second run in a single session.

I traced this to a missing test for an empty file ptr in HDF5DataStore::open_file_if_needed.  I should have found and fixed that problem when I added the prepare_for_run and finish_with_run methods, but I'm glad that we caught it now.

A candidate fix is on the bugfix/StopStartFilePtr branch, and the intention of this Pull Request is to ask someone to verify that the code change avoids the crash.