### PR TITLE
Dingpf/issue 55 hdf5dump feature

### DIFF
--- a/scripts/hdf5dump/hdf5_dump.py
+++ b/scripts/hdf5dump/hdf5_dump.py
@@ -95,11 +95,9 @@ def get_header(file_name):
     g_ith_record = -1
     with h5py.File(file_name, 'r') as f:
         f.visititems(get_header_path_func)
-        g_ith_record = -1
         for i in g_header_paths:
             if i["TriggerRecordHeader"] == "":
                 continue
-            g_ith_record += 1
             print(80*'=')
             if g_header_type in ["trigger", "both"]:
                 dset = f[i["TriggerRecordHeader"]]

--- a/scripts/hdf5dump/hdf5_dump.py
+++ b/scripts/hdf5dump/hdf5_dump.py
@@ -23,6 +23,7 @@ g_n_request = 0
 g_header_type = "both"
 g_list_components = False
 
+
 def tick_to_timestamp(ticks):
     ns = float(ticks)/CLOCK_SPEED_HZ
     return datetime.datetime.fromtimestamp(ns)
@@ -48,9 +49,9 @@ def print_header(hdict):
 
 def print_fragment_header(data_array):
     keys = ['Magic word', 'Version', 'Frag Size', 'Trig number',
-        'Trig timestamp', 'Window begin (ticks@50MHz)',
-        'Window end (ticks@50MHz)', 'Run number',
-        'GeoID (APA)', 'GeoID (link)', 'Error bits', 'Fragment type' ]
+            'Trig timestamp', 'Window begin (ticks@50MHz)',
+            'Window end (ticks@50MHz)', 'Run number',
+            'GeoID (APA)', 'GeoID (link)', 'Error bits', 'Fragment type']
     unpack_string = '<2I5Q5I'
     print_header(unpack_header(data_array[:68], unpack_string, keys))
     return
@@ -59,7 +60,7 @@ def print_fragment_header(data_array):
 def print_trigger_record_header(data_array):
     keys = ['Magic word', 'Version', 'Trigger number',
             'Trigger timestamp', 'No. of requested components', 'Run Number',
-            'Error bits', 'Trigger type' ]
+            'Error bits', 'Trigger type']
     unpack_string = '<2I3Q2IH'
     print_header(unpack_header(data_array[:42], unpack_string, keys))
 
@@ -67,7 +68,8 @@ def print_trigger_record_header(data_array):
         comp_keys = ['GeoID (APA)', 'GeoID (link)', 'Begin time (ticks@50MHz)',
                      'End time (ticks@50MHz)']
         comp_unpack_string = "<2I2Q"
-        for i_values in struct.iter_unpack(comp_unpack_string, data_array[48:]):
+        for i_values in struct.iter_unpack(comp_unpack_string,
+                                           data_array[48:]):
             i_comp = dict(zip(comp_keys, i_values))
             print(80*'-')
             print_header(i_comp)
@@ -112,14 +114,14 @@ def examine_fragments_func(name, dset):
         g_trigger_record_nfragments.append(0)
         g_ith_record += 1
     if isinstance(dset, h5py.Dataset):
-            if "FELIX" in name:
-                # This is a new fragment
-                g_trigger_record_nfragments[g_ith_record] += 1
-            if "TriggerRecordHeader" in name:
-                # This is a new TriggerRecordHeader
-                data_array = bytearray(dset[:])
-                (i,) = struct.unpack('<Q', data_array[24:32])
-                g_trigger_record_nexp_fragments.append(i)
+        if "FELIX" in name:
+            # This is a new fragment
+            g_trigger_record_nfragments[g_ith_record] += 1
+        if "TriggerRecordHeader" in name:
+            # This is a new TriggerRecordHeader
+            data_array = bytearray(dset[:])
+            (i,) = struct.unpack('<Q', data_array[24:32])
+            g_trigger_record_nexp_fragments.append(i)
     return
 
 
@@ -134,12 +136,13 @@ def examine_fragments(file_name):
     print("N_diff:      N_frag_act - N_frag_exp")
     print("{:-^60}".format("Column Definitions"))
     print("{:^10}{:^15}{:^15}{:^10}".format(
-        "i", "N_frag_exp","N_frag_act", "N_diff"))
+        "i", "N_frag_exp", "N_frag_act", "N_diff"))
     for i in range(len(g_trigger_record_nfragments)):
         print("{:^10}{:^15}{:^15}{:^10}".format(
             i, g_trigger_record_nexp_fragments[i],
             g_trigger_record_nfragments[i],
-         g_trigger_record_nfragments[i] - g_trigger_record_nexp_fragments[i]))
+            (g_trigger_record_nfragments[i] -
+             g_trigger_record_nexp_fragments[i])))
     return
 
 
@@ -151,7 +154,7 @@ def parse_args():
                         help='Path to HDF5 file',
                         required=True)
 
-    parser.add_argument('--header', choices=['trigger','fragment', 'both'],
+    parser.add_argument('--header', choices=['trigger', 'fragment', 'both'],
                         default='both',
                         help='Select which header data to display')
 
@@ -174,7 +177,7 @@ def parse_args():
 
 
 def main():
-    args=parse_args()
+    args = parse_args()
 
     h5file = args.file_name
     print("Reading file", h5file)
@@ -187,11 +190,11 @@ def main():
     g_header_type = args.header
     g_list_components = args.list_components
 
-
     if not args.check_fragments:
         get_header(h5file)
     else:
         examine_fragments(h5file)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/hdf5dump/hdf5_dump.py
+++ b/scripts/hdf5dump/hdf5_dump.py
@@ -153,25 +153,25 @@ def parse_args():
         description='Python script to parse DUNE-DAQ HDF5 output files.')
 
     parser.add_argument('-f', '--file_name',
-                        help='Path to HDF5 file',
+                        help='path to HDF5 file',
                         required=True)
 
-    parser.add_argument('--header', choices=['trigger', 'fragment',
-                                             'both', 'none'],
-                        default='both',
-                        help='Select which header data to display')
+    parser.add_argument('-p', '--print-headers',
+                        choices=['trigger', 'fragment', 'both'],
+                        help='select which header data to display')
 
-    parser.add_argument('--check-fragments',
+    parser.add_argument('-c', '--check-fragments',
                         help='''check if fragments written in trigger record
                         matches expected number in trigger record header''',
                         action='store_true')
 
-    parser.add_argument('--list-components',
-                        help='list components in trigger record header',
-                        action='store_true')
+    parser.add_argument('-l', '--list-components',
+                        help='''list components in trigger record header, used
+                        together with "--print-headers trigger" or
+                        "--print-headers both"''', action='store_true')
 
     parser.add_argument('-n', '--num-of-records', type=int,
-                        help='Select number of trigger records to be parsed',
+                        help='specify number of trigger records to be parsed',
                         default=0)
 
     parser.add_argument('-v', '--version', action='version',
@@ -182,21 +182,28 @@ def parse_args():
 def main():
     args = parse_args()
 
-    h5file = args.file_name
-    print("Reading file", h5file)
-
     global g_n_request
     global g_header_type
     global g_list_components
 
     g_n_request = args.num_of_records
-    g_header_type = args.header
+    g_header_type = args.print_headers
     g_list_components = args.list_components
 
-    if g_header_type != "none":
+    if g_header_type is None and g_list_components is False:
+        print("Error: use at least one of the two following options:")
+        print("       -p, --print-headers {trigger,fragment,both}")
+        print("       -c, --check-fragments")
+        return
+
+    h5file = args.file_name
+    print("Reading file", h5file)
+
+    if g_header_type is not None:
         get_header(h5file)
     if args.check_fragments:
         examine_fragments(h5file)
+    return
 
 
 if __name__ == "__main__":

--- a/scripts/hdf5dump/hdf5_dump.py
+++ b/scripts/hdf5dump/hdf5_dump.py
@@ -79,8 +79,8 @@ def get_header_func(name, dset):
     if isinstance(dset, h5py.Dataset):
         if g_n_request <= 0 or g_n_printed < g_n_request:
             if "TriggerRecordHeader" in name:
+                g_n_printed += 1
                 if g_header_type in ['trigger', 'both']:
-                    g_n_printed += 1
                     data_array = bytearray(dset[:])
                     print(80*'=')
                     print('{:<30}:\t{}'.format("Path", name))
@@ -89,8 +89,6 @@ def get_header_func(name, dset):
                     print_trigger_record_header(data_array)
             else:
                 if g_header_type in ['fragment', 'both']:
-                    if g_header_type != "both":
-                        g_n_printed += 1
                     data_array = bytearray(dset[:])
                     print(80*'=')
                     print('{:<30}:\t{}'.format("Path", name))
@@ -173,7 +171,7 @@ def parse_args():
                         action='store_true')
 
     parser.add_argument('-n', '--num-of-records', type=int,
-                        help='Select number of records to be parsed',
+                        help='Select number of trigger records to be parsed',
                         default=0)
 
     parser.add_argument('-v', '--version', action='version',

--- a/scripts/hdf5dump/hdf5_dump.py
+++ b/scripts/hdf5dump/hdf5_dump.py
@@ -35,7 +35,7 @@ def unpack_header(data_array, unpack_string, keys):
 
 def print_header_dict(hdict):
     for ik, iv in hdict.items():
-        if "timestamp" in ik:
+        if "time" in ik or "begin" in ik or "end" in ik:
             print("{:<30}: {} ({})".format(
                 ik, iv, tick_to_timestamp(iv)))
         elif 'Magic word' in ik:
@@ -47,8 +47,7 @@ def print_header_dict(hdict):
 
 def print_fragment_header(data_array):
     keys = ['Magic word', 'Version', 'Frag Size', 'Trig number',
-            'Trig timestamp', 'Window begin (ticks@50MHz)',
-            'Window end (ticks@50MHz)', 'Run number',
+            'Trig timestamp', 'Window begin', 'Window end', 'Run number',
             'GeoID (APA)', 'GeoID (link)', 'Error bits', 'Fragment type']
     unpack_string = '<2I5Q5I'
     print_header_dict(unpack_header(data_array[:68], unpack_string, keys))
@@ -63,8 +62,7 @@ def print_trigger_record_header(data_array):
     print_header_dict(unpack_header(data_array[:42], unpack_string, keys))
 
     if g_list_components:
-        comp_keys = ['GeoID (APA)', 'GeoID (link)', 'Begin time (ticks@50MHz)',
-                     'End time (ticks@50MHz)']
+        comp_keys = ['GeoID (APA)', 'GeoID (link)', 'Begin time', 'End time']
         comp_unpack_string = "<2I2Q"
         for i_values in struct.iter_unpack(comp_unpack_string,
                                            data_array[48:]):

--- a/scripts/hdf5dump/hdf5_dump.py
+++ b/scripts/hdf5dump/hdf5_dump.py
@@ -1,199 +1,194 @@
 #!/usr/bin/python3
 
-# Version 0.1
-# Last modified: January 23, 2021
+# Version 1.0
+# Last modified: April 10, 2021
 
-# USAGE: python3 hdf5_dump.py -f sample.hdf5 -TRH
+# USAGE: python3 hdf5_dump.py -f sample.hdf5
 
 import argparse
-import struct
 
 import h5py
 import datetime
 
+import struct
+
 CLOCK_SPEED_HZ = 50000000.0
 
-## Print FragmentHeader
-def print_frag_header(data_array):
-  (check_word, version, fragment_size,
-   trigger_number, trigger_timestamp,
-   window_begin, window_end,
-   runumber, geo_id_apa, geo_id_link,
-   error_bits, fragment_type
-   ) = struct.unpack('<2I5Q5I', data_array[:68])
-   # https://docs.python.org/3/library/struct.html
-   # Do a h5dump on the hdf5 file to see the datatype
-   # "H5T_STD_I8LE" means, 8 bit little endian standard type
-   # https://support.hdfgroup.org/HDF5/doc/RM/PredefDTypes.html
+g_trigger_record_nfragments = []
+g_trigger_record_nexp_fragments = []
+g_ith_record = -1
 
-  print("Magic word:\t\t", hex(check_word))
-  print("Version:\t\t", version)
-  print("Frag size:\t\t", fragment_size)
-  print("Trig number:\t\t", trigger_number)
-  print("Trig timestamp:\t\t {} ({})".format(trigger_timestamp,
-        datetime.datetime.fromtimestamp(float(trigger_timestamp)/CLOCK_SPEED_HZ)))
-  print("Window begin (ticks@50MHz):\t", window_begin)
-  print("Window end (ticks@50MHz):\t", window_end)
-  print("Run number:\t\t", runumber)
-  print("GeoID (APA):\t\t", geo_id_apa)
-  print("GeoID (link):\t\t", geo_id_link)
-  print("Error bits:\t\t", error_bits)
-  print("Fragment type:\t\t", fragment_type)
+g_n_printed = 0
+g_n_request = 0
+g_header_type = "both"
+g_list_components = False
+
+def tick_to_timestamp(ticks):
+    ns = float(ticks)/CLOCK_SPEED_HZ
+    return datetime.datetime.fromtimestamp(ns)
 
 
-## Print TriggerRecordHeader
-def print_trh(data_array):
-  (check_word, version, trigger_number,
-   trigger_timestamp, numb_req_comp, run_number,
-   error_bits, trigger_type) = struct.unpack('<2I3Q2IH', data_array[:42])
+def unpack_header(data_array, unpack_string, keys):
+    values = struct.unpack(unpack_string, data_array)
+    header = dict(zip(keys, values))
+    return header
 
-  print("Magic word:\t\t", hex(check_word))
-  print("Version:\t\t", version)
-  print("Trig number:\t\t", trigger_number)
-  print("Trig timestamp:\t\t", trigger_timestamp,
-        "("+str(datetime.datetime.fromtimestamp(float(trigger_timestamp)/CLOCK_SPEED_HZ))+")")
-  print("Num req comp:\t\t", numb_req_comp)
-  print("Run number:\t\t", run_number)
-  print("Error bits:\t\t", error_bits)
-  print("Trigger type:\t\t", trigger_type)
 
-  if listComponents:
-      j = 0
-      for (i_geo_id_apa, i_geo_id_link, i_begin, i_end) in struct.iter_unpack("<2I2Q", data_array[48:]):
-          print("Expected Component: \t\t", j)
-          print("       GeoID (APA): \t\t", i_geo_id_apa)
-          print("       GeoID (link): \t\t", i_geo_id_link)
-          #print("       Begin time (ticks@50MHz): \t", i_begin)
-          #print("       End time (ticks@50MHz): \t\t", i_end)
-          j += 1
-
-  return
-
-# Actions
-
-trigger_record_fragments = []
-trigger_record_header_expected_fragments = []
-
-def examine_fragments(name, dset):
-    global nheader
-    if isinstance(dset, h5py.Group) and "/" not in name:
-        # This is a new trigger record.
-        nheader += 1
-        trigger_record_fragments.append(0)
-    if isinstance(dset, h5py.Dataset) and "FELIX" in name:
-        # This is a new fragment
-        trigger_record_fragments[nheader] += 1
-    if isinstance(dset, h5py.Dataset) and "TriggerRecordHeader" in name:
-        # This is a new TriggerRecordHeader
-        data_array = bytearray(dset[:])
-        (i,) = struct.unpack('<Q', data_array[24:32])
-        trigger_record_header_expected_fragments.append(i)
+def print_header(hdict):
+    for ik, iv in hdict.items():
+        if "timestamp" in ik:
+            print("{:<30}: {} ({})".format(
+                ik, iv, tick_to_timestamp(iv)))
+        elif 'Magic word' in ik:
+            print("{:<30}: {}".format(ik, hex(iv)))
+        else:
+            print("{:<30}: {}".format(ik, iv))
     return
 
-def print_header_func(name, dset):
-    global nheader
-    if nheader < NHEADER and isinstance(dset, h5py.Dataset):
-        if printTRH and "TriggerRecordHeader" in name:
-            print(80*'=')
-            print("TriggerRecordHeader:\t\t", nheader)
-            print('Path:\t\t', name)
-            print('Size:\t\t', dset.shape)
-            print('Data type:\t\t', dset.dtype)
-            nheader += 1
-            data_array = bytearray(dset[:])
-            print_trh(data_array)
-        if not printTRH and "TriggerRecordHeader" not in name:
-            print(80*'=')
-            print("Fragment:\t\t", nheader)
-            print('Path:\t\t', name)
-            print('Size:\t\t', dset.shape)
-            print('Data type:\t\t', dset.dtype)
-            nheader += 1
-            data_array = bytearray(dset[:])
-            print_frag_header(data_array)
+
+def print_fragment_header(data_array):
+    keys = ['Magic word', 'Version', 'Frag Size', 'Trig number',
+        'Trig timestamp', 'Window begin (ticks@50MHz)',
+        'Window end (ticks@50MHz)', 'Run number',
+        'GeoID (APA)', 'GeoID (link)', 'Error bits', 'Fragment type' ]
+    unpack_string = '<2I5Q5I'
+    print_header(unpack_header(data_array[:68], unpack_string, keys))
     return
+
+
+def print_trigger_record_header(data_array):
+    keys = ['Magic word', 'Version', 'Trigger number',
+            'Trigger Timestamp', 'No. of requested components', 'Run Number',
+            'Error bits', 'Trigger type' ]
+    unpack_string = '<2I3Q2IH'
+    print_header(unpack_header(data_array[:42], unpack_string, keys))
+
+    if g_list_components:
+        comp_keys = ['GeoID (APA)', 'GeoID (link)', 'Begin time (ticks@50MHz)'
+                     'End time (ticks@50MHz)']
+        comp_unpack_string = "<2I2Q"
+        for i_values in struct.iter_unpack(comp_unpack_string, data_array[48:]):
+            i_comp = dict(zip(comp_keys, i_values))
+            print_header(i_comp)
+    return
+
+
+def get_header_func(name, dset):
+    global g_n_printed
+    if isinstance(dset, h5py.Dataset):
+        if g_n_request <= 0 or g_n_printed < g_n_request:
+            g_n_printed += 1
+            data_array = bytearray(dset[:])
+            if "TriggerRecordHeader" in name:
+                if g_header_type in ['trigger', 'both']:
+                    print(80*'=')
+                    print('{:<30}:\t{}'.format("Path", name))
+                    print('{:<30}:\t{}'.format("Size", dset.shape))
+                    print('{:<30}:\t{}'.format("Data type", dset.dtype))
+                    print_trigger_record_header(data_array)
+            else:
+                if g_header_type in ['fragment', 'both']:
+                    print(80*'=')
+                    print('{:<30}:\t{}'.format("Path", name))
+                    print('{:<30}:\t{}'.format("Size", dset.shape))
+                    print('{:<30}:\t{}'.format("Data type", dset.dtype))
+                    print_fragment_header(data_array)
+    return
+
 
 def get_header(file_name):
     with h5py.File(file_name, 'r') as f:
-        f.visititems(print_header_func)
+        f.visititems(get_header_func)
     return
 
-def examine(file_name):
-    global nheader
-    nheader = -1
+
+def examine_fragments_func(name, dset):
+    global g_ith_record
+    if isinstance(dset, h5py.Group) and "/" not in name:
+        # This is a new trigger record.
+        g_trigger_record_nfragments.append(0)
+        g_ith_record += 1
+    if isinstance(dset, h5py.Dataset):
+            if "FELIX" in name:
+                # This is a new fragment
+                g_trigger_record_nfragments[g_ith_record] += 1
+            if "TriggerRecordHeader" in name:
+                # This is a new TriggerRecordHeader
+                data_array = bytearray(dset[:])
+                (i,) = struct.unpack('<Q', data_array[24:32])
+                g_trigger_record_nexp_fragments.append(i)
+    return
+
+
+def examine_fragments(file_name):
     with h5py.File(file_name, 'r') as f:
-        f.visititems(examine_fragments)
-    for i in range(len(trigger_record_fragments)):
-        print("Trigger record {} No. of fragments (exp. vs. act): {} vs. {}; diff: {}".format(
-            i, trigger_record_header_expected_fragments[i], trigger_record_fragments[i],
-        trigger_record_header_expected_fragments[i] - trigger_record_fragments[i]
-        ))
+        f.visititems(examine_fragments_func)
+
+    print("{:-^60}".format("Column Definitions"))
+    print("i:           Trigger record number;")
+    print("N_frag_exp:  expected no. of fragments stored in header;")
+    print("N_frag_act:  no. of fragments written in trigger record;")
+    print("N_diff:      N_frag_act - N_frag_exp")
+    print("{:-^60}".format("Column Definitions"))
+    print("{:^10}{:^10}{:^10}{:^10}".format(
+        "i", "N_frag_exp","N_frag_act", "N_diff"))
+    for i in range(len(g_trigger_record_nfragments)):
+        print("{:^10}{:^10}{:^10}{:^10}".format(
+            i, g_trigger_record_nexp_fragments[i],
+            g_trigger_record_nfragments[i],
+         g_trigger_record_nfragments[i] - g_trigger_record_nexp_fragments[i]))
     return
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='Python script to parse DUNE-DAQ HDF5 output files.')
-    parser.version = '0.1'
-    parser.add_argument('-p', '--path',
-                       help='Path to HDF5 file',
-                       default='./')
+    parser = argparse.ArgumentParser(
+        description='Python script to parse DUNE-DAQ HDF5 output files.')
 
     parser.add_argument('-f', '--file_name',
-                       help='Name of HDF5 file',
-                       required=True)
+                        help='Path to HDF5 file',
+                        required=True)
 
-    parser.add_argument('-H', '--header_only',
-                       help='Print the header only; no data is displayed',
-                       action='store_true')
+    parser.add_argument('--header', choices=['trigger','fragment', 'both'],
+                        default='both',
+                        help='Select which header data to display')
 
-    parser.add_argument('-TRH', '--TRH_only',
-                       help='Print the TriggerRecordheader only; data is displayed',
-                       action='store_true')
-
-    parser.add_argument('--check-fragment',
-                       help='check if fragments written in trigger record matches expected number in trigger record header',
-                       action='store_true')
+    parser.add_argument('--check-fragments',
+                        help='''check if fragments written in trigger record
+                        matches expected number in trigger record header''',
+                        action='store_true')
 
     parser.add_argument('--list-components',
-                       help='list components in trigger record header',
-                       action='store_true')
+                        help='list components in trigger record header',
+                        action='store_true')
 
-    parser.add_argument('-num', '--num_req_trig_records',
-                        type=int,
-                       help='Select number of trigger records to be parsed',
-                       default=None)
+    parser.add_argument('-n', '--num-of-records', type=int,
+                        help='Select number of records to be parsed',
+                        default=0)
 
-    parser.add_argument('-v', '--version', action='version')
+    parser.add_argument('-v', '--version', action='version',
+                        version='%(prog)s 1.0')
     return parser.parse_args()
 
 
-nheader = 0
-NHEADER = 0
-printTRH = False
-listComponents = False
 def main():
     args=parse_args()
 
-    input_path = args.path
-    input_file_name = args.file_name
-    full_path = input_path + input_file_name
-    print("Reading file", full_path )
+    h5file = args.file_name
+    print("Reading file", h5file)
 
-    requested_trigger_records = args.num_req_trig_records
-    global NHEADER
-    global printTRH
-    global listComponents
-    NHEADER = args.num_req_trig_records
+    global g_n_request
+    global g_header_type
+    global g_list_components
 
-    if args.header_only:
-      get_header(full_path)
-    if args.TRH_only:
-      printTRH = True
-      if args.list_components:
-          listComponents = True
-      get_header(full_path)
-    if args.check_fragment:
-      examine(full_path)
+    g_n_request = args.num_of_records
+    g_header_type = args.header
+    g_list_components = args.list_components
+
+
+    if not args.check_fragments:
+        get_header(h5file)
+    else:
+        examine_fragments(h5file)
 
 if __name__ == "__main__":
     main()

--- a/scripts/hdf5dump/hdf5_dump.py
+++ b/scripts/hdf5dump/hdf5_dump.py
@@ -64,11 +64,12 @@ def print_trigger_record_header(data_array):
     print_header(unpack_header(data_array[:42], unpack_string, keys))
 
     if g_list_components:
-        comp_keys = ['GeoID (APA)', 'GeoID (link)', 'Begin time (ticks@50MHz)'
+        comp_keys = ['GeoID (APA)', 'GeoID (link)', 'Begin time (ticks@50MHz)',
                      'End time (ticks@50MHz)']
         comp_unpack_string = "<2I2Q"
         for i_values in struct.iter_unpack(comp_unpack_string, data_array[48:]):
             i_comp = dict(zip(comp_keys, i_values))
+            print(80*'-')
             print_header(i_comp)
     return
 
@@ -132,10 +133,10 @@ def examine_fragments(file_name):
     print("N_frag_act:  no. of fragments written in trigger record;")
     print("N_diff:      N_frag_act - N_frag_exp")
     print("{:-^60}".format("Column Definitions"))
-    print("{:^10}{:^10}{:^10}{:^10}".format(
+    print("{:^10}{:^15}{:^15}{:^10}".format(
         "i", "N_frag_exp","N_frag_act", "N_diff"))
     for i in range(len(g_trigger_record_nfragments)):
-        print("{:^10}{:^10}{:^10}{:^10}".format(
+        print("{:^10}{:^15}{:^15}{:^10}".format(
             i, g_trigger_record_nexp_fragments[i],
             g_trigger_record_nfragments[i],
          g_trigger_record_nfragments[i] - g_trigger_record_nexp_fragments[i]))

--- a/scripts/hdf5dump/hdf5_dump.py
+++ b/scripts/hdf5dump/hdf5_dump.py
@@ -77,10 +77,10 @@ def get_header_func(name, dset):
     global g_n_printed
     if isinstance(dset, h5py.Dataset):
         if g_n_request <= 0 or g_n_printed < g_n_request:
-            g_n_printed += 1
-            data_array = bytearray(dset[:])
             if "TriggerRecordHeader" in name:
                 if g_header_type in ['trigger', 'both']:
+                    g_n_printed += 1
+                    data_array = bytearray(dset[:])
                     print(80*'=')
                     print('{:<30}:\t{}'.format("Path", name))
                     print('{:<30}:\t{}'.format("Size", dset.shape))
@@ -88,6 +88,8 @@ def get_header_func(name, dset):
                     print_trigger_record_header(data_array)
             else:
                 if g_header_type in ['fragment', 'both']:
+                    g_n_printed += 1
+                    data_array = bytearray(dset[:])
                     print(80*'=')
                     print('{:<30}:\t{}'.format("Path", name))
                     print('{:<30}:\t{}'.format("Size", dset.shape))

--- a/scripts/hdf5dump/hdf5_dump.py
+++ b/scripts/hdf5dump/hdf5_dump.py
@@ -58,7 +58,7 @@ def print_fragment_header(data_array):
 
 def print_trigger_record_header(data_array):
     keys = ['Magic word', 'Version', 'Trigger number',
-            'Trigger Timestamp', 'No. of requested components', 'Run Number',
+            'Trigger timestamp', 'No. of requested components', 'Run Number',
             'Error bits', 'Trigger type' ]
     unpack_string = '<2I3Q2IH'
     print_header(unpack_header(data_array[:42], unpack_string, keys))


### PR DESCRIPTION
The new helper looks like:

```sh
bash $ ./hdf5_dump.py -h
usage: hdf5_dump.py [-h] -f FILE_NAME [--header {trigger,fragment,both}] [--check-fragments] [--list-components] [-n NUM_OF_RECORDS] [-v]

Python script to parse DUNE-DAQ HDF5 output files.

optional arguments:
  -h, --help            show this help message and exit
  -f FILE_NAME, --file_name FILE_NAME
                        Path to HDF5 file
  --header {trigger,fragment,both}
                        Select which header data to display
  --check-fragments     check if fragments written in trigger record matches expected number in trigger record header
  --list-components     list components in trigger record header
  -n NUM_OF_RECORDS, --num-of-records NUM_OF_RECORDS
                        Select number of records to be parsed
  -v, --version         show program's version number and exit
```

The new option `--list-components`, when used together with `--header trigger`, will list the expected components in the trigger record header:

```sh
bash $ ./hdf5_dump.py --header trigger -n 1 -f sample.hdf5 --list-components
Reading file sample.hdf5
================================================================================
Path                          : TriggerRecord00000/TriggerRecordHeader
Size                          : (288, 1)
Data type                     : int8
Magic word                    : 0x33334444
Version                       : 1
Trigger number                : 0
Trigger timestamp             : 79759095071000000 (2020-07-19 13:05:01.420000)
No. of requested components   : 10
Run Number                    : 333
Error bits                    : 0
Trigger type                  : 0
--------------------------------------------------------------------------------
GeoID (APA)                   : 0
GeoID (link)                  : 0
Begin time (ticks@50MHz)      : 1000
End time (ticks@50MHz)        : 1200
--------------------------------------------------------------------------------
GeoID (APA)                   : 0
GeoID (link)                  : 1
Begin time (ticks@50MHz)      : 1000
End time (ticks@50MHz)        : 1200
--------------------------------------------------------------------------------
GeoID (APA)                   : 0
GeoID (link)                  : 2
Begin time (ticks@50MHz)      : 1000
End time (ticks@50MHz)        : 1200
--------------------------------------------------------------------------------
GeoID (APA)                   : 0
GeoID (link)                  : 3
Begin time (ticks@50MHz)      : 1000
End time (ticks@50MHz)        : 1200
--------------------------------------------------------------------------------
GeoID (APA)                   : 0
GeoID (link)                  : 4
Begin time (ticks@50MHz)      : 1000
End time (ticks@50MHz)        : 1200
--------------------------------------------------------------------------------
GeoID (APA)                   : 0
GeoID (link)                  : 5
Begin time (ticks@50MHz)      : 1000
End time (ticks@50MHz)        : 1200
--------------------------------------------------------------------------------
GeoID (APA)                   : 0
GeoID (link)                  : 6
Begin time (ticks@50MHz)      : 1000
End time (ticks@50MHz)        : 1200
--------------------------------------------------------------------------------
GeoID (APA)                   : 0
GeoID (link)                  : 7
Begin time (ticks@50MHz)      : 1000
End time (ticks@50MHz)        : 1200
--------------------------------------------------------------------------------
GeoID (APA)                   : 0
GeoID (link)                  : 8
Begin time (ticks@50MHz)      : 1000
End time (ticks@50MHz)        : 1200
--------------------------------------------------------------------------------
GeoID (APA)                   : 0
GeoID (link)                  : 9
Begin time (ticks@50MHz)      : 1000
End time (ticks@50MHz)        : 1200
```

The new option `--check-fragments` will go through the whole file and list the expected number of components obtained from the trigger record header, as well as those actually written into the corresponding trigger record.

```sh
bash $ ./hdf5_dump.py --check-fragments -f sample.hdf5
Reading file sample.hdf5
---------------------Column Definitions---------------------
i:           Trigger record number;
N_frag_exp:  expected no. of fragments stored in header;
N_frag_act:  no. of fragments written in trigger record;
N_diff:      N_frag_act - N_frag_exp
---------------------Column Definitions---------------------
    i       N_frag_exp     N_frag_act     N_diff
    0           10             10           0
    1           10             10           0
    2           10             10           0
    3           10             10           0
    4           10             10           0
    5           10             10           0
    6           10             10           0
    7           10             10           0
    8           10             10           0
    9           10             10           0
    10          10             10           0
    11          10             10           0
    12          10             10           0
    13          10             10           0
    14          10             10           0
    15          10             10           0
    16          10             10           0
    17          10             10           0
    18          10             10           0
    19          10             10           0
    20          10             10           0
    21          10             10           0
    22          10             10           0
    23          10             10           0
    24          10             10           0
    25          10             10           0
    26          10             10           0
    27          10             10           0
```



