### PR TITLE
Since dataformats now defines a TriggerRecordHeader_test, there is a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ add_dependencies(  HDF5Write_test dfmodules_HDF5DataStore_duneDataStore)
 daq_add_unit_test( HDF5Read_test            LINK_LIBRARIES dfmodules )
 add_dependencies(  HDF5Read_test dfmodules_HDF5DataStore_duneDataStore)
 
-daq_add_unit_test( TriggerRecordHeader_test  LINK_LIBRARIES dfmodules )
-add_dependencies(  TriggerRecordHeader_test dfmodules_HDF5DataStore_duneDataStore)
+daq_add_unit_test( TriggerRecordHeaderWrite_test  LINK_LIBRARIES dfmodules )
+add_dependencies(  TriggerRecordHeaderWrite_test dfmodules_HDF5DataStore_duneDataStore)
 
 #daq_add_unit_test( HDF5GetAllKeys_test      LINK_LIBRARIES dfmodules )
 #daq_add_unit_test( HDF5Combiner_test        LINK_LIBRARIES dfmodules )

--- a/unittest/TriggerRecordHeaderWrite_test.cxx
+++ b/unittest/TriggerRecordHeaderWrite_test.cxx
@@ -1,5 +1,5 @@
 /**
- * @file HDF5Write_test.cxx Application that tests and demonstrates
+ * @file TriggerRecordHeaderWrite_test.cxx Application that tests and demonstrates
  * the write functionality of the HDF5DataStore class.
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
@@ -14,7 +14,7 @@
 
 #include "ers/ers.h"
 
-#define BOOST_TEST_MODULE HDF5RecordHeaderTest_test // NOLINT
+#define BOOST_TEST_MODULE TriggerRecordHeaderWrite_test // NOLINT
 
 #include "boost/test/unit_test.hpp"
 
@@ -56,7 +56,7 @@ delete_files_matching_pattern(const std::string& path, const std::string& patter
   return file_list;
 }
 
-BOOST_AUTO_TEST_SUITE(TriggerRecordHeader_test)
+BOOST_AUTO_TEST_SUITE(TriggerRecordHeaderWrite_test)
 
 BOOST_AUTO_TEST_CASE(WriteOneFile)
 {


### PR DESCRIPTION
target-name conflict with this test in dfmodules.