### PR TITLE
Made use of fragment_type_to_string function; removed obsolete detector_name config param

### DIFF
--- a/plugins/DataWriter.cpp
+++ b/plugins/DataWriter.cpp
@@ -261,10 +261,9 @@ DataWriter::do_work(std::atomic<bool>& running_flag)
 
         // add information about each Fragment to the list of data blocks to be stored
         // //StorageKey fragment_skey(trigger_record_ptr->get_run_number(), trigger_record_ptr->get_trigger_number,
-        // "TPC",
         StorageKey fragment_skey(frag_ptr->get_run_number(),
                                  frag_ptr->get_trigger_number(),
-                                 "TPC",
+                                 dataformats::fragment_type_to_string(frag_ptr->get_fragment_type()),
                                  frag_ptr->get_link_id().apa_number,
                                  frag_ptr->get_link_id().link_number);
         KeyedDataBlock data_block(fragment_skey);

--- a/schema/dfmodules/hdf5datastore.jsonnet
+++ b/schema/dfmodules/hdf5datastore.jsonnet
@@ -21,8 +21,6 @@ local types = {
 
     flprefix: s.string("FileLayoutPrefix", doc="String used to specify a Group or DataSet name prefix"),
 
-    detname: s.string("DetectorName", doc="String used to specify a detector type"),
-
     flag: s.boolean("Flag", doc="Parameter that can be used to enable or disable functionality"),
 
     hdf5_filename_params: s.record("HDF5DataStoreFileNameParams", [
@@ -43,8 +41,6 @@ local types = {
                 doc="Prefix for the TriggerRecord name"),
         s.field("digits_for_trigger_number", self.count, 6,
                 doc="Number of digits to use for the TriggerRecord name inside the HDF5 file"),
-        s.field("detector_name", self.detname, "TPC",
-                doc="Name for the detector"),
         s.field("apa_name_prefix", self.flprefix, "APA",
                 doc="Prefix for the APA name"),
         s.field("digits_for_apa_number", self.count, 3,


### PR DESCRIPTION
I ran a test in which I buggered the fragment ID that is put into each Fragment in the readout code and noticed that we weren't yet making full use of the fragment_type _to_string functionality.  So, I added that to the DataWriter module, and removed the obsolete detector_name configuration parameter from the hdf5datastore.jsonnet schema file.

I tested the changes with buggered fragment types in the readout code (tested kPDS and value==22).  I saw the expected error in the latter case.