### PR TITLE
Updated cernbox location of frames.bin file in integtest README

### DIFF
--- a/integtest/README.md
+++ b/integtest/README.md
@@ -2,7 +2,7 @@
 
 Here is the command for fetching an emulated frame data file:
 
-* `curl -o frames.bin -O https://cernbox.cern.ch/index.php/s/VAqNtn7bwuQtff3/download`
+* `curl -o frames.bin -O https://cernbox.cern.ch/index.php/s/7qNnuxD8igDOVJT/download`
 
 Here is a sample command for invoking a test:
 


### PR DESCRIPTION
This is based on the new frames.bin file that Florian has provided.