### PR TITLE
Integtest changes to prepare for data with multiple APAs

### DIFF
--- a/integtest/four_process_disabled_output_test.py
+++ b/integtest/four_process_disabled_output_test.py
@@ -12,20 +12,20 @@ expected_number_of_data_files=2
 check_for_logfile_errors=True
 expected_event_count=run_duration
 expected_event_count_tolerance=2
-wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
-                           "element_name_prefix": "Link", "element_number_offset": 0,
+wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
+                           "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                            "expected_fragment_count": number_of_data_producers,
                            "min_size_bytes": 37200, "max_size_bytes": 37200}
-wib1_frag_multi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
-                             "element_name_prefix": "Link", "element_number_offset": 0,
+wib1_frag_multi_trig_params={"fragment_type_description": "WIB",
+                             "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                              "expected_fragment_count": number_of_data_producers,
                              "min_size_bytes": 80, "max_size_bytes": 37200}
-rawtp_frag_params={"fragment_type_description": "Raw TP", "hdf5_groups": "TPC/TP_APA000",
-                   "element_name_prefix": "Link", "element_number_offset": number_of_data_producers,
+rawtp_frag_params={"fragment_type_description": "Raw TP",
+                   "hdf5_detector_group": "TPC", "hdf5_region_prefix": "TP_APA",
                    "expected_fragment_count": number_of_data_producers,
                    "min_size_bytes": 80, "max_size_bytes": 80}
-triggertp_frag_params={"fragment_type_description": "Trigger TP", "hdf5_groups": "Trigger/Region000",
-                       "element_name_prefix": "Element", "element_number_offset": 0,
+triggertp_frag_params={"fragment_type_description": "Trigger TP",
+                       "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
                        "expected_fragment_count": number_of_data_producers,
                        "min_size_bytes": 80, "max_size_bytes": 80}
 
@@ -82,5 +82,4 @@ def test_data_file(run_nanorc):
         assert data_file_checks.check_event_count(data_file, local_expected_event_count, local_event_count_tolerance)
         for jdx in range(len(fragment_check_list)):
             assert data_file_checks.check_fragment_count(data_file, fragment_check_list[jdx])
-            assert data_file_checks.check_fragment_presence(data_file, fragment_check_list[jdx])
-            assert data_file_checks.check_fragment_size2(data_file, fragment_check_list[jdx])
+            assert data_file_checks.check_fragment_sizes(data_file, fragment_check_list[jdx])

--- a/integtest/four_process_quick_test.py
+++ b/integtest/four_process_quick_test.py
@@ -12,8 +12,8 @@ expected_number_of_data_files=1
 check_for_logfile_errors=True
 expected_event_count=run_duration
 expected_event_count_tolerance=2
-wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
-                           "element_name_prefix": "Link", "element_number_offset": 0,
+wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
+                           "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                            "expected_fragment_count": number_of_data_producers,
                            "min_size_bytes": 37200, "max_size_bytes": 37200}
 
@@ -50,5 +50,4 @@ def test_data_file(run_nanorc):
         assert data_file_checks.check_file_attributes(data_file)
         assert data_file_checks.check_event_count(data_file, expected_event_count, expected_event_count_tolerance)
         assert data_file_checks.check_fragment_count(data_file, wib1_frag_hsi_trig_params)
-        assert data_file_checks.check_fragment_presence(data_file, wib1_frag_hsi_trig_params)
-        assert data_file_checks.check_fragment_size2(data_file, wib1_frag_hsi_trig_params)
+        assert data_file_checks.check_fragment_sizes(data_file, wib1_frag_hsi_trig_params)

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -12,28 +12,28 @@ expected_number_of_data_files=1
 check_for_logfile_errors=True
 expected_event_count=run_duration
 expected_event_count_tolerance=2
-wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
-                           "element_name_prefix": "Link", "element_number_offset": 0,
+wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
+                           "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                            "expected_fragment_count": number_of_data_producers,
                            "min_size_bytes": 37200, "max_size_bytes": 37200}
-wib1_frag_multi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
-                             "element_name_prefix": "Link", "element_number_offset": 0,
+wib1_frag_multi_trig_params={"fragment_type_description": "WIB",
+                             "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                              "expected_fragment_count": number_of_data_producers,
                              "min_size_bytes": 80, "max_size_bytes": 37200}
-wib2_frag_params={"fragment_type_description": "WIB2", "hdf5_groups": "TPC/APA000",
-                  "element_name_prefix": "Link", "element_number_offset": 0,
+wib2_frag_params={"fragment_type_description": "WIB2",
+                  "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                   "expected_fragment_count": number_of_data_producers,
                   "min_size_bytes": 29000, "max_size_bytes": 30000}
-pds_frag_params={"fragment_type_description": "PDS", "hdf5_groups": "PDS/Region000",
-                 "element_name_prefix": "Element", "element_number_offset": 0,
+pds_frag_params={"fragment_type_description": "PDS",
+                 "hdf5_detector_group": "PDS", "hdf5_region_prefix": "Region",
                  "expected_fragment_count": number_of_data_producers,
                  "min_size_bytes": 80, "max_size_bytes": 36000}
-rawtp_frag_params={"fragment_type_description": "Raw TP", "hdf5_groups": "TPC/TP_APA000",
-                   "element_name_prefix": "Link", "element_number_offset": number_of_data_producers,
+rawtp_frag_params={"fragment_type_description": "Raw TP",
+                   "hdf5_detector_group": "TPC", "hdf5_region_prefix": "TP_APA",
                    "expected_fragment_count": number_of_data_producers,
                    "min_size_bytes": 80, "max_size_bytes": 80}
-triggertp_frag_params={"fragment_type_description": "Trigger TP", "hdf5_groups": "Trigger/Region000",
-                       "element_name_prefix": "Element", "element_number_offset": 0,
+triggertp_frag_params={"fragment_type_description": "Trigger TP",
+                       "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
                        "expected_fragment_count": number_of_data_producers,
                        "min_size_bytes": 80, "max_size_bytes": 80}
 
@@ -100,5 +100,4 @@ def test_data_file(run_nanorc):
         assert data_file_checks.check_event_count(data_file, local_expected_event_count, local_event_count_tolerance)
         for jdx in range(len(fragment_check_list)):
             assert data_file_checks.check_fragment_count(data_file, fragment_check_list[jdx])
-            assert data_file_checks.check_fragment_presence(data_file, fragment_check_list[jdx])
-            assert data_file_checks.check_fragment_size2(data_file, fragment_check_list[jdx])
+            assert data_file_checks.check_fragment_sizes(data_file, fragment_check_list[jdx])

--- a/integtest/six_process_multi_file_test.py
+++ b/integtest/six_process_multi_file_test.py
@@ -10,20 +10,20 @@ number_of_readout_apps=3
 # Default values for validation parameters
 expected_number_of_data_files=5
 check_for_logfile_errors=True
-wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
-                           "element_name_prefix": "Link", "element_number_offset": 0,
+wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
+                           "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                            "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
                            "min_size_bytes": 37200, "max_size_bytes": 37200}
-wib1_frag_multi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
-                             "element_name_prefix": "Link", "element_number_offset": 0,
+wib1_frag_multi_trig_params={"fragment_type_description": "WIB",
+                             "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                              "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
                              "min_size_bytes": 80, "max_size_bytes": 37200}
-rawtp_frag_params={"fragment_type_description": "Raw TP", "hdf5_groups": "TPC/TP_APA000",
-                   "element_name_prefix": "Link", "element_number_offset": (number_of_data_producers*number_of_readout_apps),
+rawtp_frag_params={"fragment_type_description": "Raw TP",
+                   "hdf5_detector_group": "TPC", "hdf5_region_prefix": "TP_APA",
                    "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
                    "min_size_bytes": 80, "max_size_bytes": 80}
-triggertp_frag_params={"fragment_type_description": "Trigger TP", "hdf5_groups": "Trigger/Region000",
-                       "element_name_prefix": "Element", "element_number_offset": 0,
+triggertp_frag_params={"fragment_type_description": "Trigger TP",
+                       "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
                        "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
                        "min_size_bytes": 80, "max_size_bytes": 80}
 
@@ -72,5 +72,4 @@ def test_data_file(run_nanorc):
         assert data_file_checks.check_file_attributes(data_file)
         for jdx in range(len(fragment_check_list)):
             assert data_file_checks.check_fragment_count(data_file, fragment_check_list[jdx])
-            assert data_file_checks.check_fragment_presence(data_file, fragment_check_list[jdx])
-            assert data_file_checks.check_fragment_size2(data_file, fragment_check_list[jdx])
+            assert data_file_checks.check_fragment_sizes(data_file, fragment_check_list[jdx])

--- a/integtest/six_process_stop_start_test.py
+++ b/integtest/six_process_stop_start_test.py
@@ -13,20 +13,20 @@ expected_number_of_data_files=4
 check_for_logfile_errors=True
 expected_event_count=run_duration
 expected_event_count_tolerance=2
-wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
-                           "element_name_prefix": "Link", "element_number_offset": 0,
+wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
+                           "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                            "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
                            "min_size_bytes": 37200, "max_size_bytes": 37200}
-wib1_frag_multi_trig_params={"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
-                             "element_name_prefix": "Link", "element_number_offset": 0,
+wib1_frag_multi_trig_params={"fragment_type_description": "WIB",
+                             "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                              "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
                              "min_size_bytes": 80, "max_size_bytes": 37200}
-rawtp_frag_params={"fragment_type_description": "Raw TP", "hdf5_groups": "TPC/TP_APA000",
-                   "element_name_prefix": "Link", "element_number_offset": (number_of_data_producers*number_of_readout_apps),
+rawtp_frag_params={"fragment_type_description": "Raw TP",
+                   "hdf5_detector_group": "TPC", "hdf5_region_prefix": "TP_APA",
                    "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
                    "min_size_bytes": 80, "max_size_bytes": 80}
-triggertp_frag_params={"fragment_type_description": "Trigger TP", "hdf5_groups": "Trigger/Region000",
-                       "element_name_prefix": "Element", "element_number_offset": 0,
+triggertp_frag_params={"fragment_type_description": "Trigger TP",
+                       "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
                        "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
                        "min_size_bytes": 80, "max_size_bytes": 80}
 
@@ -88,5 +88,4 @@ def test_data_file(run_nanorc):
         assert data_file_checks.check_event_count(data_file, local_expected_event_count, local_event_count_tolerance)
         for jdx in range(len(fragment_check_list)):
             assert data_file_checks.check_fragment_count(data_file, fragment_check_list[jdx])
-            assert data_file_checks.check_fragment_presence(data_file, fragment_check_list[jdx])
-            assert data_file_checks.check_fragment_size2(data_file, fragment_check_list[jdx])
+            assert data_file_checks.check_fragment_sizes(data_file, fragment_check_list[jdx])

--- a/python/dfmodules/data_file_checks.py
+++ b/python/dfmodules/data_file_checks.py
@@ -7,7 +7,22 @@ class DataFile:
         self.h5file=h5py.File(filename, 'r')
         self.events=self.h5file.keys()
         self.n_events=len(self.events)
-    
+
+def find_fragments_of_specified_type(grp, detector_group='', region_prefix=''):
+    frag_list = [] # Local variable here
+    def visitor(name, obj):
+        nonlocal frag_list  # non-local to the visitor function
+        pattern = ".*"
+        if detector_group != '':
+            pattern += f"/{detector_group}"
+        if region_prefix != '':
+            pattern += f"/{region_prefix}\\d+"
+        if isinstance(obj, h5py.Dataset):
+            if re.match(pattern, obj.name):
+                frag_list.append(obj)
+    grp.visititems(visitor)
+    return frag_list
+
 def sanity_check(datafile):
     "Very basic sanity checks on file"
     passed=True
@@ -79,6 +94,70 @@ def check_event_count(datafile, expected_value, tolerance):
         print(f"Event count is within a tolerance of {tolerance} from an expected value of {expected_value}")
     return passed
 
+# 18-Aug-2021, KAB: General-purposed test for fragment count.  The idea behind this test
+# is that each type of fragment can be tested individually, by calling this routine for
+# each type.  The test is driven by a set of parameters that describe both the fragments
+# to be tested (e.g. the HDF5 Group names) and the characteristics that they should have
+# (e.g. the number of fragments that should be present).
+#
+# The parameters that are required by this routine are the following:
+# * fragment_type_description - descriptive text for the fragment type, e.g. "WIB" or "PDS" or "Raw TP"
+# * hdf5_detector_group - the HDF5 Group in the DataSet path just below the TriggerRecord identifier,
+#                         e.g. "TPC" or "PDS"
+# * hdf5_region_prefix - the prefix that should be used to identify the desired "region" in the DataSet path,
+#                        e.g. "APA" or "Region" or "TP_APA"
+# * expected_fragment_count - the expected number of fragments of this type
+def check_fragment_count(datafile, params):
+    "Checking that there are {params['expected_fragment_count']} {params['fragment_type_description']} fragments in each event in file"
+    passed=True
+    for event in datafile.events:
+        frag_list = find_fragments_of_specified_type(datafile.h5file[event], params['hdf5_detector_group'],
+                                                     params['hdf5_region_prefix']);
+        fragment_count=len(frag_list)
+        if fragment_count != params['expected_fragment_count']:
+            passed=False
+            print(f"Event {event} has an unexpected number of {params['fragment_type_description']} fragments: {fragment_count} (expected {params['expected_fragment_count']})")
+    if passed:
+        print(f"{params['fragment_type_description']} fragment count of {params['expected_fragment_count']} confirmed in all {datafile.n_events} events")
+    return passed
+
+# 18-Aug-2021, KAB: general-purposed test for fragment sizes.  The idea behind this test
+# is that each type of fragment can be tested individually, by calling this routine for
+# each type.  The test is driven by a set of parameters that describe both the fragments
+# to be tested (e.g. the HDF5 Group names) and the characteristics that they should have
+# (e.g. the minimum and maximum fragment size).
+#
+# The parameters that are required by this routine are the following:
+# * fragment_type_description - descriptive text for the fragment type, e.g. "WIB" or "PDS" or "Raw TP"
+# * hdf5_detector_group - the HDF5 Group in the DataSet path just below the TriggerRecord identifier,
+#                         e.g. "TPC" or "PDS"
+# * hdf5_region_prefix - the prefix that should be used to identify the desired "region" in the DataSet path,
+#                        e.g. "APA" or "Region" or "TP_APA"
+# * min_size_bytes - the minimum size of fragments of this type
+# * max_size_bytes - the maximum size of fragments of this type
+def check_fragment_sizes(datafile, params):
+    "Check that every {params['fragment_type_description']} fragment size is between {params['min_size_bytes']} and {params['max_size_bytes']}"
+    passed=True
+    for event in datafile.events:
+        frag_list = find_fragments_of_specified_type(datafile.h5file[event], params['hdf5_detector_group'],
+                                                     params['hdf5_region_prefix']);
+        for frag in frag_list:
+            size=frag.shape[0]
+            if size<params['min_size_bytes'] or size>params['max_size_bytes']:
+                passed=False
+                print(f" {params['fragment_type_description']} fragment {frag.name} in event {event} has size {size}, outside range [{params['min_size_bytes']}, {params['max_size_bytes']}]")
+    if passed:
+        print(f"All {params['fragment_type_description']} fragments in {datafile.n_events} events have sizes between {params['min_size_bytes']} and {params['max_size_bytes']}")
+    return passed
+
+
+# ###########################################################################
+# 11-Nov-2021, KAB: the following routines are deprecated.
+# Please do not use them. If one of the routines defined above does not meet
+# a need, let's talk about how to meet that need without using one of the
+# routines defined below.
+# ###########################################################################
+
 def check_link_presence(datafile, n_links):
     "Check that there are n_links links in each event in file"
     passed=True
@@ -92,47 +171,32 @@ def check_link_presence(datafile, n_links):
         print(f"{n_links} links present in all {datafile.n_events} events")
     return passed
 
-# 18-Aug-2021, KAB: General-purposed test for fragment count.  The idea behind this
-# test is that each type of fragment is tested individually, by calling this routine for
-# each type.  The test is driven by a set of parameters that describe both the fragments
-# to be tested (e.g. the HDF5 Group names) and the characteristics that they should have
-# (e.g. the number of fragments that should be present).
-#
-# The parameters that are required by the 'check_fragment_presence' routine are the following:
-# * fragment_type_description - descriptive text for the fragment type, e.g. "WIB" or "PDS" or "Raw TP"
-# * hdf5_groupss - the two HDF5 Groups in the DataSet path between the TriggerRecord identifier and
-#                 the DataSet name, e.g. "TPC/APA000" or "PDS/Region000"
-# * element_name_prefix - the prefix that is used to describe the detector element in the HDF5 DataSet
-#                         name, e.g. "Link" or "Element"
-# * element_number_offset - the offset that should be used for the element numbers for the fragments,
-#                           typically, this is zero, but it is currently non-zero for Raw_TP fragments
-# * expected_fragment_count - the expected number of fragments of this type
-def check_fragment_count(datafile, params):
-    "Checking that there are {params['expected_fragment_count']} {params['fragment_type_description']} fragments in each event in file"
+def check_fragment_sizes_old(datafile, min_frag_size, max_frag_size):
+    "Check that every fragment is between min_frag_size and max_frag_size"
     passed=True
     for event in datafile.events:
-        fragments_present=len(datafile.h5file[event][params['hdf5_groups']].keys())
-        if fragments_present != params['expected_fragment_count']:
-            passed=False
-            print(f"Event {event} has an unexpected number of {params['fragment_type_description']} fragments: {fragments_present} (expected {params['expected_fragment_count']})")
+        for link in datafile.h5file[event]["TPC/APA000"].values():
+            size=link.shape[0]
+            if size<min_frag_size or size>max_frag_size:
+                passed=False
+                print(f"Link {link} in event {event} has size {size}, outside range [{min_frag_size}, {max_frag_size}]")
     if passed:
-        print(f"{params['fragment_type_description']} fragment count of {params['expected_fragment_count']} confirmed in all {datafile.n_events} events")
+        print(f"All links in {datafile.n_events} events have fragment sizes between {min_frag_size} and {max_frag_size}")
     return passed
 
-# 18-Aug-2021, KAB: General-purposed test for fragment presence.  The idea behind this
-# test is that each type of fragment is tested individually, by calling this routine for
+
+# 18-Aug-2021, KAB: General-purposed test for fragment presence.  The idea behind this test
+# is that each type of fragment can be tested individually, by calling this routine for
 # each type.  The test is driven by a set of parameters that describe both the fragments
 # to be tested (e.g. the HDF5 Group names) and the characteristics that they should have
 # (e.g. the number of fragments that should be present).
 #
-# The parameters that are required by the 'check_fragment_presence' routine are the following:
+# The parameters that are required by this routine are the following:
 # * fragment_type_description - descriptive text for the fragment type, e.g. "WIB" or "PDS" or "Raw TP"
-# * hdf5_groupss - the two HDF5 Groups in the DataSet path between the TriggerRecord identifier and
-#                 the DataSet name, e.g. "TPC/APA000" or "PDS/Region000"
-# * element_name_prefix - the prefix that is used to describe the detector element in the HDF5 DataSet
-#                         name, e.g. "Link" or "Element"
-# * element_number_offset - the offset that should be used for the element numbers for the fragments,
-#                           typically, this is zero, but it is currently non-zero for Raw_TP fragments
+# * hdf5_detector_group - the HDF5 Group in the DataSet path just below the TriggerRecord identifier,
+#                         e.g. "TPC" or "PDS"
+# * hdf5_region_prefix - the prefix that should be used to identify the desired "region" in the DataSet path,
+#                        e.g. "APA" or "Region" or "TP_APA"
 # * expected_fragment_count - the expected number of fragments of this type
 def check_fragment_presence(datafile, params):
     "Checking that there are {params['expected_fragment_count']} {params['fragment_type_description']} fragments in each event in file"
@@ -147,44 +211,3 @@ def check_fragment_presence(datafile, params):
         print(f"{params['expected_fragment_count']} {params['fragment_type_description']} fragments present in all {datafile.n_events} events")
     return passed
 
-def check_fragment_sizes(datafile, min_frag_size, max_frag_size):
-    "Check that every fragment is between min_frag_size and max_frag_size"
-    passed=True
-    for event in datafile.events:
-        for link in datafile.h5file[event]["TPC/APA000"].values():
-            size=link.shape[0]
-            if size<min_frag_size or size>max_frag_size:
-                passed=False
-                print(f"Link {link} in event {event} has size {size}, outside range [{min_frag_size}, {max_frag_size}]")
-    if passed:
-        print(f"All links in {datafile.n_events} events have fragment sizes between {min_frag_size} and {max_frag_size}")
-    return passed
-
-# 18-Aug-2021, KAB: general-purposed test for fragment sizes.  The idea behind this
-# test is that each type of fragment is tested individually, by calling this routine for
-# each type.  The test is driven by a set of parameters that describe both the fragments
-# to be tested (e.g. the HDF5 Group names) and the characteristics that they should have
-# (e.g. the minimum and maximum fragment size).
-#
-# The parameters that are required by the 'check_fragment_presence' routine are the following:
-# * fragment_type_description - descriptive text for the fragment type, e.g. "WIB" or "PDS" or "Raw TP"
-# * hdf5_groupss - the two HDF5 Groups in the DataSet path between the TriggerRecord identifier and
-#                 the DataSet name, e.g. "TPC/APA000" or "PDS/Region000"
-# * element_name_prefix - the prefix that is used to describe the detector element in the HDF5 DataSet
-#                         name, e.g. "Link" or "Element"
-# * element_number_offset - the offset that should be used for the element numbers for the fragments,
-#                           typically, this is zero, but it is currently non-zero for Raw_TP fragments
-# * min_size_bytes - the minimum size of fragments of this type
-# * max_size_bytes - the maximum size of fragments of this type
-def check_fragment_size2(datafile, params):
-    "Check that every {params['fragment_type_description']} fragment size is between {params['min_size_bytes']} and {params['max_size_bytes']}"
-    passed=True
-    for event in datafile.events:
-        for frag in datafile.h5file[event][params['hdf5_groups']].values():
-            size=frag.shape[0]
-            if size<params['min_size_bytes'] or size>params['max_size_bytes']:
-                passed=False
-                print(f" {params['fragment_type_description']} fragment {frag.name} in event {event} has size {size}, outside range [{params['min_size_bytes']}, {params['max_size_bytes']}]")
-    if passed:
-        print(f"All {params['fragment_type_description']} fragments in {datafile.n_events} events have sizes between {params['min_size_bytes']} and {params['max_size_bytes']}")
-    return passed

--- a/python/dfmodules/run_check.py
+++ b/python/dfmodules/run_check.py
@@ -56,22 +56,22 @@ def cli(skip_tps, number_of_data_producers, check_for_logfile_errors, run_durati
     expected_event_count = run_duration * trigger_rate
     expected_event_count_tolerance = 2
 
-    wib1_frag_hsi_trig_params = {"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
-                           "element_name_prefix": "Link", "element_number_offset": 0,
-                           "expected_fragment_count": number_of_data_producers,
-                           "min_size_bytes": 37200, "max_size_bytes": 37200}
-    wib1_frag_multi_trig_params = {"fragment_type_description": "WIB", "hdf5_groups": "TPC/APA000",
-                             "element_name_prefix": "Link", "element_number_offset": 0,
+    wib1_frag_hsi_trig_params = {"fragment_type_description": "WIB",
+                                 "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
+                                 "expected_fragment_count": number_of_data_producers,
+                                 "min_size_bytes": 37200, "max_size_bytes": 37200}
+    wib1_frag_multi_trig_params = {"fragment_type_description": "WIB",
+                                   "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
+                                   "expected_fragment_count": number_of_data_producers,
+                                   "min_size_bytes": 80, "max_size_bytes": 37200}
+    rawtp_frag_params = {"fragment_type_description": "Raw TP",
+                         "hdf5_detector_group": "TPC", "hdf5_region_prefix": "TP_APA",
+                         "expected_fragment_count": number_of_data_producers,
+                         "min_size_bytes": 80, "max_size_bytes": 80}
+    triggertp_frag_params = {"fragment_type_description": "Trigger TP",
+                             "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
                              "expected_fragment_count": number_of_data_producers,
-                             "min_size_bytes": 80, "max_size_bytes": 37200}
-    rawtp_frag_params = {"fragment_type_description": "Raw TP", "hdf5_groups": "TPC/TP_APA000",
-                   "element_name_prefix": "Link", "element_number_offset": 0,
-                   "expected_fragment_count": number_of_data_producers,
-                   "min_size_bytes": 80, "max_size_bytes": 80}
-    triggertp_frag_params = {"fragment_type_description": "Trigger TP", "hdf5_groups": "Trigger/Region000",
-                       "element_name_prefix": "Element", "element_number_offset": 0,
-                       "expected_fragment_count": number_of_data_producers,
-                       "min_size_bytes": 80, "max_size_bytes": 80}
+                             "min_size_bytes": 80, "max_size_bytes": 80}
 
     def test_log_files():
        if check_for_logfile_errors:
@@ -94,11 +94,11 @@ def cli(skip_tps, number_of_data_producers, check_for_logfile_errors, run_durati
        for idx in range(len(data_files)):
            data_file = data_file_checks.DataFile(data_files[idx])
            data_file_checks.sanity_check(data_file)
+           data_file_checks.check_file_attributes(data_file)
            data_file_checks.check_event_count(data_file, local_expected_event_count, local_event_count_tolerance)
            for jdx in range(len(fragment_check_list)):
                data_file_checks.check_fragment_count(data_file, fragment_check_list[jdx])
-               data_file_checks.check_fragment_presence(data_file, fragment_check_list[jdx])
-               data_file_checks.check_fragment_size2(data_file, fragment_check_list[jdx])
+               data_file_checks.check_fragment_sizes(data_file, fragment_check_list[jdx])
 
     test_log_files()
     test_data_file()


### PR DESCRIPTION
A little while ago, I noticed that on the NetworkManager branches, the code produces data with APA numbers different than zero.  So for example, when there are 3 RUs with 5 DLHs each, the data Fragments in the HDF5 file would have five DataSets within each of APA000, APA001, and APA002. 
The existing integtests can not handle this because they used a rather simple model of looking for HDF5 paths that included a specified string (e.g. "TPC/APA000").
The changes on this branch switch to a  model in which we specify the detector group (e.g. "TPC") and the region prefix name (e.g. "APA"), and the "check" code looks for DataSets underneath "TPC/APA\d+".  This will pick up APA000..APA002. 
As part of this, I gave up on testing for specific DataSet names, and my sense was that this was a good thing.  It seems like that might be too much detail in the integtest.
Included in these changes were the appropriate mods to the new run_check.py script.
