### PR TITLE
Added run number to TimeSync messages from FakeDataProd

### DIFF
--- a/plugins/FakeDataProd.cpp
+++ b/plugins/FakeDataProd.cpp
@@ -33,7 +33,8 @@ enum
 {
   TLVL_ENTER_EXIT_METHODS = 5,
   TLVL_CONFIG = 7,
-  TLVL_WORK_STEPS = 10
+  TLVL_WORK_STEPS = 10,
+  TLVL_TIME_SYNCS = 12
 };
 
 namespace dunedaq {
@@ -50,6 +51,8 @@ FakeDataProd::FakeDataProd(const std::string& name)
   register_command("conf", &FakeDataProd::do_conf);
   register_command("start", &FakeDataProd::do_start);
   register_command("stop", &FakeDataProd::do_stop);
+
+  m_pid_of_current_process = getpid();
 }
 
 void
@@ -123,11 +126,18 @@ void
 FakeDataProd::do_timesync(std::atomic<bool>& running_flag)
 {
   int sent_count = 0;
+  uint64_t msg_seqno = 0;
   while (running_flag.load()) {
     auto time_now = std::chrono::system_clock::now().time_since_epoch();
     uint64_t current_timestamp = // NOLINT (build/unsigned)
       std::chrono::duration_cast<std::chrono::nanoseconds>(time_now).count();
     auto timesyncmsg = dfmessages::TimeSync(current_timestamp);
+    timesyncmsg.run_number = m_run_number;
+    timesyncmsg.sequence_number = ++msg_seqno;
+    timesyncmsg.source_pid = m_pid_of_current_process;
+    TLOG_DEBUG(TLVL_TIME_SYNCS) << "New timesync: daq=" << timesyncmsg.daq_time
+                                << " wall=" << timesyncmsg.system_time << " run=" << timesyncmsg.run_number
+                                << " seqno=" << timesyncmsg.sequence_number << " pid=" << timesyncmsg.source_pid;
     try {
       auto serialised_timesync = dunedaq::serialization::serialize(timesyncmsg, dunedaq::serialization::kMsgPack);
       networkmanager::NetworkManager::get().send_to(m_timesync_connection_name,

--- a/plugins/FakeDataProd.hpp
+++ b/plugins/FakeDataProd.hpp
@@ -88,6 +88,7 @@ private:
   daqdataformats::FragmentType m_fragment_type;
   std::string m_timesync_connection_name;
   std::string m_timesync_topic_name;
+  uint32_t m_pid_of_current_process;
 
   // Queue(s)
   using datareqsource_t = dunedaq::appfwk::DAQSource<dfmessages::DataRequest>;


### PR DESCRIPTION
Ron noticed that using the FakeDataProd module from the _dfmodules_ repo as part of a _dunedaq-v2.9.0_ system did not result in data being written to disk.

This can be demonstrated with a confgen command like the following:
```
python -m minidaqapp.nanorc.mdapp_multiru_gen --host-ru localhost -o . --use-fake-data-producers mdapp_4proc_fdp
```

I tracked this down to the fact that the FakeDataProd module did not get updated when we added the run number to the TimeSync message (so the FakeHSI module was discarding all of the TimeSync messages from FDP because they had the wrong run number [0]).

The code on this branch adds the run number to the TimeSync messages from FakeDataProd and restores successful data taking with that module.

This branch is based on the HEAD of the _develop_ branch, so we will need to use a software area that uses a recent nightly build to test this code.