### PR TITLE
Tweaks to the HDF5 Group name for TP_APA

### DIFF
--- a/include/dfmodules/StorageKey.hpp
+++ b/include/dfmodules/StorageKey.hpp
@@ -35,6 +35,7 @@ public:
     kTPC = 2,
     kPDS = 3,
     kTrigger = 4,
+    kTPC_TP = 5,
     kInvalid = 0
   };
 

--- a/plugins/DataWriter.cpp
+++ b/plugins/DataWriter.cpp
@@ -276,7 +276,8 @@ DataWriter::do_work(std::atomic<bool>& running_flag)
         }
 
         // add information about each Fragment to the list of data blocks to be stored
-        StorageKey::DataRecordGroupType group_type = get_group_type(frag_ptr->get_element_id().system_type);
+        StorageKey::DataRecordGroupType group_type =
+          get_group_type(frag_ptr->get_element_id().system_type, frag_ptr->get_fragment_type());
         StorageKey fragment_skey(frag_ptr->get_run_number(),
                                  frag_ptr->get_trigger_number(),
                                  group_type,

--- a/plugins/DataWriter.hpp
+++ b/plugins/DataWriter.hpp
@@ -93,8 +93,13 @@ private:
   using geoid_system_type_t = dataformats::GeoID::SystemType;
   using key_group_type_t = StorageKey::DataRecordGroupType;
   std::map<geoid_system_type_t, key_group_type_t> m_system_type_to_group_type_mapping;
-  key_group_type_t get_group_type(geoid_system_type_t system_type)
+  key_group_type_t get_group_type(geoid_system_type_t system_type, dataformats::FragmentType frag_type)
   {
+    // 16-Aug-2021, KAB: ugly hack
+    if (system_type == geoid_system_type_t::kTPC && frag_type == dataformats::FragmentType::kTriggerPrimitives) {
+      return key_group_type_t::kTPC_TP;
+    }
+
     if (m_system_type_to_group_type_mapping.size() == 0) {
       m_system_type_to_group_type_mapping[geoid_system_type_t::kTPC] = key_group_type_t::kTPC;
       m_system_type_to_group_type_mapping[geoid_system_type_t::kPDS] = key_group_type_t::kPDS;

--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -526,7 +526,7 @@ private:
         TLOG_DEBUG(TLVL_BASIC) << get_name() << "Created HDF5 file (" << unique_filename << ").";
 
         if (!m_file_ptr->hasAttribute("data_format_version")) {
-          int version = 1;
+          int version = m_key_translator.get_current_version();
           m_file_ptr->createAttribute("data_format_version", version);
         }
         if (!m_file_ptr->hasAttribute("operational_environment")) {

--- a/plugins/HDF5KeyTranslator.hpp
+++ b/plugins/HDF5KeyTranslator.hpp
@@ -37,8 +37,8 @@ public:
 
   HDF5KeyTranslator(/*OperationalEnvironmentType op_env_type*/)
   {
-    m_data_record_params = HDF5FormattingParameters::get_data_record_parameters(/*op_env_type,*/ s_current_version);
-    m_path_param_map = HDF5FormattingParameters::get_path_parameters(/*op_env_type,*/ s_current_version);
+    m_data_record_params = HDF5FormattingParameters::get_data_record_parameters(/*op_env_type,*/ get_current_version());
+    m_path_param_map = HDF5FormattingParameters::get_path_parameters(/*op_env_type,*/ get_current_version());
   }
 
   /**
@@ -110,7 +110,7 @@ public:
    * returned by this class. This is independent of the translations from HDF5 paths
    * to StorageKeys (that translation may support multiple versions).
    */
-  int get_current_version() { return s_current_version; }
+  int get_current_version() { return HDF5FormattingParameters::get_current_version(); }
 
   /**
    * @brief Translates the specified input parameters into the appropriate filename.

--- a/src/dfmodules/HDF5FormattingParameters.hpp
+++ b/src/dfmodules/HDF5FormattingParameters.hpp
@@ -48,7 +48,7 @@ public:
     int number_of_digits_for_run_number;
   };
 
-  static int get_current_version_number(/*OperationalEnvironmentType op_env_type*/) { return 1; }
+  static int get_current_version(/*OperationalEnvironmentType op_env_type*/) { return 2; }
 
   static DataRecordParameters get_data_record_parameters(/*OperationalEnvironmentType op_env_type,*/
                                                          int /*param_version*/)
@@ -96,6 +96,14 @@ public:
     invalid_params.element_name_prefix = "Element";
     invalid_params.digits_for_element_number = 2;
     the_map[StorageKey::DataRecordGroupType::kInvalid] = invalid_params;
+
+    PathParameters tpc_tp_params;
+    tpc_tp_params.group_name_within_data_record = "TPC";
+    tpc_tp_params.region_name_prefix = "TP_APA";
+    tpc_tp_params.digits_for_region_number = 3;
+    tpc_tp_params.element_name_prefix = "Link";
+    tpc_tp_params.digits_for_element_number = 2;
+    the_map[StorageKey::DataRecordGroupType::kTPC_TP] = tpc_tp_params;
 
     return the_map;
   }


### PR DESCRIPTION
Here is the request from Giovanna:

```
GROUP "TPC” {
  GROUP “TP_APA000" {
    DATASET "Link02" {
    DATASET "Link03" {
  } } }
```

The code changes associated with this PR implement this requested naming.

To test, we can use
* `python -m minidaqapp.nanorc.mdapp_multiru_gen --host-ru localhost -d $PWD/frames.bin -o . -s 10 --enable-software-tpg mdapp_4proc_swtpg`
