### PR TITLE
Use opmon Info structs with atomic members

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,18 @@ find_package(logging REQUIRED)
 find_package(HighFive REQUIRED)
 find_package(dfmessages REQUIRED)
 
-daq_codegen(*.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
+daq_codegen(datagenerator.jsonnet
+            datatransfermodule.jsonnet
+            datawriter.jsonnet
+            fakedataprod.jsonnet
+            faketrigdecemu.jsonnet
+            fragmentreceiver.jsonnet
+            hdf5datastore.jsonnet
+            requestgenerator.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
+
+daq_codegen(datawriterinfo.jsonnet
+            fragmentreceiverinfo.jsonnet
+            DEP_PKGS appfwk TEMPLATES appfwk/OpmonStructs.hpp.j2 appfwk/OpmonNljs.hpp.j2 )
 
 ##############################################################################
 daq_add_library( StorageKey.cpp TriggerDecisionForwarder.cpp TriggerInhibitAgent.cpp

--- a/plugins/DataWriter.hpp
+++ b/plugins/DataWriter.hpp
@@ -10,6 +10,7 @@
 #define DFMODULES_PLUGINS_DATAWRITER_HPP_
 
 #include "dfmodules/DataStore.hpp"
+#include "dfmodules/datawriterinfo/OpmonNljs.hpp"
 
 #include "appfwk/DAQModule.hpp"
 #include "appfwk/DAQSink.hpp"
@@ -74,10 +75,7 @@ private:
   // Worker(s)
   std::unique_ptr<DataStore> m_data_writer;
 
-  std::atomic<uint64_t> m_records_received = { 0 };
-  std::atomic<uint64_t> m_records_received_tot = { 0 };
-  std::atomic<uint64_t> m_records_written = { 0 };
-  std::atomic<uint64_t> m_records_written_tot = { 0 };
+  datawriterinfo::Info m_info;
 
   inline double elapsed_seconds(std::chrono::steady_clock::time_point then,
                                 std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now()) const

--- a/plugins/FragmentReceiver.cpp
+++ b/plugins/FragmentReceiver.cpp
@@ -107,16 +107,7 @@ FragmentReceiver::init(const data_t& init_data)
 void
 FragmentReceiver::get_info(opmonlib::InfoCollector& ci, int /*level*/)
 {
-
-  fragmentreceiverinfo::Info i;
-
-  i.trigger_decisions = m_trigger_decisions_counter.load();
-  i.populated_trigger_ids = m_fragment_index_counter.load();
-  i.old_trigger_ids = m_old_fragment_index_counter.load();
-  i.total_fragments = m_fragment_counter.load();
-  i.old_fragments = m_old_fragment_counter.load();
-
-  ci.add(i);
+  ci.add(m_info);
 }
 
 void
@@ -454,8 +445,8 @@ FragmentReceiver::check_old_fragments() const
     }
   } // fragment loop
 
-  m_old_fragment_counter.store(old_fragments);
-  m_old_fragment_index_counter.store(old_trigger_indexes);
+  m_info.old_fragments.store(old_fragments);
+  m_info.old_trigger_ids.store(old_trigger_indexes);
 
   return old_stuff;
 }
@@ -464,11 +455,11 @@ void
 FragmentReceiver::fill_counters() const
 {
 
-  m_trigger_decisions_counter.store(m_trigger_decisions.size());
-  m_fragment_index_counter.store(m_fragments.size());
+  m_info.trigger_decisions.store(m_trigger_decisions.size());
+  m_info.populated_trigger_ids.store(m_fragments.size());
   metric_counter_type tot = std::accumulate(
     m_fragments.begin(), m_fragments.end(), 0, [](auto tot, auto& ele) { return tot += ele.second.size(); });
-  m_fragment_counter.store(tot);
+  m_info.total_fragments.store(tot);
 }
 
 } // namespace dfmodules

--- a/plugins/FragmentReceiver.hpp
+++ b/plugins/FragmentReceiver.hpp
@@ -9,7 +9,7 @@
 #ifndef DFMODULES_PLUGINS_FRAGMENTRECEIVER_HPP_
 #define DFMODULES_PLUGINS_FRAGMENTRECEIVER_HPP_
 
-#include "dfmodules/fragmentreceiverinfo/Nljs.hpp"
+#include "dfmodules/fragmentreceiverinfo/OpmonNljs.hpp"
 
 #include "dataformats/Fragment.hpp"
 #include "dataformats/TriggerRecord.hpp"
@@ -165,12 +165,14 @@ private:
   std::map<TriggerId, dfmessages::TriggerDecision> m_trigger_decisions;
 
   // book related metrics
+  mutable fragmentreceiverinfo::Info m_info;
+  
   using metric_counter_type = decltype(fragmentreceiverinfo::Info::trigger_decisions);
-  mutable std::atomic<metric_counter_type> m_trigger_decisions_counter = { 0 };
-  mutable std::atomic<metric_counter_type> m_fragment_index_counter = { 0 };
-  mutable std::atomic<metric_counter_type> m_old_fragment_index_counter = { 0 };
-  mutable std::atomic<metric_counter_type> m_fragment_counter = { 0 };
-  mutable std::atomic<metric_counter_type> m_old_fragment_counter = { 0 };
+  // mutable std::atomic<metric_counter_type> m_trigger_decisions_counter = { 0 };
+  // mutable std::atomic<metric_counter_type> m_fragment_index_counter = { 0 };
+  // mutable std::atomic<metric_counter_type> m_old_fragment_index_counter = { 0 };
+  // mutable std::atomic<metric_counter_type> m_fragment_counter = { 0 };
+  // mutable std::atomic<metric_counter_type> m_old_fragment_counter = { 0 };
 
   dataformats::timestamp_diff_t m_max_time_difference;
   dataformats::timestamp_t m_current_time = 0;


### PR DESCRIPTION
This PR provides a simple example of using the opmon info structs with `std::atomic` members, as provided by the philiprodrigues/atomic-info-struct branch of appfwk discussed in https://github.com/DUNE-DAQ/appfwk/pull/174 . It's mostly intended as an example.

It does show up one thing that's possible in the old approach, but not in this approach: having metrics that represent a count since the last call of `get_info` (eg the `new_records_received` metric of `DataWriter`, which I've just not filled in this PR). But opmon can calculate deltas itself if we just pass the total, so I don't think this is much of a loss.