### PR TITLE
integtest event count

### DIFF
--- a/integtest/four_process_disabled_output_test.py
+++ b/integtest/four_process_disabled_output_test.py
@@ -10,8 +10,8 @@ run_duration=20  # seconds
 # Default values for validation parameters
 expected_number_of_data_files=2
 check_for_logfile_errors=True
-min_expected_event_count=run_duration-2
-max_expected_event_count=run_duration+2
+expected_event_count=run_duration
+expected_event_count_tolerance=2
 wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
                            "element_name_prefix": "Link", "element_number_offset": 0,
                            "expected_fragment_count": number_of_data_producers,
@@ -60,12 +60,12 @@ def test_log_files(run_nanorc):
         assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
 
 def test_data_file(run_nanorc):
-    local_min_event_count=min_expected_event_count
-    local_max_event_count=max_expected_event_count
+    local_expected_event_count=expected_event_count
+    local_event_count_tolerance=expected_event_count_tolerance
     fragment_check_list=[]
     if "--enable-software-tpg" in run_nanorc.confgen_arguments:
-        local_min_event_count+=(265*number_of_data_producers*run_duration/100)
-        local_max_event_count+=(280*number_of_data_producers*run_duration/100)
+        local_expected_event_count+=(270*number_of_data_producers*run_duration/100)
+        local_event_count_tolerance+=(10*number_of_data_producers*run_duration/100)
         fragment_check_list.append(wib1_frag_multi_trig_params)
         fragment_check_list.append(rawtp_frag_params)
         fragment_check_list.append(triggertp_frag_params)
@@ -78,7 +78,7 @@ def test_data_file(run_nanorc):
     for idx in range(len(run_nanorc.data_files)):
         data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
         assert data_file_checks.sanity_check(data_file)
-        assert data_file_checks.check_event_count(data_file, local_min_event_count, local_max_event_count)
+        assert data_file_checks.check_event_count(data_file, local_expected_event_count, local_event_count_tolerance)
         for jdx in range(len(fragment_check_list)):
             assert data_file_checks.check_fragment_count(data_file, fragment_check_list[jdx])
             assert data_file_checks.check_fragment_presence(data_file, fragment_check_list[jdx])

--- a/integtest/four_process_disabled_output_test.py
+++ b/integtest/four_process_disabled_output_test.py
@@ -10,6 +10,8 @@ run_duration=20  # seconds
 # Default values for validation parameters
 expected_number_of_data_files=2
 check_for_logfile_errors=True
+min_expected_event_count=run_duration-2
+max_expected_event_count=run_duration+2
 wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
                            "element_name_prefix": "Link", "element_number_offset": 0,
                            "expected_fragment_count": number_of_data_producers,
@@ -58,8 +60,12 @@ def test_log_files(run_nanorc):
         assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
 
 def test_data_file(run_nanorc):
+    local_min_event_count=min_expected_event_count
+    local_max_event_count=max_expected_event_count
     fragment_check_list=[]
     if "--enable-software-tpg" in run_nanorc.confgen_arguments:
+        local_min_event_count+=(265*number_of_data_producers*run_duration/100)
+        local_max_event_count+=(280*number_of_data_producers*run_duration/100)
         fragment_check_list.append(wib1_frag_multi_trig_params)
         fragment_check_list.append(rawtp_frag_params)
         fragment_check_list.append(triggertp_frag_params)
@@ -72,6 +78,7 @@ def test_data_file(run_nanorc):
     for idx in range(len(run_nanorc.data_files)):
         data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
         assert data_file_checks.sanity_check(data_file)
+        assert data_file_checks.check_event_count(data_file, local_min_event_count, local_max_event_count)
         for jdx in range(len(fragment_check_list)):
             assert data_file_checks.check_fragment_count(data_file, fragment_check_list[jdx])
             assert data_file_checks.check_fragment_presence(data_file, fragment_check_list[jdx])

--- a/integtest/four_process_quick_test.py
+++ b/integtest/four_process_quick_test.py
@@ -10,8 +10,8 @@ run_duration=20  # seconds
 # Default values for validation parameters
 expected_number_of_data_files=1
 check_for_logfile_errors=True
-min_expected_event_count=run_duration-1
-max_expected_event_count=run_duration+2
+expected_event_count=run_duration
+expected_event_count_tolerance=2
 wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
                            "element_name_prefix": "Link", "element_number_offset": 0,
                            "expected_fragment_count": number_of_data_producers,
@@ -47,7 +47,7 @@ def test_data_file(run_nanorc):
     for idx in range(len(run_nanorc.data_files)):
         data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
         assert data_file_checks.sanity_check(data_file)
-        assert data_file_checks.check_event_count(data_file, min_expected_event_count, max_expected_event_count)
+        assert data_file_checks.check_event_count(data_file, expected_event_count, expected_event_count_tolerance)
         assert data_file_checks.check_fragment_count(data_file, wib1_frag_hsi_trig_params)
         assert data_file_checks.check_fragment_presence(data_file, wib1_frag_hsi_trig_params)
         assert data_file_checks.check_fragment_size2(data_file, wib1_frag_hsi_trig_params)

--- a/integtest/four_process_quick_test.py
+++ b/integtest/four_process_quick_test.py
@@ -10,6 +10,8 @@ run_duration=20  # seconds
 # Default values for validation parameters
 expected_number_of_data_files=1
 check_for_logfile_errors=True
+min_expected_event_count=run_duration-1
+max_expected_event_count=run_duration+2
 wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
                            "element_name_prefix": "Link", "element_number_offset": 0,
                            "expected_fragment_count": number_of_data_producers,
@@ -45,6 +47,7 @@ def test_data_file(run_nanorc):
     for idx in range(len(run_nanorc.data_files)):
         data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
         assert data_file_checks.sanity_check(data_file)
+        assert data_file_checks.check_event_count(data_file, min_expected_event_count, max_expected_event_count)
         assert data_file_checks.check_fragment_count(data_file, wib1_frag_hsi_trig_params)
         assert data_file_checks.check_fragment_presence(data_file, wib1_frag_hsi_trig_params)
         assert data_file_checks.check_fragment_size2(data_file, wib1_frag_hsi_trig_params)

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -10,8 +10,8 @@ run_duration=20  # seconds
 # Default values for validation parameters
 expected_number_of_data_files=1
 check_for_logfile_errors=True
-min_expected_event_count=run_duration-1
-max_expected_event_count=run_duration+2
+expected_event_count=run_duration
+expected_event_count_tolerance=2
 wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
                            "element_name_prefix": "Link", "element_number_offset": 0,
                            "expected_fragment_count": number_of_data_producers,
@@ -71,12 +71,12 @@ def test_log_files(run_nanorc):
         assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
 
 def test_data_file(run_nanorc):
-    local_min_event_count=min_expected_event_count
-    local_max_event_count=max_expected_event_count
+    local_expected_event_count=expected_event_count
+    local_event_count_tolerance=expected_event_count_tolerance
     fragment_check_list=[]
     if "--enable-software-tpg" in run_nanorc.confgen_arguments:
-        local_min_event_count+=(275*number_of_data_producers*run_duration/100)
-        local_max_event_count+=(295*number_of_data_producers*run_duration/100)
+        local_expected_event_count+=(285*number_of_data_producers*run_duration/100)
+        local_event_count_tolerance+=(10*number_of_data_producers*run_duration/100)
         fragment_check_list.append(wib1_frag_multi_trig_params)
         fragment_check_list.append(rawtp_frag_params)
         fragment_check_list.append(triggertp_frag_params)
@@ -96,7 +96,7 @@ def test_data_file(run_nanorc):
     for idx in range(len(run_nanorc.data_files)):
         data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
         assert data_file_checks.sanity_check(data_file)
-        assert data_file_checks.check_event_count(data_file, local_min_event_count, local_max_event_count)
+        assert data_file_checks.check_event_count(data_file, local_expected_event_count, local_event_count_tolerance)
         for jdx in range(len(fragment_check_list)):
             assert data_file_checks.check_fragment_count(data_file, fragment_check_list[jdx])
             assert data_file_checks.check_fragment_presence(data_file, fragment_check_list[jdx])

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -10,6 +10,8 @@ run_duration=20  # seconds
 # Default values for validation parameters
 expected_number_of_data_files=1
 check_for_logfile_errors=True
+min_expected_event_count=run_duration-1
+max_expected_event_count=run_duration+2
 wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
                            "element_name_prefix": "Link", "element_number_offset": 0,
                            "expected_fragment_count": number_of_data_producers,
@@ -25,7 +27,7 @@ wib2_frag_params={"fragment_type_description": "WIB2", "hdf5_groups": "TPC/APA00
 pds_frag_params={"fragment_type_description": "PDS", "hdf5_groups": "PDS/Region000",
                  "element_name_prefix": "Element", "element_number_offset": 0,
                  "expected_fragment_count": number_of_data_producers,
-                 "min_size_bytes": 80, "max_size_bytes": 32000}
+                 "min_size_bytes": 80, "max_size_bytes": 36000}
 rawtp_frag_params={"fragment_type_description": "Raw TP", "hdf5_groups": "TPC/TP_APA000",
                    "element_name_prefix": "Link", "element_number_offset": number_of_data_producers,
                    "expected_fragment_count": number_of_data_producers,
@@ -69,8 +71,12 @@ def test_log_files(run_nanorc):
         assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
 
 def test_data_file(run_nanorc):
+    local_min_event_count=min_expected_event_count
+    local_max_event_count=max_expected_event_count
     fragment_check_list=[]
     if "--enable-software-tpg" in run_nanorc.confgen_arguments:
+        local_min_event_count+=(275*number_of_data_producers*run_duration/100)
+        local_max_event_count+=(295*number_of_data_producers*run_duration/100)
         fragment_check_list.append(wib1_frag_multi_trig_params)
         fragment_check_list.append(rawtp_frag_params)
         fragment_check_list.append(triggertp_frag_params)
@@ -90,6 +96,7 @@ def test_data_file(run_nanorc):
     for idx in range(len(run_nanorc.data_files)):
         data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
         assert data_file_checks.sanity_check(data_file)
+        assert data_file_checks.check_event_count(data_file, local_min_event_count, local_max_event_count)
         for jdx in range(len(fragment_check_list)):
             assert data_file_checks.check_fragment_count(data_file, fragment_check_list[jdx])
             assert data_file_checks.check_fragment_presence(data_file, fragment_check_list[jdx])

--- a/integtest/six_process_stop_start_test.py
+++ b/integtest/six_process_stop_start_test.py
@@ -11,6 +11,8 @@ run_duration=20  # seconds
 # Default values for validation parameters
 expected_number_of_data_files=4
 check_for_logfile_errors=True
+min_expected_event_count=run_duration-2
+max_expected_event_count=run_duration+2
 wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
                            "element_name_prefix": "Link", "element_number_offset": 0,
                            "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
@@ -64,8 +66,12 @@ def test_log_files(run_nanorc):
         assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
 
 def test_data_file(run_nanorc):
+    local_min_event_count=min_expected_event_count
+    local_max_event_count=max_expected_event_count
     fragment_check_list=[]
     if "--enable-software-tpg" in run_nanorc.confgen_arguments:
+        local_min_event_count+=(265*number_of_data_producers*number_of_readout_apps*run_duration/100)
+        local_max_event_count+=(280*number_of_data_producers*number_of_readout_apps*run_duration/100)
         fragment_check_list.append(wib1_frag_multi_trig_params)
         fragment_check_list.append(rawtp_frag_params)
         fragment_check_list.append(triggertp_frag_params)
@@ -78,6 +84,7 @@ def test_data_file(run_nanorc):
     for idx in range(len(run_nanorc.data_files)):
         data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
         assert data_file_checks.sanity_check(data_file)
+        assert data_file_checks.check_event_count(data_file, local_min_event_count, local_max_event_count)
         for jdx in range(len(fragment_check_list)):
             assert data_file_checks.check_fragment_count(data_file, fragment_check_list[jdx])
             assert data_file_checks.check_fragment_presence(data_file, fragment_check_list[jdx])

--- a/integtest/six_process_stop_start_test.py
+++ b/integtest/six_process_stop_start_test.py
@@ -44,10 +44,10 @@ confgen_arguments={"WIB1_System": confgen_arguments_base,
                    "DQM-enabled_System": confgen_arguments_base+["--enable-dqm"]}
 # The commands to run in nanorc, as a list
 nanorc_command_list="boot init conf".split()
-nanorc_command_list+="start                 101 wait ".split() + [str(run_duration)] + "stop --stop-wait 2 wait 2".split()
-nanorc_command_list+="start --resume-wait 4 102 wait ".split() + [str(run_duration)] + "stop               wait 2".split()
-nanorc_command_list+="start --resume-wait 2 103 wait ".split() + [str(run_duration)] + "stop --stop-wait 1 wait 2".split()
-nanorc_command_list+="start --resume-wait 1 104 wait ".split() + [str(run_duration)] + "stop --stop-wait 4 wait 2".split()
+nanorc_command_list+="start                 101 wait ".split() + [str(run_duration)] + "stop --stop-wait 2 wait 12".split()
+nanorc_command_list+="start --resume-wait 4 102 wait ".split() + [str(run_duration)] + "stop               wait 12".split()
+nanorc_command_list+="start --resume-wait 2 103 wait ".split() + [str(run_duration)] + "stop --stop-wait 1 wait 12".split()
+nanorc_command_list+="start --resume-wait 1 104 wait ".split() + [str(run_duration)] + "stop --stop-wait 4 wait 12".split()
 nanorc_command_list+="scrap terminate".split()
 
 # The tests themselves

--- a/integtest/six_process_stop_start_test.py
+++ b/integtest/six_process_stop_start_test.py
@@ -11,8 +11,8 @@ run_duration=20  # seconds
 # Default values for validation parameters
 expected_number_of_data_files=4
 check_for_logfile_errors=True
-min_expected_event_count=run_duration-2
-max_expected_event_count=run_duration+2
+expected_event_count=run_duration
+expected_event_count_tolerance=2
 wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
                            "element_name_prefix": "Link", "element_number_offset": 0,
                            "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
@@ -66,12 +66,12 @@ def test_log_files(run_nanorc):
         assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
 
 def test_data_file(run_nanorc):
-    local_min_event_count=min_expected_event_count
-    local_max_event_count=max_expected_event_count
+    local_expected_event_count=expected_event_count
+    local_event_count_tolerance=expected_event_count_tolerance
     fragment_check_list=[]
     if "--enable-software-tpg" in run_nanorc.confgen_arguments:
-        local_min_event_count+=(265*number_of_data_producers*number_of_readout_apps*run_duration/100)
-        local_max_event_count+=(280*number_of_data_producers*number_of_readout_apps*run_duration/100)
+        local_expected_event_count+=(270*number_of_data_producers*number_of_readout_apps*run_duration/100)
+        local_event_count_tolerance+=(10*number_of_data_producers*number_of_readout_apps*run_duration/100)
         fragment_check_list.append(wib1_frag_multi_trig_params)
         fragment_check_list.append(rawtp_frag_params)
         fragment_check_list.append(triggertp_frag_params)
@@ -84,7 +84,7 @@ def test_data_file(run_nanorc):
     for idx in range(len(run_nanorc.data_files)):
         data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
         assert data_file_checks.sanity_check(data_file)
-        assert data_file_checks.check_event_count(data_file, local_min_event_count, local_max_event_count)
+        assert data_file_checks.check_event_count(data_file, local_expected_event_count, local_event_count_tolerance)
         for jdx in range(len(fragment_check_list)):
             assert data_file_checks.check_fragment_count(data_file, fragment_check_list[jdx])
             assert data_file_checks.check_fragment_presence(data_file, fragment_check_list[jdx])

--- a/python/dfmodules/data_file_checks.py
+++ b/python/dfmodules/data_file_checks.py
@@ -23,15 +23,17 @@ def sanity_check(datafile):
         print("Sanity-check passed")
     return passed
 
-def check_event_count(datafile, min_event_count, max_event_count):
-    "Check that the number of events is between min_event_count and max_event_count"
+def check_event_count(datafile, expected_value, tolerance):
+    "Check that the number of events is within tolerance of expected_value"
     passed=True
     event_count=len(datafile.events)
+    min_event_count=expected_value-tolerance
+    max_event_count=expected_value+tolerance
     if event_count<min_event_count or event_count>max_event_count:
         passed=False
-        print(f"Event count {event_count} is outside range [{min_event_count}, {max_event_count}]")
+        print(f"Event count {event_count} is outside the tolerance of {tolerance} from an expected value of {expected_value}")
     if passed:
-        print(f"Event count is between {min_event_count} and {max_event_count}")
+        print(f"Event count is within a tolerance of {tolerance} from an expected value of {expected_value}")
     return passed
 
 def check_link_presence(datafile, n_links):

--- a/python/dfmodules/data_file_checks.py
+++ b/python/dfmodules/data_file_checks.py
@@ -23,6 +23,17 @@ def sanity_check(datafile):
         print("Sanity-check passed")
     return passed
 
+def check_event_count(datafile, min_event_count, max_event_count):
+    "Check that the number of events is between min_event_count and max_event_count"
+    passed=True
+    event_count=len(datafile.events)
+    if event_count<min_event_count or event_count>max_event_count:
+        passed=False
+        print(f"Event count {event_count} is outside range [{min_event_count}, {max_event_count}]")
+    if passed:
+        print(f"Event count is between {min_event_count} and {max_event_count}")
+    return passed
+
 def check_link_presence(datafile, n_links):
     "Check that there are n_links links in each event in file"
     passed=True


### PR DESCRIPTION
In an attempt to provide additional validity checking in several of the integration tests that we have in dfmodules/integtest, I've added validation of the expected number of trigger records.

The test generally succeeds, but I suspect that there may be some computers on which the event rate is low (because of a lack of sufficient resources). 

However, I'm submitting these changes as a pull request to get them reviewed by others, and if approved, to make them available for others to use in testing.