### PR TITLE
Made changes needed to convert to using Info Structs from opmonlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,10 @@ find_package(appfwk REQUIRED)
 find_package(logging REQUIRED)
 find_package(HighFive REQUIRED)
 find_package(dfmessages REQUIRED)
+find_package(opmonlib REQUIRED)
 
-daq_codegen(*.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
+daq_codegen( datawriter.jsonnet hdf5datastore.jsonnet triggerrecordbuilder.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
+daq_codegen( *info.jsonnet DEP_PKGS opmonlib TEMPLATES opmonlib/InfoStructs.hpp.j2 opmonlib/InfoNljs.hpp.j2 )
 
 ##############################################################################
 daq_add_library( StorageKey.cpp TriggerDecisionForwarder.cpp TriggerInhibitAgent.cpp

--- a/plugins/DataWriter.cpp
+++ b/plugins/DataWriter.cpp
@@ -11,7 +11,7 @@
 #include "dfmodules/KeyedDataBlock.hpp"
 #include "dfmodules/StorageKey.hpp"
 #include "dfmodules/datawriter/Nljs.hpp"
-#include "dfmodules/datawriterinfo/Nljs.hpp"
+#include "dfmodules/datawriterinfo/InfoNljs.hpp"
 
 #include "appfwk/DAQModuleHelper.hpp"
 #include "dataformats/Fragment.hpp"

--- a/plugins/TriggerRecordBuilder.cpp
+++ b/plugins/TriggerRecordBuilder.cpp
@@ -13,8 +13,6 @@
 #include "appfwk/app/Nljs.hpp"
 #include "dfmodules/triggerrecordbuilder/Nljs.hpp"
 #include "dfmodules/triggerrecordbuilder/Structs.hpp"
-#include "dfmodules/triggerrecordbuilderinfo/Nljs.hpp"
-#include "dfmodules/triggerrecordbuilderinfo/Structs.hpp"
 #include "logging/Logging.hpp"
 
 #include <chrono>

--- a/plugins/TriggerRecordBuilder.hpp
+++ b/plugins/TriggerRecordBuilder.hpp
@@ -1,4 +1,4 @@
-1;95;0c/**
+/**
  * @file TriggerRecordBuilder.hpp
  *
  * This is part of the DUNE DAQ Software Suite, copyright 2020.

--- a/plugins/TriggerRecordBuilder.hpp
+++ b/plugins/TriggerRecordBuilder.hpp
@@ -11,7 +11,7 @@
 
 
 #include "dfmodules/TriggerDecisionForwarder.hpp"
-#include "dfmodules/triggerrecordbuilderinfo/Nljs.hpp" 
+#include "dfmodules/triggerrecordbuilderinfo/InfoNljs.hpp" 
 
 
 #include "dataformats/Fragment.hpp"

--- a/schema/dfmodules/datawriterinfo.jsonnet
+++ b/schema/dfmodules/datawriterinfo.jsonnet
@@ -6,11 +6,9 @@ local moo = import "moo.jsonnet";
 local s = moo.oschema.schema("dunedaq.dfmodules.datawriterinfo");
 
 local info = {
-   cl : s.string("class_s", moo.re.ident, doc="A string field"), 
    uint8  : s.number("uint8", "u8", doc="An unsigned of 8 bytes"),
 
    info: s.record("Info", [
-       s.field("class_name", self.cl, "datawriterinfo", doc="Info class name"),
        s.field("records_received", self.uint8, 0, doc="Integral trigger records received counter"), 
        s.field("new_records_received", self.uint8, 0, doc="Incremental trigger records received counter"), 
        s.field("records_written", self.uint8, 0, doc="Integral trigger records written counter"), 

--- a/schema/dfmodules/triggerrecordbuilderinfo.jsonnet
+++ b/schema/dfmodules/triggerrecordbuilderinfo.jsonnet
@@ -6,13 +6,9 @@ local moo = import "moo.jsonnet";
 local s = moo.oschema.schema("dunedaq.dfmodules.triggerrecordbuilderinfo");
 
 local info = {
-   cl : s.string("class_s", moo.re.ident,
-                  doc="A string field"), 
-    uint8  : s.number("uint8", "u8",
-                     doc="An unsigned of 8 bytes"),
+   uint8  : s.number("uint8", "u8", doc="An unsigned of 8 bytes"),
 
    info: s.record("Info", [
-       s.field("class_name", self.cl, "triggerrecordbuilderinfo", doc="Info class name"),
        s.field("trigger_decisions", self.uint8, 0, doc="Number of trigger decisions in the book"), 
        s.field("fragments", self.uint8, 0, doc="Number of fragments in the book"), 
        s.field("old_fragments", self.uint8, 0, doc="Number of fragments that are late with respect to present time. How late is configurable"),


### PR DESCRIPTION
Alessandro mentioned the need to make these changes several days ago in the daq-integration Slack channel:

- `opmonlib has now custom templates for Info structs. The immediate purpose is to standardise the definition of class_name but it’s likely they will be used for further customisation. All packages targeting  2.6 should switch to using those. Will prepare some instructions early next week. In the meantime, listrev is probably the simplest example to follow:
  https://github.com/DUNE-DAQ/listrev/pull/19/files`

Here is the link:  [listrev sample](https://github.com/DUNE-DAQ/listrev/pull/19/files)

The changes in this PR are my attempt to apply the example changes to the _dfmodules_ repo.  

I have run tests that show that A) the _dfmodules_ code compiles, B) the generated JSON for the _dfmodules_ jsonnet files is identical to what was produced before the change, and C) I see the expected opmon quantities being produced from the _dfmodules_ code.