### PR TITLE
Introduce the NDLArTPC data type to dfmodules for the purpose of deve…

### DIFF
--- a/include/dfmodules/StorageKey.hpp
+++ b/include/dfmodules/StorageKey.hpp
@@ -36,6 +36,7 @@ public:
     kPDS = 3,
     kTrigger = 4,
     kTPC_TP = 5,
+    kNDLArTPC = 6,
     kInvalid = 0
   };
 

--- a/plugins/DataWriter.hpp
+++ b/plugins/DataWriter.hpp
@@ -104,6 +104,7 @@ private:
       m_system_type_to_group_type_mapping[geoid_system_type_t::kTPC] = key_group_type_t::kTPC;
       m_system_type_to_group_type_mapping[geoid_system_type_t::kPDS] = key_group_type_t::kPDS;
       m_system_type_to_group_type_mapping[geoid_system_type_t::kDataSelection] = key_group_type_t::kTrigger;
+      m_system_type_to_group_type_mapping[geoid_system_type_t::kNDLArTPC] = key_group_type_t::kNDLArTPC;
       m_system_type_to_group_type_mapping[geoid_system_type_t::kInvalid] = key_group_type_t::kInvalid;
     }
     auto map_iter = m_system_type_to_group_type_mapping.find(system_type);

--- a/scripts/hdf5dump/hdf5_dump.py
+++ b/scripts/hdf5dump/hdf5_dump.py
@@ -37,7 +37,7 @@ def unpack_header(data_array, unpack_string, keys):
 
 
 def get_geo_id_type(i):
-    types = {1: 'TPC', 2: 'PDS', 3: 'DataSelection'}
+    types = {1: 'TPC', 2: 'PDS', 3: 'DataSelection', 4: 'NDLArTPC'}
     if i in types.keys():
         return types[i]
     else:

--- a/src/dfmodules/HDF5FormattingParameters.hpp
+++ b/src/dfmodules/HDF5FormattingParameters.hpp
@@ -89,6 +89,14 @@ public:
     trigger_params.digits_for_element_number = 2;
     the_map[StorageKey::DataRecordGroupType::kTrigger] = trigger_params;
 
+    PathParameters ndlartpc_params;
+    ndlartpc_params.group_name_within_data_record = "NDLArTPC";
+    ndlartpc_params.region_name_prefix = "Region";
+    ndlartpc_params.digits_for_region_number = 3;
+    ndlartpc_params.element_name_prefix = "Element";
+    ndlartpc_params.digits_for_element_number = 2;
+    the_map[StorageKey::DataRecordGroupType::kNDLArTPC] = ndlartpc_params;
+
     PathParameters invalid_params;
     invalid_params.group_name_within_data_record = "Invalid";
     invalid_params.region_name_prefix = "Region";


### PR DESCRIPTION
…loping near detector data selection.

- Have verified that when running the nominal minidaqapp.nanorc.mdapp_multiru_gen configuration, the output is unchanged when dumped using `hdf5_dump.py`.
- Have verified that when running minidaqapp.nanorc.mdapp_multiru_gen in "ND mode" (with `--frontend-type pacman`, PR to minidaqapp coming soon), `hdf5_dump.py` gives expected output. For example:

`Path                          :	TriggerRecord00074/NDLArTPC/Region000/Element00`

and

`GeoID type                    : NDLArTPC`