### PR TITLE
Rename Fragment::get_link_id and set_link_id to get_element_id and set_element_id

### DIFF
--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -14,7 +14,6 @@ on:
 
   workflow_dispatch:
 
-
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   Build_against_dev_release:

--- a/plugins/DataWriter.cpp
+++ b/plugins/DataWriter.cpp
@@ -234,7 +234,7 @@ DataWriter::do_work(std::atomic<bool>& running_flag)
 
         // print out some debug information, if requested
         TLOG_DEBUG(TLVL_FRAGMENT_HEADER_DUMP)
-          << get_name() << ": Partial(?) contents of the Fragment from link " << frag_ptr->get_link_id();
+          << get_name() << ": Partial(?) contents of the Fragment from link " << frag_ptr->get_element_id();
         const size_t number_of_32bit_values_per_row = 5;
         const size_t max_number_of_rows = 5;
         int number_of_32bit_values_to_print =
@@ -264,8 +264,8 @@ DataWriter::do_work(std::atomic<bool>& running_flag)
         StorageKey fragment_skey(frag_ptr->get_run_number(),
                                  frag_ptr->get_trigger_number(),
                                  dataformats::fragment_type_to_string(frag_ptr->get_fragment_type()),
-                                 frag_ptr->get_link_id().region_id,
-                                 frag_ptr->get_link_id().element_id);
+                                 frag_ptr->get_element_id().region_id,
+                                 frag_ptr->get_element_id().element_id);
         KeyedDataBlock data_block(fragment_skey);
         data_block.m_unowned_data_start = frag_ptr->get_storage_location();
         data_block.m_data_size = frag_ptr->get_size();

--- a/plugins/TriggerRecordBuilder.cpp
+++ b/plugins/TriggerRecordBuilder.cpp
@@ -378,7 +378,7 @@ TriggerRecordBuilder::read_fragments( fragment_sources_t& frag_sources, bool dra
 	ers::error( UnexpectedFragment( ERS_HERE, 
 					temp_id,
 					temp_fragment -> get_fragment_type_code(), 
-					temp_fragment -> get_link_id() ) ) ;
+					temp_fragment -> get_element_id() ) ) ;
       }
       else {
 	
@@ -389,7 +389,7 @@ TriggerRecordBuilder::read_fragments( fragment_sources_t& frag_sources, bool dra
 	for ( size_t i = 0 ; i < header.get_num_requested_components() ; ++i ) {
 	  
 	  const dataformats::ComponentRequest &  request = header[i] ;
-	  if ( request.component == temp_fragment -> get_link_id() ) {
+	  if ( request.component == temp_fragment -> get_element_id() ) {
 	    requested = true ;
 	    break ;
 	  }
@@ -405,7 +405,7 @@ TriggerRecordBuilder::read_fragments( fragment_sources_t& frag_sources, bool dra
 	  ers::error( UnexpectedFragment( ERS_HERE, 
 					  temp_id,
 					  temp_fragment -> get_fragment_type_code(), 
-					  temp_fragment -> get_link_id() ) ) ;
+					  temp_fragment -> get_element_id() ) ) ;
 
 	}
 	


### PR DESCRIPTION
Depends on DUNE-DAQ/dataformats#66