### PR TITLE
Changes related to better handling of a full disk when trying to write data

### DIFF
--- a/include/dfmodules/DataStore.hpp
+++ b/include/dfmodules/DataStore.hpp
@@ -64,17 +64,6 @@ ERS_DECLARE_ISSUE(dfmodules,               ///< Namespace
 )
 /// @endcond LCOV_EXCL_STOP
 
-/**
- * @brief A generic ERS Issue for DataStore writing failure
- * @cond Doxygen doesn't like ERS macros LCOV_EXCL_START
- */
-ERS_DECLARE_ISSUE(dfmodules,                                     ///< Namespace
-                  DataStoreWritingFailed,                        ///< Type of the Issue
-                  "Failed to write data using  " << plugin_name, ///< Log Message from the issue
-                  ((std::string)plugin_name)                     ///< Message parameters
-)
-/// @endcond LCOV_EXCL_STOP
-
 namespace dfmodules {
 
 /**

--- a/include/dfmodules/DataStore.hpp
+++ b/include/dfmodules/DataStore.hpp
@@ -53,7 +53,7 @@
 namespace dunedaq {
 
 /**
- * @brief A ERS Issue for DataStore creation failure
+ * @brief An ERS Issue for DataStore creation failure
  * @cond Doxygen doesn't like ERS macros LCOV_EXCL_START
  */
 ERS_DECLARE_ISSUE(dfmodules,               ///< Namespace
@@ -62,6 +62,28 @@ ERS_DECLARE_ISSUE(dfmodules,               ///< Namespace
                                                 << conf,           ///< Log Message from the issue
                   ((std::string)plugin_name)((nlohmann::json)conf) ///< Message parameters
 )
+/// @endcond LCOV_EXCL_STOP
+
+/**
+ * @brief An ERS Issue for DataStore problems in which it is
+ * reasonable to retry the operation.
+ * @cond Doxygen doesn't like ERS macros LCOV_EXCL_START
+ */
+ERS_DECLARE_ISSUE(dfmodules,
+                  RetryableDataStoreProblem,
+                  "Module " << mod_name << ": A problem was encountered when " << description,
+                  ((std::string)mod_name)((std::string)description))
+/// @endcond LCOV_EXCL_STOP
+
+/**
+ * @brief An ERS Issue for DataStore problems in which it is
+ * not clear whether retrying the operation might succeed or not.
+ * @cond Doxygen doesn't like ERS macros LCOV_EXCL_START
+ */
+ERS_DECLARE_ISSUE(dfmodules,
+                  GeneralDataStoreProblem,
+                  "Module " << mod_name << ": A problem was encountered when " << description,
+                  ((std::string)mod_name)((std::string)description))
 /// @endcond LCOV_EXCL_STOP
 
 namespace dfmodules {

--- a/plugins/DataWriter.cpp
+++ b/plugins/DataWriter.cpp
@@ -291,8 +291,8 @@ DataWriter::do_work(std::atomic<bool>& running_flag)
 
         bool should_retry = true;
         int retry_wait_usec = 5000;
-	do {
-	  should_retry = false;
+        do {
+          should_retry = false;
           try {
             m_data_writer->write(data_block_list);
             ++m_records_written;
@@ -317,8 +317,7 @@ DataWriter::do_work(std::atomic<bool>& running_flag)
                                           trigger_record_ptr->get_header_ref().get_run_number(),
                                           excpt));
           }
-        }
-	while (should_retry && running_flag.load());
+        } while (should_retry && running_flag.load());
       }
     }
 

--- a/plugins/DataWriter.cpp
+++ b/plugins/DataWriter.cpp
@@ -155,7 +155,11 @@ DataWriter::do_stop(const data_t& /*args*/)
   // I've put this call fairly late in this method so that any draining of queues
   // (or whatever) can take place before we finalize things in the DataStore.
   if (m_data_storage_is_enabled) {
-    m_data_writer->finish_with_run(m_run_number);
+    try {
+      m_data_writer->finish_with_run(m_run_number);
+    } catch (const std::exception& excpt) {
+      ers::error(ProblemDuringStop(ERS_HERE, get_name(), m_run_number, excpt));
+    }
   }
 
   TLOG() << get_name() << " successfully stopped for run number " << m_run_number;

--- a/plugins/DataWriter.hpp
+++ b/plugins/DataWriter.hpp
@@ -65,6 +65,9 @@ private:
   int m_data_storage_prescale;
   int m_initial_tokens;
   dataformats::run_number_t m_run_number;
+  size_t m_min_write_retry_time_usec;
+  size_t m_max_write_retry_time_usec;
+  int m_write_retry_time_increase_factor;
 
   // Queue(s)
   using trigrecsource_t = dunedaq::appfwk::DAQSource<std::unique_ptr<dataformats::TriggerRecord>>;

--- a/plugins/DataWriter.hpp
+++ b/plugins/DataWriter.hpp
@@ -108,12 +108,19 @@ private:
 } // namespace dfmodules
 
 ERS_DECLARE_ISSUE_BASE(dfmodules,
-                       InvalidDataWriterError,
+                       InvalidDataWriter,
                        appfwk::GeneralDAQModuleIssue,
                        "A valid dataWriter instance is not available so it will not be possible to write data. A "
                        "likely cause for this is a skipped or missed Configure transition.",
                        ((std::string)name),
                        ERS_EMPTY)
+
+ERS_DECLARE_ISSUE_BASE(dfmodules,
+                       DataWritingProblem,
+                       appfwk::GeneralDAQModuleIssue,
+                       "A problem was encountered when writing TriggerRecord number " << trnum << " in run " << runnum,
+                       ((std::string)name),
+                       ((size_t)trnum)((size_t)runnum))
 
 } // namespace dunedaq
 

--- a/plugins/FakeDataProd.cpp
+++ b/plugins/FakeDataProd.cpp
@@ -130,7 +130,7 @@ FakeDataProd::do_timesync(std::atomic<bool>& running_flag)
 {
   while (running_flag.load()) {
     auto time_now = std::chrono::system_clock::now().time_since_epoch();
-    uint64_t current_timestamp =  // NOLINT (build/unsigned)
+    uint64_t current_timestamp = // NOLINT (build/unsigned)
       std::chrono::duration_cast<std::chrono::nanoseconds>(time_now).count();
     auto timesyncmsg = dfmessages::TimeSync(current_timestamp);
     try {

--- a/schema/dfmodules/datawriter.jsonnet
+++ b/schema/dfmodules/datawriter.jsonnet
@@ -18,6 +18,12 @@ local types = {
                 doc="Prescale value for writing TriggerRecords to storage"),
         s.field("data_store_parameters", self.dsparams,
                 doc="Parameters that configure the DataStore associated with this DataWriter"),
+	s.field("min_write_retry_time_usec", self.count, "1000",
+		doc="The minimum time between retries of data writes, in microseconds"),
+	s.field("max_write_retry_time_usec", self.count, "1000000",
+		doc="The maximum time between retries of data writes, in microseconds"),
+	s.field("write_retry_time_increase_factor", self.count, "2",
+		doc="The factor that is used to increase the time between subsequent retries of data writes"),
     ], doc="DataWriter configuration parameters"),
 
 };

--- a/schema/dfmodules/hdf5datastore.jsonnet
+++ b/schema/dfmodules/hdf5datastore.jsonnet
@@ -9,6 +9,8 @@ local types = {
     count : s.number("Count", "i4",
                      doc="A count of not too many things"),
 
+    factor : s.number("Factor", "f4", doc="A float number of 4 bytes"),
+
     data_store_type: s.string( "DataStoreType", doc="Specific Data store implementation to be instantiated" ),
 
     data_store_name: s.string( "DataStoreName", doc="String to specify names for DataStores"),
@@ -68,6 +70,8 @@ local types = {
                 doc="Parameters that are use for the filenames of the HDF5 files"),
         s.field("file_layout_parameters", self.hdf5_file_layout_params,
                 doc="Parameters that are use for the layout of Groups and DataSets within the HDF5 file"),
+        s.field("free_space_safety_factor_for_write", self.factor, 5.0,
+                doc="The safety factor that should be used when determining if there is sufficient free disk space during write operations"),
     ], doc="HDF5DataStore configuration"),
 
 };

--- a/src/dfmodules/CommonIssues.hpp
+++ b/src/dfmodules/CommonIssues.hpp
@@ -20,7 +20,7 @@
 
 namespace dunedaq {
 
-    // Disable coverage checking LCOV_EXCL_START
+// Disable coverage checking LCOV_EXCL_START
 
 ERS_DECLARE_ISSUE_BASE(dfmodules,
                        ProgressUpdate,
@@ -50,7 +50,14 @@ ERS_DECLARE_ISSUE_BASE(dfmodules,
                        ((std::string)name),
                        ((size_t)run_number))
 
-    // Re-enable coverage checking LCOV_EXCL_STOP
+ERS_DECLARE_ISSUE_BASE(dfmodules,
+                       ProblemDuringStop,
+                       appfwk::GeneralDAQModuleIssue,
+                       "A problem was enountered during the stopping of run " << run_number << ".",
+                       ((std::string)name),
+                       ((size_t)run_number))
+
+// Re-enable coverage checking LCOV_EXCL_STOP
 
 } // namespace dunedaq
 


### PR DESCRIPTION
The original impetus for these changes was when Giovanna noticed that the Dataflow App would crash when the output disk filled up.  In addition to handling that condition, these changes add a few other improvements.

The changes:

- ERS Issues in DataStore.hpp, DataWriter.hpp/cpp, and HDF5DataStore.hpp were modified somewhat.  This is to bring them in line with best practices (e.g. not having the word "Error" in the name of the Issue), to provide the right level of detail in each place in the call stack, and to provide finer-grain control over the reaction to certain exceptional conditions (e.g. "can/should the operation be retried, or would that be fruitless?")
- Exception handling was added to the Stop transition (DataWriter and HDF5DataStore).
- An explicit free-space check was added to the HDF5DataStore write operation.  This will cost us a little bit in terms of performance, but I found that the original crash was happening inside the HDF5 code (e.g. HDF5_Flush), and there appeared to be no way to prevent that.  So, the right reaction seemed to be to never call the HDF5 write routine(s) when the disk is full.
- Retries of write operations were added to DataWriter.  The DW code checks if the exceptional condition is something that a retry might fix, and if so, it retries it, as long as a Stop command has not been received.
   - This has the very practical effect of avoiding data loss.  In the earlier code, if an exception was encountered during a write operation, the current TriggerRecord was dropped on the floor and data taking continued.  Now, the write operation will be retried until either the run ends or the write succeeds (because someone cleared up some disk space).
   - If a run ends while the DataWriter is stuck retrying the write of a given TR, it will give up on that TR and attempt to write all of the TRs in its input queue that are waiting.  For each of those, it tries just once and then goes on.  If the write attempt for each TR fails, an error is reported.

Configuration parameters were added so that users can specify the following values:

- how much of a free-space safety factor should be required when writing each TriggerRecord.  (The code enforces a minimum of 1.1, i.e. 10% overhead.)  Default value is 5.
- what minimum and maximum retry intervals to use.  And, the compounding factor to use on each iteration.  (The idea was to implement something like an exponential back-off.).  So, for a write_retry_time_increase_factor value of 2, the wait time between retries will double each time.  The code enforces a minimum value for the min_write_retry_time_usec of 1 usec.  Defaults values are 1 msec, 1.0 second, and factor of 2.

Tests were done in which a disk was filled up during one run, that run was allowed to continue for a little while, then it was ended. and a second run was started without freeing up any space.  The following behaviors were validated:  the absence of a crash when the disk filled up, the retries of the writing of the next TR beyond the "full" condition, the draining of the DataWriter input queue on Stop, the failure of the second run to start because the disk was full.  
Tests were also done in which a full-disk condition happened during a run, that run was allowed to continue, and some free space was created.  In that case, data-writing resumed.

Most of my tests were done on a seldom-used (at the moment, at least) server at NP04 (np04-srv-002), and I would temporarily fill up the /tmp disk.
Here are some commands that might be useful reference:

- `python -m minidaqapp.nanorc.mdapp_multiru_gen --host-ru localhost -d $HOME/.biery/dunedaq/frames.bin -o . -s 10 -b 100000 -a 100000 -t 5 -o /tmp/biery full_disk_test`
- `let run1=930; runduration=100; waitAfterStop=11; let run2=$run1+1; nanorc full_disk_test boot init conf start ${run1} wait 2 resume wait ${runduration} pause wait 2 stop wait ${waitAfterStop} start ${run2} resume wait 10 stop scrap terminate; df -h /tmp ; rm -fv /tmp/biery/*${run1}* ; df -h /tmp`

In order to see all of the retry-failed error messages in the log_dataflow_<portno>.txt file, I would change the thresholds for ERS messages in the configuration boot.json file.  For example:

```
(dbt-pyvenv) [np04daq@np04-srv-002 full_disk_test]$ diff boot.json boot.json~
25c25
<         "DUNEDAQ_ERS_ERROR": "erstrace,throttle(1000,0),lstderr",
---
>         "DUNEDAQ_ERS_ERROR": "erstrace,throttle,lstderr",
27c27
<         "DUNEDAQ_ERS_INFO": "erstrace,throttle(1000,0),lstdout",
---
>         "DUNEDAQ_ERS_INFO": "erstrace,throttle,lstdout",
29c29
<         "DUNEDAQ_ERS_WARNING": "erstrace,throttle(1000,0),lstderr",
---
>         "DUNEDAQ_ERS_WARNING": "erstrace,throttle,lstderr",
```