### PR TITLE
Incremental changes in dfmodules integtests

### DIFF
--- a/integtest/README.md
+++ b/integtest/README.md
@@ -1,6 +1,6 @@
-# 28-Jul-2021, KAB: notes on some initial integrationtests...
+# 10-Aug-2021, KAB: notes on some initial integrationtests...
 
-Here is the command for fetching an emulated frame data file:
+Here is a command for fetching a file that has WIB data in it (to be used in generating emulated data):
 
 * `curl -o frames.bin -O https://cernbox.cern.ch/index.php/s/7qNnuxD8igDOVJT/download`
 
@@ -18,6 +18,7 @@ For reference, here are the ideas behind the existing tests:
 To enable SWTPG and/or DQM functionality, these test files currently support some env vars:
 * export MDAPP_INTEGTEST_SWTPG=1
 * export MDAPP_INTEGTEST_DQM=1
+
 And, to turn off that functionality, unset those env vars:
 * unset MDAPP_INTEGTEST_SWTPG
 * unset MDAPP_INTEGTEST_DQM

--- a/integtest/README.md
+++ b/integtest/README.md
@@ -6,7 +6,7 @@ Here is the command for fetching an emulated frame data file:
 
 Here is a sample command for invoking a test:
 
-* `pytest -s four_process_quick_test.py --frame-file `pwd`/frames.bin`
+* `pytest -s four_process_quick_test.py --frame-file $PWD/frames.bin`
 
 For reference, here are the ideas behind the existing tests:
 * four_process_quick_test.py - verify that data gets written in a short run

--- a/integtest/README.md
+++ b/integtest/README.md
@@ -14,3 +14,10 @@ For reference, here are the ideas behind the existing tests:
 * four_process_empty_run_test.py - verify that runs with no events don't crash
 * six_process_multi_file_test.py - test that the file size maximum works
 * six_process_stop_start_test.py - verify that we don't get empty fragments at end run
+
+To enable SWTPG and/or DQM functionality, these test files currently support some env vars:
+* export MDAPP_INTEGTEST_SWTPG=1
+* export MDAPP_INTEGTEST_DQM=1
+And, to turn off that functionality, unset those env vars:
+* unset MDAPP_INTEGTEST_SWTPG
+* unset MDAPP_INTEGTEST_DQM

--- a/integtest/four_process_disabled_output_test.py
+++ b/integtest/four_process_disabled_output_test.py
@@ -13,7 +13,7 @@ confgen_name="minidaqapp.nanorc.mdapp_multiru_gen"
 # output directory (the test framework handles that)
 confgen_arguments=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", "2", "-b", "1000", "-a", "1000", "--host-ru", "localhost"]
 # The commands to run in nanorc, as a list
-nanorc_command_list="boot init conf start --disable-data-storage 101 resume wait 20 pause stop wait 3 start 102 resume wait 20 pause stop wait 3 start --disable-data-storage 102 resume wait 20 stop wait 3 start 103 resume wait 20 stop wait 3 scrap terminate".split()
+nanorc_command_list="boot init conf start --disable-data-storage 101 resume wait 20 pause wait 2 stop wait 2 start 102 resume wait 20 pause wait 2 stop wait 2 start --disable-data-storage 102 resume wait 20 pause wait 2 stop wait 2 start 103 resume wait 20 pause wait 2 stop wait 2 scrap terminate".split()
 
 # The tests themselves
 

--- a/integtest/four_process_disabled_output_test.py
+++ b/integtest/four_process_disabled_output_test.py
@@ -3,6 +3,13 @@ import pytest
 import dfmodules.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 
+# Initialization
+number_of_data_producers=2
+expected_fragments_per_trigger_record=number_of_data_producers
+min_fragment_size_bytes=37200
+max_fragment_size_bytes=37200
+check_for_logfile_errors=True
+
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
 # to run the config generation and nanorc
@@ -11,9 +18,22 @@ import integrationtest.log_file_checks as log_file_checks
 confgen_name="minidaqapp.nanorc.mdapp_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-confgen_arguments=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", "2", "-b", "1000", "-a", "1000", "--host-ru", "localhost"]
+confgen_arguments=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "--host-ru", "localhost"]
 # The commands to run in nanorc, as a list
 nanorc_command_list="boot init conf start --disable-data-storage 101 resume wait 20 pause wait 2 stop wait 2 start 102 resume wait 20 pause wait 2 stop wait 2 start --disable-data-storage 102 resume wait 20 pause wait 2 stop wait 2 start 103 resume wait 20 pause wait 2 stop wait 2 scrap terminate".split()
+
+import os
+if "MDAPP_INTEGTEST_SWTPG" in os.environ:
+    confgen_arguments.append("--enable-software-tpg")
+    expected_fragments_per_trigger_record*=2
+    min_fragment_size_bytes=80
+    print()
+    print("*** Software TPG is enabled ***")
+if "MDAPP_INTEGTEST_DQM" in os.environ:
+    confgen_arguments.append("--enable-dqm")
+    check_for_logfile_errors=False
+    print()
+    print("*** DQM is enabled ***")
 
 # The tests themselves
 
@@ -22,8 +42,9 @@ def test_nanorc_success(run_nanorc):
     assert run_nanorc.completed_process.returncode==0
 
 def test_log_files(run_nanorc):
-    # Check that there are no warnings or errors in the log files
-    assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
+    if check_for_logfile_errors:
+        # Check that there are no warnings or errors in the log files
+        assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
 
 def test_data_file(run_nanorc):
     # Run some tests on the output data file
@@ -32,5 +53,5 @@ def test_data_file(run_nanorc):
     for idx in range(len(run_nanorc.data_files)):
         data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
         assert data_file_checks.sanity_check(data_file)
-        assert data_file_checks.check_link_presence(data_file, n_links=2)
-        assert data_file_checks.check_fragment_sizes(data_file, min_frag_size=37200, max_frag_size=37200)
+        assert data_file_checks.check_link_presence(data_file, n_links=expected_fragments_per_trigger_record)
+        assert data_file_checks.check_fragment_sizes(data_file, min_frag_size=min_fragment_size_bytes, max_frag_size=max_fragment_size_bytes)

--- a/integtest/four_process_empty_run_test.py
+++ b/integtest/four_process_empty_run_test.py
@@ -3,6 +3,13 @@ import pytest
 import dfmodules.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 
+# Initialization
+number_of_data_producers=2
+expected_fragments_per_trigger_record=number_of_data_producers
+min_fragment_size_bytes=37200
+max_fragment_size_bytes=37200
+check_for_logfile_errors=True
+
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
 # to run the config generation and nanorc
@@ -11,9 +18,22 @@ import integrationtest.log_file_checks as log_file_checks
 confgen_name="minidaqapp.nanorc.mdapp_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-confgen_arguments=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", "2", "-b", "1000", "-a", "1000", "--host-ru", "localhost"]
+confgen_arguments=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "--host-ru", "localhost"]
 # The commands to run in nanorc, as a list
 nanorc_command_list="boot init conf start 101 wait 10 pause wait 2 stop wait 2 start 102 resume wait 20 pause wait 2 stop wait 2 start 103 wait 10 stop wait 2 start 104 wait 2 resume wait 20 pause wait 2 stop wait 2 scrap terminate".split()
+
+import os
+if "MDAPP_INTEGTEST_SWTPG" in os.environ:
+    confgen_arguments.append("--enable-software-tpg")
+    expected_fragments_per_trigger_record*=2
+    min_fragment_size_bytes=80
+    print()
+    print("*** Software TPG is enabled ***")
+if "MDAPP_INTEGTEST_DQM" in os.environ:
+    confgen_arguments.append("--enable-dqm")
+    check_for_logfile_errors=False
+    print()
+    print("*** DQM is enabled ***")
 
 # The tests themselves
 
@@ -22,8 +42,9 @@ def test_nanorc_success(run_nanorc):
     assert run_nanorc.completed_process.returncode==0
 
 def test_log_files(run_nanorc):
-    # Check that there are no warnings or errors in the log files
-    assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
+    if check_for_logfile_errors:
+        # Check that there are no warnings or errors in the log files
+        assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
 
 def test_data_file(run_nanorc):
     # Run some tests on the output data file
@@ -32,5 +53,5 @@ def test_data_file(run_nanorc):
     for idx in range(len(run_nanorc.data_files)):
         data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
         assert data_file_checks.sanity_check(data_file)
-        assert data_file_checks.check_link_presence(data_file, n_links=2)
-        assert data_file_checks.check_fragment_sizes(data_file, min_frag_size=37200, max_frag_size=37200)
+        assert data_file_checks.check_link_presence(data_file, n_links=expected_fragments_per_trigger_record)
+        assert data_file_checks.check_fragment_sizes(data_file, min_frag_size=min_fragment_size_bytes, max_frag_size=max_fragment_size_bytes)

--- a/integtest/four_process_empty_run_test.py
+++ b/integtest/four_process_empty_run_test.py
@@ -13,7 +13,7 @@ confgen_name="minidaqapp.nanorc.mdapp_multiru_gen"
 # output directory (the test framework handles that)
 confgen_arguments=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", "2", "-b", "1000", "-a", "1000", "--host-ru", "localhost"]
 # The commands to run in nanorc, as a list
-nanorc_command_list="boot init conf start 101 wait 20 pause stop wait 3 start 102 resume wait 20 pause stop wait 3 start 103 wait 20 stop wait 3 start 104 resume wait 20 stop wait 3 scrap terminate".split()
+nanorc_command_list="boot init conf start 101 wait 10 pause wait 2 stop wait 2 start 102 resume wait 20 pause wait 2 stop wait 2 start 103 wait 10 stop wait 2 start 104 wait 2 resume wait 20 pause wait 2 stop wait 2 scrap terminate".split()
 
 # The tests themselves
 

--- a/integtest/four_process_quick_test.py
+++ b/integtest/four_process_quick_test.py
@@ -23,8 +23,12 @@ import os
 if "MDAPP_INTEGTEST_SWTPG" in os.environ:
     confgen_arguments.append("--enable-software-tpg")
     expected_fragments_per_trigger_record*=2
+    print()
+    print("*** Software TPG is enabled ***")
 if "MDAPP_INTEGTEST_DQM" in os.environ:
     confgen_arguments.append("--enable-dqm")
+    print()
+    print("*** DQM is enabled ***")
 
 # The tests themselves
 

--- a/integtest/four_process_quick_test.py
+++ b/integtest/four_process_quick_test.py
@@ -17,7 +17,7 @@ confgen_name="minidaqapp.nanorc.mdapp_multiru_gen"
 # output directory (the test framework handles that)
 confgen_arguments=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "--host-ru", "localhost"]
 # The commands to run in nanorc, as a list
-nanorc_command_list="boot init conf start 101 wait 1 resume wait 20 pause wait 1 stop wait 2 scrap terminate".split()
+nanorc_command_list="boot init conf start 101 wait 1 resume wait 20 pause wait 2 stop wait 2 scrap terminate".split()
 
 import os
 if "MDAPP_INTEGTEST_SWTPG" in os.environ:

--- a/integtest/six_process_multi_file_test.py
+++ b/integtest/six_process_multi_file_test.py
@@ -13,7 +13,7 @@ confgen_name="minidaqapp.nanorc.mdapp_multiru_gen"
 # output directory (the test framework handles that)
 confgen_arguments=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", "5", "-b", "1000", "-a", "1000", "--host-ru", "localhost", "--host-ru", "localhost", "--host-ru", "localhost", "-t", "10.0"]
 # The commands to run in nanorc, as a list
-nanorc_command_list="boot init conf start 101 resume wait 660 pause stop wait 21 start 102 resume wait 480 pause stop wait 21 scrap terminate".split()
+nanorc_command_list="boot init conf start 101 resume wait 660 pause wait 2 stop wait 21 start 102 resume wait 480 pause wait 2 stop wait 21 scrap terminate".split()
 
 # The tests themselves
 

--- a/integtest/six_process_multi_file_test.py
+++ b/integtest/six_process_multi_file_test.py
@@ -8,6 +8,7 @@ number_of_data_producers=5
 expected_fragments_per_trigger_record=number_of_data_producers*3
 min_fragment_size_bytes=37200
 max_fragment_size_bytes=37200
+expected_number_of_files=7
 check_for_logfile_errors=False
 
 # The next three variable declarations *must* be present as globals in the test
@@ -27,6 +28,7 @@ if "MDAPP_INTEGTEST_SWTPG" in os.environ:
     confgen_arguments.append("--enable-software-tpg")
     expected_fragments_per_trigger_record*=2
     min_fragment_size_bytes=80
+    expected_number_of_files=12
     check_for_logfile_errors=False
     print()
     print("*** Software TPG is enabled ***")
@@ -49,7 +51,7 @@ def test_log_files(run_nanorc):
 
 def test_data_file(run_nanorc):
     # Run some tests on the output data file
-    assert len(run_nanorc.data_files)==7
+    assert len(run_nanorc.data_files)==expected_number_of_files
 
     for idx in range(len(run_nanorc.data_files)):
         data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])

--- a/integtest/six_process_multi_file_test.py
+++ b/integtest/six_process_multi_file_test.py
@@ -9,7 +9,7 @@ expected_fragments_per_trigger_record=number_of_data_producers*3
 min_fragment_size_bytes=37200
 max_fragment_size_bytes=37200
 expected_number_of_files=7
-check_for_logfile_errors=False
+check_for_logfile_errors=True
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -29,7 +29,6 @@ if "MDAPP_INTEGTEST_SWTPG" in os.environ:
     expected_fragments_per_trigger_record*=2
     min_fragment_size_bytes=80
     expected_number_of_files=12
-    check_for_logfile_errors=False
     print()
     print("*** Software TPG is enabled ***")
 if "MDAPP_INTEGTEST_DQM" in os.environ:

--- a/integtest/six_process_multi_file_test.py
+++ b/integtest/six_process_multi_file_test.py
@@ -3,6 +3,13 @@ import pytest
 import dfmodules.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 
+# Initialization
+number_of_data_producers=5
+expected_fragments_per_trigger_record=number_of_data_producers*3
+min_fragment_size_bytes=37200
+max_fragment_size_bytes=37200
+check_for_logfile_errors=False
+
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
 # to run the config generation and nanorc
@@ -11,9 +18,23 @@ import integrationtest.log_file_checks as log_file_checks
 confgen_name="minidaqapp.nanorc.mdapp_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-confgen_arguments=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", "5", "-b", "1000", "-a", "1000", "--host-ru", "localhost", "--host-ru", "localhost", "--host-ru", "localhost", "-t", "10.0"]
+confgen_arguments=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "--host-ru", "localhost", "--host-ru", "localhost", "--host-ru", "localhost", "-t", "10.0"]
 # The commands to run in nanorc, as a list
 nanorc_command_list="boot init conf start 101 resume wait 660 pause wait 2 stop wait 21 start 102 resume wait 480 pause wait 2 stop wait 21 scrap terminate".split()
+
+import os
+if "MDAPP_INTEGTEST_SWTPG" in os.environ:
+    confgen_arguments.append("--enable-software-tpg")
+    expected_fragments_per_trigger_record*=2
+    min_fragment_size_bytes=80
+    check_for_logfile_errors=False
+    print()
+    print("*** Software TPG is enabled ***")
+if "MDAPP_INTEGTEST_DQM" in os.environ:
+    confgen_arguments.append("--enable-dqm")
+    check_for_logfile_errors=False
+    print()
+    print("*** DQM is enabled ***")
 
 # The tests themselves
 
@@ -22,8 +43,9 @@ def test_nanorc_success(run_nanorc):
     assert run_nanorc.completed_process.returncode==0
 
 def test_log_files(run_nanorc):
-    # Check that there are no warnings or errors in the log files
-    assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
+    if check_for_logfile_errors:
+        # Check that there are no warnings or errors in the log files
+        assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
 
 def test_data_file(run_nanorc):
     # Run some tests on the output data file
@@ -32,5 +54,5 @@ def test_data_file(run_nanorc):
     for idx in range(len(run_nanorc.data_files)):
         data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
         assert data_file_checks.sanity_check(data_file)
-        assert data_file_checks.check_link_presence(data_file, n_links=15)
-        assert data_file_checks.check_fragment_sizes(data_file, min_frag_size=37200, max_frag_size=37200)
+        assert data_file_checks.check_link_presence(data_file, n_links=expected_fragments_per_trigger_record)
+        assert data_file_checks.check_fragment_sizes(data_file, min_frag_size=min_fragment_size_bytes, max_frag_size=max_fragment_size_bytes)

--- a/integtest/six_process_stop_start_test.py
+++ b/integtest/six_process_stop_start_test.py
@@ -8,6 +8,7 @@ number_of_data_producers=5
 expected_fragments_per_trigger_record=number_of_data_producers*3
 min_fragment_size_bytes=37200
 max_fragment_size_bytes=37200
+check_for_logfile_errors=False
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -26,8 +27,14 @@ if "MDAPP_INTEGTEST_SWTPG" in os.environ:
     confgen_arguments.append("--enable-software-tpg")
     expected_fragments_per_trigger_record*=2
     min_fragment_size_bytes=80
+    check_for_logfile_errors=False
+    print()
+    print("*** Software TPG is enabled ***")
 if "MDAPP_INTEGTEST_DQM" in os.environ:
     confgen_arguments.append("--enable-dqm")
+    check_for_logfile_errors=False
+    print()
+    print("*** DQM is enabled ***")
 
 # The tests themselves
 
@@ -35,11 +42,10 @@ def test_nanorc_success(run_nanorc):
     # Check that nanorc completed correctly
     assert run_nanorc.completed_process.returncode==0
 
-# 29-Jul-2021, KAB: temporarily turn off the log file checks n this test because we tend
-# to get TimeSync push error messages when we abruptly stop a run
-#def test_log_files(run_nanorc):
-#    # Check that there are no warnings or errors in the log files
-#    assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
+def test_log_files(run_nanorc):
+    if check_for_logfile_errors:
+        # Check that there are no warnings or errors in the log files
+        assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
 
 def test_data_file(run_nanorc):
     # Run some tests on the output data file

--- a/integtest/six_process_stop_start_test.py
+++ b/integtest/six_process_stop_start_test.py
@@ -6,6 +6,8 @@ import integrationtest.log_file_checks as log_file_checks
 # Initialization
 number_of_data_producers=5
 expected_fragments_per_trigger_record=number_of_data_producers*3
+min_fragment_size_bytes=37200
+max_fragment_size_bytes=37200
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -23,6 +25,7 @@ import os
 if "MDAPP_INTEGTEST_SWTPG" in os.environ:
     confgen_arguments.append("--enable-software-tpg")
     expected_fragments_per_trigger_record*=2
+    min_fragment_size_bytes=80
 if "MDAPP_INTEGTEST_DQM" in os.environ:
     confgen_arguments.append("--enable-dqm")
 
@@ -46,4 +49,4 @@ def test_data_file(run_nanorc):
         data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
         assert data_file_checks.sanity_check(data_file)
         assert data_file_checks.check_link_presence(data_file, n_links=expected_fragments_per_trigger_record)
-        assert data_file_checks.check_fragment_sizes(data_file, min_frag_size=37200, max_frag_size=37200)
+        assert data_file_checks.check_fragment_sizes(data_file, min_frag_size=min_fragment_size_bytes, max_frag_size=max_fragment_size_bytes)

--- a/integtest/six_process_stop_start_test.py
+++ b/integtest/six_process_stop_start_test.py
@@ -17,7 +17,7 @@ confgen_name="minidaqapp.nanorc.mdapp_multiru_gen"
 # output directory (the test framework handles that)
 confgen_arguments=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "--host-ru", "localhost", "--host-ru", "localhost", "--host-ru", "localhost"]
 # The commands to run in nanorc, as a list
-nanorc_command_list="boot init conf start 101 resume wait 20 pause stop wait 3 start 102 resume wait 20 pause stop wait 3 start 103 resume wait 20 stop wait 3 start 104 resume wait 20 stop wait 3 scrap terminate".split()
+nanorc_command_list="boot init conf start 101 resume wait 20 pause wait 2 stop wait 2 start 102 resume wait 20 pause wait 2 stop wait 2 start 103 resume wait 20 pause wait 2 stop wait 2 start 104 resume wait 20 pause wait 2 stop wait 2 scrap terminate".split()
 
 import os
 if "MDAPP_INTEGTEST_SWTPG" in os.environ:

--- a/integtest/six_process_stop_start_test.py
+++ b/integtest/six_process_stop_start_test.py
@@ -8,7 +8,7 @@ number_of_data_producers=5
 expected_fragments_per_trigger_record=number_of_data_producers*3
 min_fragment_size_bytes=37200
 max_fragment_size_bytes=37200
-check_for_logfile_errors=False
+check_for_logfile_errors=True
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -27,7 +27,6 @@ if "MDAPP_INTEGTEST_SWTPG" in os.environ:
     confgen_arguments.append("--enable-software-tpg")
     expected_fragments_per_trigger_record*=2
     min_fragment_size_bytes=80
-    check_for_logfile_errors=False
     print()
     print("*** Software TPG is enabled ***")
 if "MDAPP_INTEGTEST_DQM" in os.environ:

--- a/integtest/six_process_stop_start_test.py
+++ b/integtest/six_process_stop_start_test.py
@@ -3,6 +3,10 @@ import pytest
 import dfmodules.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 
+# Initialization
+number_of_data_producers=5
+expected_fragments_per_trigger_record=number_of_data_producers*3
+
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
 # to run the config generation and nanorc
@@ -11,9 +15,16 @@ import integrationtest.log_file_checks as log_file_checks
 confgen_name="minidaqapp.nanorc.mdapp_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-confgen_arguments=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", "5", "-b", "1000", "-a", "1000", "--host-ru", "localhost", "--host-ru", "localhost", "--host-ru", "localhost"]
+confgen_arguments=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "--host-ru", "localhost", "--host-ru", "localhost", "--host-ru", "localhost"]
 # The commands to run in nanorc, as a list
 nanorc_command_list="boot init conf start 101 resume wait 20 pause stop wait 3 start 102 resume wait 20 pause stop wait 3 start 103 resume wait 20 stop wait 3 start 104 resume wait 20 stop wait 3 scrap terminate".split()
+
+import os
+if "MDAPP_INTEGTEST_SWTPG" in os.environ:
+    confgen_arguments.append("--enable-software-tpg")
+    expected_fragments_per_trigger_record*=2
+if "MDAPP_INTEGTEST_DQM" in os.environ:
+    confgen_arguments.append("--enable-dqm")
 
 # The tests themselves
 
@@ -34,5 +45,5 @@ def test_data_file(run_nanorc):
     for idx in range(len(run_nanorc.data_files)):
         data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
         assert data_file_checks.sanity_check(data_file)
-        assert data_file_checks.check_link_presence(data_file, n_links=15)
+        assert data_file_checks.check_link_presence(data_file, n_links=expected_fragments_per_trigger_record)
         assert data_file_checks.check_fragment_sizes(data_file, min_frag_size=37200, max_frag_size=37200)

--- a/integtest/six_process_stop_start_test.py
+++ b/integtest/six_process_stop_start_test.py
@@ -20,7 +20,12 @@ confgen_name="minidaqapp.nanorc.mdapp_multiru_gen"
 # output directory (the test framework handles that)
 confgen_arguments=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "--host-ru", "localhost", "--host-ru", "localhost", "--host-ru", "localhost"]
 # The commands to run in nanorc, as a list
-nanorc_command_list="boot init conf start 101 resume wait 20 pause wait 2 stop wait 2 start 102 resume wait 20 pause wait 2 stop wait 2 start 103 resume wait 20 pause wait 2 stop wait 2 start 104 resume wait 20 pause wait 2 stop wait 2 scrap terminate".split()
+nanorc_command_list="boot init conf".split()
+nanorc_command_list+="start 101 resume wait 20 pause wait 2 stop wait 2".split()
+nanorc_command_list+="start 102 resume wait 20 pause wait 2 stop wait 2".split()
+nanorc_command_list+="start 103 resume wait 20 pause wait 2 stop wait 2".split()
+nanorc_command_list+="start 104 resume wait 20 pause wait 2 stop wait 2".split()
+nanorc_command_list+="scrap terminate".split()
 
 import os
 if "MDAPP_INTEGTEST_SWTPG" in os.environ:


### PR DESCRIPTION
The changes in this PR add the ability to control whether the Software TP Generation and/or the Readout-App-based DQM functionality are included in each test.  For now, this control is done in a rather brute-force way (setting and un-setting of env vars).

The changes also added a few calculated quantities in the scripts instead of having everything hard-coded.  (This was a recommendation from Eric earlier, and we'll likely add more in the future.)

For now, my goal is simply to make these changes generally available by having them reviewed and merged to the _develop_ branch.