### PR TITLE
Run clang-format on files, implement some lint fixes.

### DIFF
--- a/include/dfmodules/DataStore.hpp
+++ b/include/dfmodules/DataStore.hpp
@@ -32,6 +32,7 @@
 #include <vector>
 
 #ifndef EXTERN_C_FUNC_DECLARE_START
+// NOLINTNEXTLINE(build/define_used)
 #define EXTERN_C_FUNC_DECLARE_START                                                                                    \
   extern "C"                                                                                                           \
   {
@@ -40,6 +41,7 @@
  * @brief Declare the function that will be called by the plugin loader
  * @param klass Class to be defined as a DUNE IPM Receiver
  */
+// NOLINTNEXTLINE(build/define_used)
 #define DEFINE_DUNE_DATA_STORE(klass)                                                                                  \
   EXTERN_C_FUNC_DECLARE_START                                                                                          \
   std::unique_ptr<dunedaq::dfmodules::DataStore> make(const nlohmann::json& conf)                                      \

--- a/include/dfmodules/StorageKey.hpp
+++ b/include/dfmodules/StorageKey.hpp
@@ -50,7 +50,6 @@ public:
     , m_element_number(element_number)
 
   {}
-  ~StorageKey() {} // NOLINT
 
   int get_run_number() const;
   int get_trigger_number() const;

--- a/plugins/DataWriter.cpp
+++ b/plugins/DataWriter.cpp
@@ -298,7 +298,7 @@ DataWriter::do_work(std::atomic<bool>& running_flag)
   }
 
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_work() method";
-}
+} // NOLINT(readability/fn_size)
 
 } // namespace dfmodules
 } // namespace dunedaq

--- a/plugins/DataWriter.cpp
+++ b/plugins/DataWriter.cpp
@@ -214,7 +214,7 @@ DataWriter::do_work(std::atomic<bool>& running_flag)
     // written out.
     if (m_data_storage_prescale <= 1 || ((m_records_received_tot.load() % m_data_storage_prescale) == 1)) {
       std::vector<KeyedDataBlock> data_block_list;
-      uint64_t bytes_in_data_blocks = 0;
+      uint64_t bytes_in_data_blocks = 0; // NOLINT(build/unsigned)
 
       // First deal with the trigger record header
       const void* trh_ptr = trigger_record_ptr->get_header_ref().get_storage_location();

--- a/plugins/DataWriter.hpp
+++ b/plugins/DataWriter.hpp
@@ -19,6 +19,7 @@
 #include "dfmessages/TriggerDecisionToken.hpp"
 
 #include <chrono>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -74,11 +75,11 @@ private:
   // Worker(s)
   std::unique_ptr<DataStore> m_data_writer;
 
-  std::atomic<uint64_t> m_records_received = { 0 };
-  std::atomic<uint64_t> m_records_received_tot = { 0 };
-  std::atomic<uint64_t> m_records_written = { 0 };
-  std::atomic<uint64_t> m_records_written_tot = { 0 };
-  std::atomic<uint64_t> m_bytes_output = { 0 };
+  std::atomic<uint64_t> m_records_received = { 0 };     // NOLINT(build/unsigned)
+  std::atomic<uint64_t> m_records_received_tot = { 0 }; // NOLINT(build/unsigned)
+  std::atomic<uint64_t> m_records_written = { 0 };      // NOLINT(build/unsigned)
+  std::atomic<uint64_t> m_records_written_tot = { 0 };  // NOLINT(build/unsigned)
+  std::atomic<uint64_t> m_bytes_output = { 0 };         // NOLINT(build/unsigned)
 
   inline double elapsed_seconds(std::chrono::steady_clock::time_point then,
                                 std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now()) const

--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -25,9 +25,9 @@
 #include "boost/lexical_cast.hpp"
 #include "highfive/H5File.hpp"
 
+#include <cstdlib>
 #include <functional>
 #include <memory>
-#include <stdlib.h>
 #include <string>
 #include <sys/statvfs.h>
 #include <utility>

--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -164,7 +164,7 @@ public:
     } catch (HighFive::Exception const& excpt) {
       throw HDF5Issue(ERS_HERE, excpt.what(), excpt);
     } catch (...) { // NOLINT(runtime/exceptions)
-        // NOLINT here because we *ARE* re-throwing the exception!
+      // NOLINT here because we *ARE* re-throwing the exception!
       throw HDF5Issue(ERS_HERE, "Unknown exception thrown by HDF5");
     }
 

--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -163,7 +163,8 @@ public:
       open_file_if_needed(full_filename, HighFive::File::ReadOnly);
     } catch (HighFive::Exception const& excpt) {
       throw HDF5Issue(ERS_HERE, excpt.what(), excpt);
-    } catch (...) {
+    } catch (...) { // NOLINT(runtime/exceptions)
+        // NOLINT here because we *ARE* re-throwing the exception!
       throw HDF5Issue(ERS_HERE, "Unknown exception thrown by HDF5");
     }
 
@@ -211,7 +212,8 @@ public:
       open_file_if_needed(full_filename, HighFive::File::OpenOrCreate);
     } catch (HighFive::Exception const& excpt) {
       throw HDF5Issue(ERS_HERE, excpt.what(), excpt);
-    } catch (...) {
+    } catch (...) { // NOLINT(runtime/exceptions)
+      // NOLINT here because we *ARE* re-throwing the exception!
       throw HDF5Issue(ERS_HERE, "Unknown exception thrown by HDF5");
     }
 
@@ -249,7 +251,8 @@ public:
       open_file_if_needed(full_filename, HighFive::File::OpenOrCreate);
     } catch (HighFive::Exception const& excpt) {
       throw HDF5Issue(ERS_HERE, excpt.what(), excpt);
-    } catch (...) {
+    } catch (...) { // NOLINT(runtime/exceptions)
+      // NOLINT here because we *ARE* re-throwing the exception!
       throw HDF5Issue(ERS_HERE, "Unknown exception thrown by HDF5");
     }
 
@@ -428,7 +431,8 @@ private:
       throw HDF5DataSetError(ERS_HERE, get_name(), dataset_name, excpt.what());
     } catch (HighFive::Exception const& excpt) {
       throw HDF5Issue(ERS_HERE, excpt.what(), excpt);
-    } catch (...) {
+    } catch (...) { // NOLINT(runtime/exceptions)
+      // NOLINT here because we *ARE* re-throwing the exception!
       throw HDF5Issue(ERS_HERE, "Unknown exception thrown by HDF5");
     }
 

--- a/plugins/HDF5KeyTranslator.hpp
+++ b/plugins/HDF5KeyTranslator.hpp
@@ -21,6 +21,7 @@
 #include "boost/algorithm/string.hpp"
 
 #include <iomanip>
+#include <map>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/plugins/TriggerRecordBuilder.cpp
+++ b/plugins/TriggerRecordBuilder.cpp
@@ -340,7 +340,7 @@ TriggerRecordBuilder::do_work(std::atomic<bool>& running_flag)
   TLOG() << ProgressUpdate(ERS_HERE, get_name(), oss_summ.str());
 
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_work() method";
-}
+} // NOLINT(readability/fn_size)
 
 bool
 TriggerRecordBuilder::read_fragments(fragment_sources_t& frag_sources, bool drain)

--- a/plugins/TriggerRecordBuilder.hpp
+++ b/plugins/TriggerRecordBuilder.hpp
@@ -9,17 +9,15 @@
 #ifndef DFMODULES_PLUGINS_TRIGGERRECORDBUILDER_HPP_
 #define DFMODULES_PLUGINS_TRIGGERRECORDBUILDER_HPP_
 
-
 #include "dfmodules/TriggerDecisionForwarder.hpp"
-#include "dfmodules/triggerrecordbuilderinfo/Nljs.hpp" 
-
+#include "dfmodules/triggerrecordbuilderinfo/Nljs.hpp"
 
 #include "dataformats/Fragment.hpp"
 #include "dataformats/TriggerRecord.hpp"
 #include "dataformats/Types.hpp"
+#include "dfmessages/DataRequest.hpp"
 #include "dfmessages/TriggerDecision.hpp"
 #include "dfmessages/Types.hpp"
-#include "dfmessages/DataRequest.hpp"
 
 #include "appfwk/DAQModule.hpp"
 #include "appfwk/DAQSink.hpp"
@@ -33,206 +31,194 @@
 
 namespace dunedaq {
 
-  namespace dfmodules {
+namespace dfmodules {
 
-    /**
-     * @brief TriggerId is a little class that defines a unique identifier for a trigger decision/record
-     * It also provides an operator < to be used by map to optimise bookkeeping
-     */
-    struct TriggerId
-    {
-      
-      TriggerId() = default ;
+/**
+ * @brief TriggerId is a little class that defines a unique identifier for a trigger decision/record
+ * It also provides an operator < to be used by map to optimise bookkeeping
+ */
+struct TriggerId
+{
 
-      explicit TriggerId(const dfmessages::TriggerDecision& td)
-	: trigger_number(td.trigger_number)
-	, run_number(td.run_number)
-      {
-	;
-      }
-      explicit TriggerId(dataformats::Fragment& f)
-	: trigger_number(f.get_trigger_number())
-	, run_number(f.get_run_number())
-      {
-	;
-      }
+  TriggerId() = default;
 
-      dataformats::trigger_number_t trigger_number;
-      dataformats::run_number_t run_number;
+  explicit TriggerId(const dfmessages::TriggerDecision& td)
+    : trigger_number(td.trigger_number)
+    , run_number(td.run_number)
+  {
+    ;
+  }
+  explicit TriggerId(dataformats::Fragment& f)
+    : trigger_number(f.get_trigger_number())
+    , run_number(f.get_run_number())
+  {
+    ;
+  }
 
-      bool operator<(const TriggerId& other) const noexcept
-      {
-	return run_number == other.run_number ? trigger_number < other.trigger_number : run_number < other.run_number;
-      }
+  dataformats::trigger_number_t trigger_number;
+  dataformats::run_number_t run_number;
 
-      friend std::ostream& operator<<(std::ostream& out, const TriggerId& id) noexcept 
-      {
-	out << id.trigger_number << '/' << id.run_number;
-	return out;
-      }
+  bool operator<(const TriggerId& other) const noexcept
+  {
+    return run_number == other.run_number ? trigger_number < other.trigger_number : run_number < other.run_number;
+  }
 
-      friend TraceStreamer& operator<<(TraceStreamer& out, const TriggerId& id) noexcept 
-      {
-	return out << id.trigger_number << "/" << id.run_number;
-      }
+  friend std::ostream& operator<<(std::ostream& out, const TriggerId& id) noexcept
+  {
+    out << id.trigger_number << '/' << id.run_number;
+    return out;
+  }
 
-      friend std::istream& operator>>(std::istream& in, TriggerId& id) 
-      {
-	char t ;
-	in >> id.trigger_number >> t >> id.run_number;
-	return in;
-      }
+  friend TraceStreamer& operator<<(TraceStreamer& out, const TriggerId& id) noexcept
+  {
+    return out << id.trigger_number << "/" << id.run_number;
+  }
 
-    };
+  friend std::istream& operator>>(std::istream& in, TriggerId& id)
+  {
+    char t;
+    in >> id.trigger_number >> t >> id.run_number;
+    return in;
+  }
+};
 
-  } // namespace dfmoduls
+} // namespace dfmodules
 
-    /**
-   * @brief Timed out Trigger Decision
+/**
+ * @brief Timed out Trigger Decision
+ */
+ERS_DECLARE_ISSUE(dfmodules,               ///< Namespace
+                  TimedOutTriggerDecision, ///< Issue class name
+                  "trigger id: " << trigger_id << " generate at: " << trigger_timestamp
+                                 << " too late for: " << present_time, ///< Message
+                  ((dfmodules::TriggerId)trigger_id)                   ///< Message parameters
+                  ((dataformats::timestamp_t)trigger_timestamp)        ///< Message parameters
+                  ((dataformats::timestamp_t)present_time)             ///< Message parameters
+)
+
+/**
+ * @brief Unexpected fragment
+ */
+ERS_DECLARE_ISSUE(dfmodules,          ///< Namespace
+                  UnexpectedFragment, ///< Issue class name
+                  "Unexpected Fragment for triggerID " << trigger_id << ", type " << fragment_type << ", " << geo_id,
+                  ((dfmodules::TriggerId)trigger_id)            ///< Message parameters
+                  ((dataformats::fragment_type_t)fragment_type) ///< Message parameters
+                  ((dataformats::GeoID)geo_id)                  ///< Message parameters
+)
+
+/**
+ * @brief Unknown GeoID
+ */
+ERS_DECLARE_ISSUE(dfmodules,    ///< Namespace
+                  UnknownGeoID, ///< Issue class name
+                  "Uknown GeoID: " << geo_id,
+                  ((dataformats::GeoID)geo_id) ///< Message parameters
+)
+
+/**
+ * @brief Duplicate trigger decision
+ */
+ERS_DECLARE_ISSUE(dfmodules,                 ///< Namespace
+                  DuplicatedTriggerDecision, ///< Issue class name
+                  "Duplicated trigger ID " << trigger_id,
+                  ((dfmodules::TriggerId)trigger_id) ///< Message parameters
+)
+
+/**
+ * @brief Invalid System Type
+ */
+ERS_DECLARE_ISSUE(dfmodules,         ///< Namespace
+                  InvalidSystemType, ///< Issue class name
+                  "Unknown system type " << type,
+                  ((std::string)type) ///< Message parameters
+)
+
+namespace dfmodules {
+
+/**
+ * @brief TriggerRecordBuilder is the Module that collects Trigger TriggersDecisions,
+ sends the corresponding data requests and collects Fragment to form a complete Trigger Record.
+ The TR then sent out possibly to a write module
+*/
+class TriggerRecordBuilder : public dunedaq::appfwk::DAQModule
+{
+public:
+  /**
+   * @brief TriggerRecordBuilder Constructor
+   * @param name Instance name for this TriggerRecordBuilder instance
    */
-  ERS_DECLARE_ISSUE(dfmodules,               ///< Namespace
-		    TimedOutTriggerDecision, ///< Issue class name
-		    "trigger id: " << trigger_id
-		    << " generate at: " << trigger_timestamp 
-		    << " too late for: " << present_time,           ///< Message
-		    ((dfmodules::TriggerId)trigger_id)              ///< Message parameters
-		    ((dataformats::timestamp_t)trigger_timestamp)   ///< Message parameters
-		    ((dataformats::timestamp_t)present_time)        ///< Message parameters
-		    )
+  explicit TriggerRecordBuilder(const std::string& name);
 
-  /**
-  * @brief Unexpected fragment
-  */
-  ERS_DECLARE_ISSUE(dfmodules,                  ///< Namespace
-  		    UnexpectedFragment,         ///< Issue class name
-   		    "Unexpected Fragment for triggerID " << trigger_id
-		    << ", type " << fragment_type 
-		    << ", " << geo_id,
-		    ((dfmodules::TriggerId)trigger_id)              ///< Message parameters
-   		    ((dataformats::fragment_type_t)fragment_type)   ///< Message parameters
-		    ((dataformats::GeoID)geo_id)                       ///< Message parameters
-     		    )
-    
+  TriggerRecordBuilder(const TriggerRecordBuilder&) = delete; ///< TriggerRecordBuilder is not copy-constructible
+  TriggerRecordBuilder& operator=(const TriggerRecordBuilder&) =
+    delete;                                                         ///< TriggerRecordBuilder is not copy-assignable
+  TriggerRecordBuilder(TriggerRecordBuilder&&) = delete;            ///< TriggerRecordBuilder is not move-constructible
+  TriggerRecordBuilder& operator=(TriggerRecordBuilder&&) = delete; ///< TriggerRecordBuilder is not move-assignable
 
-  /**
-  * @brief Unknown GeoID
-  */
-  ERS_DECLARE_ISSUE(dfmodules,    ///< Namespace
-   		    UnknownGeoID, ///< Issue class name
-   		    "Uknown GeoID: " << geo_id,
-		    ((dataformats::GeoID)geo_id)                       ///< Message parameters
-   		    )
+  void init(const data_t&) override;
+  void get_info(opmonlib::InfoCollector& ci, int level) override;
 
-  
-  /**
-   * @brief Duplicate trigger decision
-   */
-  ERS_DECLARE_ISSUE(dfmodules,    ///< Namespace
-   		    DuplicatedTriggerDecision, ///< Issue class name
-   		    "Duplicated trigger ID " << trigger_id,
-		    ((dfmodules::TriggerId)trigger_id)              ///< Message parameters
- 		    )
+protected:
+  using trigger_decision_source_t = dunedaq::appfwk::DAQSource<dfmessages::TriggerDecision>;
+  using datareqsink_t = dunedaq::appfwk::DAQSink<dfmessages::DataRequest>;
+  using datareqsinkmap_t = std::map<dataformats::GeoID, std::unique_ptr<datareqsink_t>>;
 
+  using fragment_source_t = dunedaq::appfwk::DAQSource<std::unique_ptr<dataformats::Fragment>>;
+  using fragment_sources_t = std::vector<std::unique_ptr<fragment_source_t>>;
 
-  /**
-   * @brief Invalid System Type
-   */
-  ERS_DECLARE_ISSUE(dfmodules,    ///< Namespace
-   		    InvalidSystemType, ///< Issue class name
-   		    "Unknown system type " << type,
-		    ((std::string)type)              ///< Message parameters
- 		    )
+  using trigger_record_ptr_t = std::unique_ptr<dataformats::TriggerRecord>;
+  using trigger_record_sink_t = appfwk::DAQSink<trigger_record_ptr_t>;
 
+  bool read_fragments(fragment_sources_t&, bool drain = false);
 
-  namespace dfmodules {
+  trigger_record_ptr_t extract_trigger_record(const TriggerId&);
+  // build_trigger_record will allocate memory and then orphan it to the caller via the returned pointer
+  // Plese note that the method will destroy the memory saved in the bookkeeping map
 
+  bool dispatch_data_requests(const dfmessages::TriggerDecision&, datareqsinkmap_t&, std::atomic<bool>& running) const;
 
+  bool send_trigger_record(const TriggerId&, trigger_record_sink_t&, std::atomic<bool>& running);
+  // this creates a trigger record and send it
 
-    /**
-     * @brief TriggerRecordBuilder is the Module that collects Trigger TriggersDecisions, 
-     sends the corresponding data requests and collects Fragment to form a complete Trigger Record.
-     The TR then sent out possibly to a write module
-    */
-    class TriggerRecordBuilder : public dunedaq::appfwk::DAQModule
-    {
-    public:
-      /**
-       * @brief TriggerRecordBuilder Constructor
-       * @param name Instance name for this TriggerRecordBuilder instance
-       */
-      explicit TriggerRecordBuilder(const std::string& name);
+  bool check_stale_requests();
 
-      TriggerRecordBuilder(const TriggerRecordBuilder&) = delete;            ///< TriggerRecordBuilder is not copy-constructible
-      TriggerRecordBuilder& operator=(const TriggerRecordBuilder&) = delete; ///< TriggerRecordBuilder is not copy-assignable
-      TriggerRecordBuilder(TriggerRecordBuilder&&) = delete;                 ///< TriggerRecordBuilder is not move-constructible
-      TriggerRecordBuilder& operator=(TriggerRecordBuilder&&) = delete;      ///< TriggerRecordBuilder is not move-assignable
+private:
+  // Commands
+  void do_conf(const data_t&);
+  void do_start(const data_t&);
+  void do_stop(const data_t&);
 
-      void init(const data_t&) override;
-      void get_info(opmonlib::InfoCollector& ci, int level) override;
+  // Threading
+  dunedaq::appfwk::ThreadHelper m_thread;
+  void do_work(std::atomic<bool>&);
 
-    protected:
-      using trigger_decision_source_t = dunedaq::appfwk::DAQSource<dfmessages::TriggerDecision>;
-      using datareqsink_t = dunedaq::appfwk::DAQSink<dfmessages::DataRequest>;
-      using datareqsinkmap_t = std::map<dataformats::GeoID, std::unique_ptr<datareqsink_t> > ;
+  // Configuration
+  // size_t m_sleep_msec_while_running;
+  std::chrono::milliseconds m_queue_timeout;
 
-      using fragment_source_t = dunedaq::appfwk::DAQSource<std::unique_ptr<dataformats::Fragment>>;
-      using fragment_sources_t = std::vector<std::unique_ptr<fragment_source_t>>;
+  // Input Queues
+  std::string m_trigger_decision_source_name;
+  std::vector<std::string> m_fragment_source_names;
 
-      using trigger_record_ptr_t = std::unique_ptr<dataformats::TriggerRecord> ;
-      using trigger_record_sink_t = appfwk::DAQSink<trigger_record_ptr_t>;
+  // Output queues
+  std::string m_trigger_record_sink_name;
+  std::map<dataformats::GeoID, std::string> m_map_geoid_queues; ///< Mappinng between GeoID and queues
 
-      
-      bool read_fragments( fragment_sources_t&, bool drain = false);
-      
-      trigger_record_ptr_t extract_trigger_record(const TriggerId&);
-      // build_trigger_record will allocate memory and then orphan it to the caller via the returned pointer
-      // Plese note that the method will destroy the memory saved in the bookkeeping map
+  // bookeeping
+  std::map<TriggerId, trigger_record_ptr_t> m_trigger_records;
 
-      bool dispatch_data_requests( const dfmessages::TriggerDecision &, 
-				   datareqsinkmap_t &, 
-				   std::atomic<bool>& running ) const ;
+  // book related metrics
+  using metric_counter_type = decltype(triggerrecordbuilderinfo::Info::trigger_decisions);
+  mutable std::atomic<metric_counter_type> m_trigger_decisions_counter = { 0 };
+  mutable std::atomic<metric_counter_type> m_fragment_counter = { 0 };
+  mutable std::atomic<metric_counter_type> m_old_trigger_decisions = { 0 };
+  mutable std::atomic<metric_counter_type> m_old_fragments = { 0 };
 
-      bool send_trigger_record(const TriggerId&, trigger_record_sink_t&, std::atomic<bool>& running);
-      // this creates a trigger record and send it
-      
-      bool check_stale_requests() ;
-      
-    private:
-      // Commands
-      void do_conf(const data_t&);
-      void do_start(const data_t&);
-      void do_stop(const data_t&);
-
-      // Threading
-      dunedaq::appfwk::ThreadHelper m_thread;
-      void do_work(std::atomic<bool>&);
-
-      // Configuration
-      // size_t m_sleep_msec_while_running;
-      std::chrono::milliseconds m_queue_timeout;
-
-      // Input Queues
-      std::string m_trigger_decision_source_name;
-      std::vector<std::string> m_fragment_source_names;
-
-      // Output queues
-      std::string m_trigger_record_sink_name;
-      std::map<dataformats::GeoID, std::string> m_map_geoid_queues; ///< Mappinng between GeoID and queues
-
-      // bookeeping
-      std::map<TriggerId, trigger_record_ptr_t> m_trigger_records;
-
-      // book related metrics
-      using metric_counter_type = decltype(triggerrecordbuilderinfo::Info::trigger_decisions);
-      mutable std::atomic<metric_counter_type> m_trigger_decisions_counter = { 0 };
-      mutable std::atomic<metric_counter_type> m_fragment_counter = { 0 };
-      mutable std::atomic<metric_counter_type> m_old_trigger_decisions = { 0 };
-      mutable std::atomic<metric_counter_type> m_old_fragments = { 0 };
-
-      dataformats::timestamp_diff_t m_max_time_difference;
-      dataformats::timestamp_t m_current_time = 0;
-    };
-  } // namespace dfmodules
+  dataformats::timestamp_diff_t m_max_time_difference;
+  dataformats::timestamp_t m_current_time = 0;
+};
+} // namespace dfmodules
 } // namespace dunedaq
 
 #endif // DFMODULES_PLUGINS_TRIGGERRECORDBUILDER_HPP_

--- a/src/dfmodules/HDF5FormattingParameters.hpp
+++ b/src/dfmodules/HDF5FormattingParameters.hpp
@@ -6,11 +6,13 @@
  * received with this code.
  */
 
-#ifndef DFMODULES_SRC_HDF5FORMATTINGPARAMETERS_HPP_
-#define DFMODULES_SRC_HDF5FORMATTINGPARAMETERS_HPP_
+#ifndef DFMODULES_SRC_DFMODULES_HDF5FORMATTINGPARAMETERS_HPP_
+#define DFMODULES_SRC_DFMODULES_HDF5FORMATTINGPARAMETERS_HPP_
 
 #include "dfmodules/StorageKey.hpp"
+
 #include <map>
+#include <string>
 
 namespace dunedaq {
 namespace dfmodules {
@@ -19,7 +21,7 @@ class HDF5FormattingParameters
 {
 
 public:
-  enum class OperationalEnvironmentType : uint16_t
+  enum class OperationalEnvironmentType : uint16_t // NOLINT(build/unsigned)
   {
     kSoftwareTest = 1,
     kICEBERG = 2,
@@ -134,4 +136,4 @@ public:
 } // namespace dfmodules
 } // namespace dunedaq
 
-#endif // DFMODULES_SRC_HDF5FORMATTINGPARAMETERS_HPP_
+#endif // DFMODULES_SRC_DFMODULES_HDF5FORMATTINGPARAMETERS_HPP_

--- a/unittest/DataStoreFactory_test.cxx
+++ b/unittest/DataStoreFactory_test.cxx
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(invalid_request)
   BOOST_CHECK_THROW(make_data_store(nlohmann::json{}), std::exception);
 }
 
-/*
+#if 0
 BOOST_AUTO_TEST_CASE(valid_request)
 {
 
@@ -44,6 +44,6 @@ BOOST_AUTO_TEST_CASE(valid_request)
   BOOST_TEST( ds.get() ) ;
 
 }
-*/
+#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/HDF5GetAllKeys_test.cxx
+++ b/unittest/HDF5GetAllKeys_test.cxx
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(GetKeysFromFragmentFiles)
   std::string file_prefix = "demo" + std::to_string(getpid());
   const int events_to_generate = 5;
   const int links_to_generate = 3;
-  const int dummydata_size = 20;
+  constexpr int dummydata_size = 20;
 
   // delete any pre-existing files so that we start with a clean slate
   std::string delete_pattern = file_prefix + ".*.hdf5";
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(GetKeysFromFragmentFiles)
   std::unique_ptr<HDF5DataStore> data_store_ptr(new HDF5DataStore(conf));
 
   // write several events, each with several fragments
-  char dummy_data[dummydata_size];
+  std::array<char, dummydata_size> dummy_data;
   for (int event_id = 1; event_id <= events_to_generate; ++event_id) {
     for (int geo_location = 0; geo_location < links_to_generate; ++geo_location) {
       StorageKey key(event_id, StorageKey::s_invalid_detector_id, geo_location);
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(GetKeysFromEventFiles)
   std::string file_prefix = "demo" + std::to_string(getpid());
   const int events_to_generate = 5;
   const int links_to_generate = 3;
-  const int dummydata_size = 20;
+  constexpr int dummydata_size = 20;
 
   // delete any pre-existing files so that we start with a clean slate
   std::string delete_pattern = file_prefix + ".*.hdf5";
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(GetKeysFromEventFiles)
   std::unique_ptr<HDF5DataStore> data_store_ptr(new HDF5DataStore(conf));
 
   // write several events, each with several fragments
-  char dummy_data[dummydata_size];
+  std::array<char, dummydata_size> dummy_data;
   for (int event_id = 1; event_id <= events_to_generate; ++event_id) {
     for (int geo_location = 0; geo_location < links_to_generate; ++geo_location) {
       StorageKey key(event_id, StorageKey::s_invalid_detector_id, geo_location);
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(GetKeysFromAllInOneFiles)
   std::string file_prefix = "demo" + std::to_string(getpid());
   const int events_to_generate = 5;
   const int links_to_generate = 3;
-  const int dummydata_size = 20;
+  constexpr int dummydata_size = 20;
 
   // delete any pre-existing files so that we start with a clean slate
   std::string delete_pattern = file_prefix + ".*.hdf5";
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE(GetKeysFromAllInOneFiles)
   std::unique_ptr<HDF5DataStore> data_store_ptr(new HDF5DataStore(conf));
 
   // write several events, each with several fragments
-  char dummy_data[dummydata_size];
+  std::array<char, dummydata_size> dummy_data;
   for (int event_id = 1; event_id <= events_to_generate; ++event_id) {
     for (int geo_location = 0; geo_location < links_to_generate; ++geo_location) {
       StorageKey key(event_id, StorageKey::s_invalid_detector_id, geo_location);
@@ -288,8 +288,8 @@ BOOST_AUTO_TEST_CASE(CheckCrossTalk)
   std::string file_prefix = "demo" + std::to_string(getpid());
   const int events_to_generate = 5;
   const int links_to_generate = 3;
-  const int dummydata_size = 20;
-  char dummy_data[dummydata_size];
+  constexpr int dummydata_size = 20;
+  std::array<char, dummydata_size> dummy_data;
   std::unique_ptr<HDF5DataStore> data_store_ptr;
   std::vector<StorageKey> key_list;
 

--- a/unittest/HDF5Read_test.cxx
+++ b/unittest/HDF5Read_test.cxx
@@ -43,14 +43,14 @@ delete_files_matching_pattern(const std::string& path, const std::string& patter
 
 BOOST_AUTO_TEST_SUITE(HDF5Read_test)
 
-/*
+#if 0
 BOOST_AUTO_TEST_CASE(ReadFragmentFiles)
 {
   std::string file_path(std::filesystem::temp_directory_path());
   std::string file_prefix = "demo" + std::to_string(getpid());
   const int events_to_generate = 2;
   const int links_to_generate = 2;
-  const int dummydata_size = 128;
+  constexpr int dummydata_size = 128;
 
   // delete any pre-existing files so that we start with a clean slate
   std::string delete_pattern = file_prefix + ".*.hdf5";
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(ReadFragmentFiles)
 
   // write several events, each with several fragments
   int initialized_checksum = 0;
-  char dummy_data[dummydata_size];
+  std::array<char, dummydata_size> dummy_data;
   for (int idx = 0; idx < dummydata_size; ++idx) {
     int val = 0x7f & idx;
     dummy_data[idx] = val;
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(ReadEventFiles)
   std::string file_prefix = "demo" + std::to_string(getpid());
   const int events_to_generate = 2;
   const int links_to_generate = 2;
-  const int dummydata_size = 128;
+  constexpr int dummydata_size = 128;
 
   // delete any pre-existing files so that we start with a clean slate
   std::string delete_pattern = file_prefix + ".*.hdf5";
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(ReadEventFiles)
 
   // write several events, each with several fragments
   int initialized_checksum = 0;
-  char dummy_data[dummydata_size];
+  std::array<char, dummydata_size> dummy_data;
   for (int idx = 0; idx < dummydata_size; ++idx) {
     int val = 0x7f & idx;
     dummy_data[idx] = val;
@@ -177,13 +177,14 @@ BOOST_AUTO_TEST_CASE(ReadEventFiles)
   // clean up the files that were created
   delete_files_matching_pattern(file_path, delete_pattern);
 }
-*/
+#endif
+
 BOOST_AUTO_TEST_CASE(ReadSingleFile)
 {
   std::string file_path(std::filesystem::temp_directory_path());
   std::string file_prefix = "demo" + std::to_string(getpid()) + "_" + std::string(getenv("USER"));
 
-  const int dummydata_size = 7;
+  constexpr int dummydata_size = 7;
   const int run_number = 52;
   const int trigger_count = 5;
   const std::string detector_name = "TPC";
@@ -208,7 +209,7 @@ BOOST_AUTO_TEST_CASE(ReadSingleFile)
 
   int initialized_checksum = 0;
   // write several events, each with several fragments
-  char dummy_data[dummydata_size];
+  std::array<char, dummydata_size> dummy_data;
   for (int idx = 0; idx < dummydata_size; ++idx) {
     int val = 0x7f & idx;
     dummy_data[idx] = val;

--- a/unittest/HDF5Write_test.cxx
+++ b/unittest/HDF5Write_test.cxx
@@ -20,9 +20,9 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
-#include <utility>
 #include <regex>
 #include <string>
+#include <utility>
 #include <vector>
 
 using namespace dunedaq::dfmodules;
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(WriteFragmentFiles)
   data_store_ptr = make_data_store(hdf5ds_json);
 
   // write several events, each with several fragments
-  std::array<char,dummydata_size> dummy_data;
+  std::array<char, dummydata_size> dummy_data;
   for (int trigger_number = 1; trigger_number <= trigger_count; ++trigger_number) {
     for (int apa_number = 1; apa_number <= apa_count; ++apa_number) {
       for (int link_number = 1; link_number <= link_count; ++link_number) {

--- a/unittest/HDF5Write_test.cxx
+++ b/unittest/HDF5Write_test.cxx
@@ -15,12 +15,13 @@
 
 #include "boost/test/unit_test.hpp"
 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <utility>
 #include <regex>
-#include <stdlib.h>
 #include <string>
 #include <vector>
 
@@ -61,7 +62,7 @@ BOOST_AUTO_TEST_CASE(WriteFragmentFiles)
   std::string file_path(std::filesystem::temp_directory_path());
   std::string file_prefix = "demo" + std::to_string(getpid()) + "_" + std::string(getenv("USER"));
 
-  const int dummydata_size = 7;
+  constexpr int dummydata_size = 7;
   const int run_number = 52;
   const int trigger_count = 5;
   const StorageKey::DataRecordGroupType group_type = StorageKey::DataRecordGroupType::kTPC;
@@ -84,7 +85,7 @@ BOOST_AUTO_TEST_CASE(WriteFragmentFiles)
   data_store_ptr = make_data_store(hdf5ds_json);
 
   // write several events, each with several fragments
-  char dummy_data[dummydata_size];
+  std::array<char,dummydata_size> dummy_data;
   for (int trigger_number = 1; trigger_number <= trigger_count; ++trigger_number) {
     for (int apa_number = 1; apa_number <= apa_count; ++apa_number) {
       for (int link_number = 1; link_number <= link_count; ++link_number) {
@@ -113,7 +114,7 @@ BOOST_AUTO_TEST_CASE(WriteEventFiles)
   std::string file_path(std::filesystem::temp_directory_path());
   std::string file_prefix = "demo" + std::to_string(getpid()) + "_" + std::string(getenv("USER"));
 
-  const int dummydata_size = 7;
+  constexpr int dummydata_size = 7;
   const int run_number = 53;
   const int trigger_count = 5;
   const StorageKey::DataRecordGroupType group_type = StorageKey::DataRecordGroupType::kTPC;
@@ -136,7 +137,7 @@ BOOST_AUTO_TEST_CASE(WriteEventFiles)
   data_store_ptr = make_data_store(hdf5ds_json);
 
   // write several events, each with several fragments
-  char dummy_data[dummydata_size];
+  std::array<char, dummydata_size> dummy_data;
   for (int trigger_number = 1; trigger_number <= trigger_count; ++trigger_number) {
     for (int apa_number = 1; apa_number <= apa_count; ++apa_number) {
       for (int link_number = 1; link_number <= link_count; ++link_number) {
@@ -165,7 +166,7 @@ BOOST_AUTO_TEST_CASE(WriteOneFile)
   std::string file_path(std::filesystem::temp_directory_path());
   std::string file_prefix = "demo" + std::to_string(getpid()) + "_" + std::string(getenv("USER"));
 
-  const int dummydata_size = 7;
+  constexpr int dummydata_size = 7;
   const int run_number = 54;
   const int trigger_count = 5;
   const StorageKey::DataRecordGroupType group_type = StorageKey::DataRecordGroupType::kTPC;
@@ -189,7 +190,7 @@ BOOST_AUTO_TEST_CASE(WriteOneFile)
   data_store_ptr = make_data_store(hdf5ds_json);
 
   // write several events, each with several fragments
-  char dummy_data[dummydata_size];
+  std::array<char, dummydata_size> dummy_data;
   for (int trigger_number = 1; trigger_number <= trigger_count; ++trigger_number) {
     for (int apa_number = 1; apa_number <= apa_count; ++apa_number) {
       for (int link_number = 1; link_number <= link_count; ++link_number) {
@@ -218,7 +219,7 @@ BOOST_AUTO_TEST_CASE(FileSizeLimitResultsInMultipleFiles)
   std::string file_path(std::filesystem::temp_directory_path());
   std::string file_prefix = "demo" + std::to_string(getpid()) + "_" + std::string(getenv("USER"));
 
-  const int dummydata_size = 10000;
+  constexpr int dummydata_size = 10000;
   const int run_number = 55;
   const int trigger_count = 15;
   const StorageKey::DataRecordGroupType group_type = StorageKey::DataRecordGroupType::kTPC;
@@ -244,7 +245,7 @@ BOOST_AUTO_TEST_CASE(FileSizeLimitResultsInMultipleFiles)
   std::unique_ptr<DataStore> data_store_ptr;
   data_store_ptr = make_data_store(hdf5ds_json);
 
-  char dummy_data[dummydata_size];
+  std::array<char, dummydata_size> dummy_data;
   for (int trigger_number = 1; trigger_number <= trigger_count; ++trigger_number) {
     for (int apa_number = 1; apa_number <= apa_count; ++apa_number) {
       for (int link_number = 1; link_number <= link_count; ++link_number) {
@@ -274,7 +275,7 @@ BOOST_AUTO_TEST_CASE(SmallFileSizeLimitDataBlockListWrite)
   std::string file_path(std::filesystem::temp_directory_path());
   std::string file_prefix = "demo" + std::to_string(getpid()) + "_" + std::string(getenv("USER"));
 
-  const int dummydata_size = 100000;
+  constexpr int dummydata_size = 100000;
   const int run_number = 56;
   const int trigger_count = 5;
   const StorageKey::DataRecordGroupType group_type = StorageKey::DataRecordGroupType::kTPC;
@@ -299,7 +300,7 @@ BOOST_AUTO_TEST_CASE(SmallFileSizeLimitDataBlockListWrite)
   std::unique_ptr<DataStore> data_store_ptr;
   data_store_ptr = make_data_store(hdf5ds_json);
 
-  char dummy_data[dummydata_size];
+  std::array<char, dummydata_size> dummy_data;
   for (int trigger_number = 1; trigger_number <= trigger_count; ++trigger_number) {
     std::vector<KeyedDataBlock> data_block_list;
     for (int apa_number = 1; apa_number <= apa_count; ++apa_number) {

--- a/unittest/StorageKey_test.cxx
+++ b/unittest/StorageKey_test.cxx
@@ -24,7 +24,11 @@ constexpr int event_id = 111;
 onstexpr int group_type = StorageKey::DataRecordGroupType::kTPC;
 constexpr int region_number = 1;
 constexpr int element_number = 1;
-dunedaq::dfmodules::StorageKey stk(run_number, event_id, group_type, region_number, element_number); ///< StorageKey instance for the test
+dunedaq::dfmodules::StorageKey stk(run_number,
+                                   event_id,
+                                   group_type,
+                                   region_number,
+                                   element_number); ///< StorageKey instance for the test
 
 } // namespace ""
 

--- a/unittest/TriggerRecordHeaderWrite_test.cxx
+++ b/unittest/TriggerRecordHeaderWrite_test.cxx
@@ -15,12 +15,12 @@
 
 #include "boost/test/unit_test.hpp"
 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <memory>
 #include <regex>
-#include <stdlib.h>
 #include <string>
 #include <vector>
 
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(WriteOneFile)
   std::string file_path(std::filesystem::temp_directory_path());
   std::string file_prefix = "demo" + std::to_string(getpid()) + "_" + std::string(getenv("USER"));
 
-  const int dummydata_size = 7;
+  constexpr int dummydata_size = 7;
   const int run_number = 52;
   const int trigger_count = 1;
   const StorageKey::DataRecordGroupType group_type = StorageKey::DataRecordGroupType::kTPC;
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(WriteOneFile)
   data_store_ptr = make_data_store(hdf5ds_json);
 
   // write several events, each with several fragments
-  char dummy_data[dummydata_size];
+  std::array<char, dummydata_size> dummy_data;
   for (int trigger_number = 1; trigger_number <= trigger_count; ++trigger_number) {
 
     // TriggerRecordHeader


### PR DESCRIPTION
This fixes the trivial items in #78, however, a few more substantive complaints remain.

```
sourcecode/dfmodules/plugins/DataWriter.cpp:301:  Small and focused functions are preferred: DataWriter::do_work() has 93 non-comment lines (error triggered by exceeding 80 lines) (disable this by putting "// NOLINT" after the function's closing brace.)  [readability/fn_size] [1]
sourcecode/dfmodules/plugins/HDF5DataStore.hpp:166:  A catch-all-exceptions construct was found in a file which doesn't contain int main(); this can only be used to wrap main()  [runtime/exceptions] [5]
sourcecode/dfmodules/plugins/HDF5DataStore.hpp:214:  A catch-all-exceptions construct was found in a file which doesn't contain int main(); this can only be used to wrap main()  [runtime/exceptions] [5]
sourcecode/dfmodules/plugins/HDF5DataStore.hpp:252:  A catch-all-exceptions construct was found in a file which doesn't contain int main(); this can only be used to wrap main()  [runtime/exceptions] [5]
sourcecode/dfmodules/plugins/HDF5DataStore.hpp:431:  A catch-all-exceptions construct was found in a file which doesn't contain int main(); this can only be used to wrap main()  [runtime/exceptions] [5]
sourcecode/dfmodules/plugins/TriggerRecordBuilder.cpp:343:  Small and focused functions are preferred: TriggerRecordBuilder::do_work() has 88 non-comment lines (error triggered by exceeding 80 lines) (disable this by putting "// NOLINT" after the function's closing brace.)  [readability/fn_size] [1]
```