### PR TITLE
Fix for bug in which small max_file_size_bytes values were splitting TriggerRecords

### DIFF
--- a/unittest/HDF5Write_test.cxx
+++ b/unittest/HDF5Write_test.cxx
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE(FileSizeLimitResultsInMultipleFiles)
   const int apa_count = 5;
   const int link_count = 10;
 
-  // 5 APAs times 10 links time 10000 bytes per fragment gives 500,000 bytes per TR
+  // 5 APAs times 10 links times 10000 bytes per fragment gives 500,000 bytes per TR
   // So, 15 TRs would give 7,500,000 bytes total.
 
   // delete any pre-existing files so that we start with a clean slate
@@ -305,6 +305,74 @@ BOOST_AUTO_TEST_CASE(FileSizeLimitResultsInMultipleFiles)
   // clean up the files that were created
   file_list = delete_files_matching_pattern(file_path, delete_pattern);
   BOOST_REQUIRE_EQUAL(file_list.size(), 3);
+}
+
+BOOST_AUTO_TEST_CASE(SmallFileSizeLimitDataBlockListWrite)
+{
+  std::string file_path(std::filesystem::temp_directory_path());
+  std::string file_prefix = "demo" + std::to_string(getpid());
+
+  const int dummydata_size = 100000;
+  const int run_number = 55;
+  const int trigger_count = 5;
+  const std::string detector_name = "TPC";
+  const int apa_count = 5;
+  const int link_count = 1;
+
+  // 5 APAs times 100000 bytes per fragment gives 500,000 bytes per TR
+
+  // delete any pre-existing files so that we start with a clean slate
+  std::string delete_pattern = file_prefix + ".*.hdf5";
+  delete_files_matching_pattern(file_path, delete_pattern);
+
+  // create the DataStore
+  nlohmann::json conf;
+  conf["name"] = "tempWriter";
+  conf["directory_path"] = file_path;
+  conf["mode"] = "all-per-file";
+  conf["max_file_size_bytes"] = 150000;  // ~1.5 Fragment, ~0.3 TR
+  nlohmann::json subconf;
+  subconf["overall_prefix"] = file_prefix;
+  conf["filename_parameters"] = subconf;
+  std::unique_ptr<HDF5DataStore> data_store_ptr(new HDF5DataStore(conf));
+#if 0
+  hdf5datastore::ConfParams config_params;
+  config_params.name = "tempWriter";
+  config_params.mode = "all-per-file";
+  config_params.max_file_size_bytes = 10000000;  // much larger than what we expect, so no second file;
+  config_params.directory_path = file_path;
+  config_params.filename_parameters.overall_prefix = file_prefix;
+  hdf5datastore::data_t hdf5ds_json;
+  hdf5datastore::to_json(hdf5ds_json, config_params);
+  std::unique_ptr<DataStore> data_store_ptr;
+  data_store_ptr = make_data_store(hdf5ds_json);
+#endif
+
+  char dummy_data[dummydata_size];
+  for (int trigger_number = 1; trigger_number <= trigger_count; ++trigger_number) {
+    std::vector<KeyedDataBlock> data_block_list;
+    for (int apa_number = 1; apa_number <= apa_count; ++apa_number) {
+      for (int link_number = 1; link_number <= link_count; ++link_number) {
+        StorageKey key(run_number, trigger_number, detector_name, apa_number, link_number);
+        KeyedDataBlock data_block(key);
+        data_block.m_unowned_data_start = static_cast<void*>(&dummy_data[0]);
+        data_block.m_data_size = dummydata_size;
+        data_block_list.emplace_back(std::move(data_block));
+      }                   // link number
+    }                     // apa number
+    data_store_ptr->write(data_block_list);
+  }                       // trigger number
+  data_store_ptr.reset(); // explicit destruction
+
+  // check that the expected number of files was created
+  std::string search_pattern = file_prefix + ".*.hdf5";
+  std::vector<std::string> file_list = get_files_matching_pattern(file_path, search_pattern);
+  // each TriggerRecord should be stored in its own file
+  BOOST_REQUIRE_EQUAL(file_list.size(), 5);
+
+  // clean up the files that were created
+  //file_list = delete_files_matching_pattern(file_path, delete_pattern);
+  //BOOST_REQUIRE_EQUAL(file_list.size(), 5);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
When I decreased the value of the max_file_size_bytes parameter below the size of an individual TriggerRecord, but larger than a single Fragment, I saw TriggerRecord Fragments get written into separate files.  This violates what I've told the Offline to expect.

I believe that the code changes on this branch will fix the problem.  They may not be the final ones related to writing data blocks and opening files, though, since we need to get back to some more general 'data store'  functionality at some point.  That will not be in dunedaq-v2.4.0, though.