### PR TITLE
adding a python script to convert hdf5 file into binary file.

### DIFF
--- a/scripts/hdf5dump/binary_dump.py
+++ b/scripts/hdf5dump/binary_dump.py
@@ -54,7 +54,7 @@ def read_binary_file(fname):
                 nfrag = 0
                 if ntrh !=0 and g_header_type in ['both', 'fragment']:
                     print(80*'-')
-                    print_fragment_header(bytesbuffer)
+                    print_fragment_header(bytesbuffer, g_list_components)
                 bytesbuffer = bytearray()
                 ntrh += 1
                 if ntrh > g_n_request and g_n_request != 0: break
@@ -62,7 +62,7 @@ def read_binary_file(fname):
                 if nfrag == 0 and ntrh != 0 and g_header_type in ['both',
                                                                   'trigger']:
                     print(80*'=')
-                    print_trigger_record_header(bytesbuffer)
+                    print_trigger_record_header(bytesbuffer, g_list_components)
                 if nfrag != 0 and g_header_type in ['both', 'fragment']:
                     print(80*'-')
                     print_fragment_header(bytesbuffer)

--- a/scripts/hdf5dump/binary_dump.py
+++ b/scripts/hdf5dump/binary_dump.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+
+import argparse
+import datetime
+import h5py
+import struct
+from hdf5_dump import print_fragment_header, print_trigger_record_header
+
+CLOCK_SPEED_HZ = 50000000.0
+
+g_n_request = 0
+g_header_type = "both"
+g_list_components = False
+
+
+def get_record_locations_from_binary_file(fname):
+    frag_magic_word = bytes.fromhex("22221111")
+    trh_magic_word = bytes.fromhex("44443333")
+    trh_loc = []
+    frag_loc = []
+    with open(fname, "rb") as f:
+        iloc = 0
+        nrec = 0
+        while (byte := f.read(4)):
+            if byte == trh_magic_word:
+                trh_loc.append(iloc)
+                frag_loc.append([])
+                nrec += 1
+            if byte == frag_magic_word:
+                frag_loc[nrec-1].append(iloc)
+            iloc += 4
+    print(80*'=')
+    print(19*'=', " Location of records in the binary file ", 19*'=')
+    print(80*'=')
+    for i in range(len(trh_loc)):
+        if i >= g_n_request:
+            break
+        print("trigger {:<8} header - {:<16}".format(i+1, trh_loc[i]),
+              "fragments: ", frag_loc[i])
+    return (trh_loc, frag_loc)
+
+
+def read_binary_file(fname):
+    frag_magic_word = bytes.fromhex("22221111")
+    trh_magic_word = bytes.fromhex("44443333")
+    with open(fname, "rb") as f:
+        bytesbuffer = bytearray()
+        ntrh = 0
+        nfrag = 0
+        while (byte := f.read(4)):
+            #print(byte)
+            #if iloc > 4: break
+            if byte == trh_magic_word:
+                nfrag = 0
+                if ntrh !=0 and g_header_type in ['both', 'fragment']:
+                    print(80*'-')
+                    print_fragment_header(bytesbuffer)
+                bytesbuffer = bytearray()
+                ntrh += 1
+                if ntrh > g_n_request and g_n_request != 0: break
+            if byte == frag_magic_word:
+                if nfrag == 0 and ntrh != 0 and g_header_type in ['both',
+                                                                  'trigger']:
+                    print(80*'=')
+                    print_trigger_record_header(bytesbuffer)
+                if nfrag != 0 and g_header_type in ['both', 'fragment']:
+                    print(80*'-')
+                    print_fragment_header(bytesbuffer)
+                bytesbuffer = bytearray()
+                nfrag += 1
+            bytesbuffer.extend(byte)
+    return
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Python script to parse binary files converted from HDF5.')
+
+    parser.add_argument('-f', '--file_name',
+                        help='path to binary file',
+                        required=True)
+
+    parser.add_argument('-p', '--print-headers',
+                        choices=['trigger', 'fragment', 'both'],
+                        default='both',
+                        help='select which header data to display')
+
+    parser.add_argument('-l', '--list-components',
+                        help='''list components in trigger record header, used
+                        together with "--print-headers trigger" or
+                        "--print-headers both"''', action='store_true')
+
+    parser.add_argument('-d', '--debug',
+                        help='print locations of headers in the file',
+                        action='store_true')
+
+    parser.add_argument('-n', '--num-of-records', type=int,
+                        help='specify number of trigger records to be parsed',
+                        default=0)
+
+    parser.add_argument('-v', '--version', action='version',
+                        version='%(prog)s 1.0')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    global g_n_request
+    global g_header_type
+    global g_list_components
+
+    g_n_request = args.num_of_records
+    g_header_type = args.print_headers
+    g_list_components = args.list_components
+
+    bfile = args.file_name
+    print("Reading file", bfile)
+
+    read_binary_file(bfile)
+    if args.debug:
+        get_record_locations_from_binary_file(bfile)
+    return
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hdf5dump/binary_dump.py
+++ b/scripts/hdf5dump/binary_dump.py
@@ -54,7 +54,7 @@ def read_binary_file(fname):
                 nfrag = 0
                 if ntrh !=0 and g_header_type in ['both', 'fragment']:
                     print(80*'-')
-                    print_fragment_header(bytesbuffer, g_list_components)
+                    print_fragment_header(bytesbuffer)
                 bytesbuffer = bytearray()
                 ntrh += 1
                 if ntrh > g_n_request and g_n_request != 0: break

--- a/scripts/hdf5dump/hdf5_dump.py
+++ b/scripts/hdf5dump/hdf5_dump.py
@@ -72,14 +72,14 @@ def print_fragment_header(data_array):
     return
 
 
-def print_trigger_record_header(data_array):
+def print_trigger_record_header(data_array, k_list_components=False):
     keys = ['Magic word', 'Version', 'Trigger number',
             'Trigger timestamp', 'No. of requested components', 'Run Number',
             'Error bits', 'Trigger type', 'Sequence number', 'Max sequence num']
     unpack_string = '<2I3Q2I3H'
     print_header_dict(unpack_header(data_array[:46], unpack_string, keys))
 
-    if g_list_components:
+    if g_list_components or k_list_components:
         comp_keys = ['Component request version', 'Component Request Padding',
                      'GeoID version', 'GeoID type', 'GeoID region',
                      'GeoID element', 'Geo ID Padding', 'Begin time',

--- a/scripts/hdf5dump/hdf5_to_binary.py
+++ b/scripts/hdf5dump/hdf5_to_binary.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+# Version 1.0
+# Last modified: Feb 18, 2022
+
+# USAGE: python3 hdf5_to_binary.py -i sample.hdf5 -o sample.bin [-n N]  [-r]
+
+import argparse
+import h5py
+import os
+
+
+# Global variables are required to save the save of the state of
+# function call "h5py.File.visititems(process_record_func)"
+
+g_ith_record = -1
+g_header_paths = []
+
+
+def process_record_func(name, dset):
+    global g_ith_record
+    global g_header_paths
+    if isinstance(dset, h5py.Group) and "/" not in name:
+        g_ith_record += 1
+        g_header_paths.append({"TriggerRecordHeader": '', "Fragments": []})
+    if isinstance(dset, h5py.Dataset):
+        if "TriggerRecordHeader" in name:
+            g_header_paths[g_ith_record]["TriggerRecordHeader"] = name
+        else:
+            g_header_paths[g_ith_record]["Fragments"].append(name)
+    return
+
+
+def process_hdf5_file(file_name):
+    global g_ith_record
+    g_ith_record = -1
+    with h5py.File(file_name, 'r') as f:
+        f.visititems(process_record_func)
+    return
+
+
+##
+# g_header_paths is a list of maps
+# [
+#   {
+#     'TriggerRecordHeader': 'TriggerRecord00000/TriggerRecordHeader',
+#     'Fragments': ['TriggerRecord00000/FELIX/APA000/Link00',
+#                   'TriggerRecord00000/FELIX/APA000/Link01']
+#   }
+# ]
+
+def convert_to_binary_file(h5file, binary_file, n_record=-1):
+    processed_record = 0
+    process_hdf5_file(h5file)
+    with open(binary_file, 'wb') as bf:
+        with h5py.File(h5file, 'r') as hf:
+            for i in g_header_paths:
+                if processed_record >= n_record and n_record != -1:
+                    continue
+                if i["TriggerRecordHeader"] == "":
+                    continue
+                dset = hf[i["TriggerRecordHeader"]]
+                idata_array = bytearray(dset[:])
+                bf.write(idata_array)
+                for j in i["Fragments"]:
+                    dset = hf[j]
+                    jdata_array = bytearray(dset[:])
+                    bf.write(jdata_array)
+                processed_record += 1
+    return
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Python script to parse DUNE-DAQ HDF5 output files.')
+
+    parser.add_argument('-i', '--input-file',
+                        help='path to the input HDF5 file',
+                        required=True)
+
+    parser.add_argument('-o', '--output-file',
+                        help='path to the output binary file',
+                        required=True)
+
+    parser.add_argument('-r', '--rewrite-file',
+                        help='overwrite output binary file with the same name',
+                        action='store_true')
+
+    parser.add_argument('-n', '--num-of-records', type=int,
+                        help='specify number of trigger records, -1 for all',
+                        default=-1)
+
+    parser.add_argument('-v', '--version', action='version',
+                        version='%(prog)s 1.0')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if os.path.isfile(args.output_file) and not args.rewrite_file:
+        print("Error: Output binary file {} exists! ".format(args.output_file))
+        print("Error: Use a different name or turn on '-r' option.")
+        return
+    convert_to_binary_file(args.input_file, args.output_file,
+                           args.num_of_records)
+    return
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is a simple script to convert HDF5 files into binary files.

The procedure uses the following two steps:

* Step one, traverse through the HDF5 file using `h5py.File.visititems()` to assemble a list containing paths to both trigger record and fragments in the following format:

```python
[
   {
     'TriggerRecordHeader': 'ithTriggerRecordHeaderPath',
     'Fragments': ['jthFragmentsPath_in_ithTriggerRecord,
                             ...]
   },
   ...
]

e.g. 

[
   {
     'TriggerRecordHeader': 'TriggerRecord00000/TriggerRecordHeader',
     'Fragments': ['TriggerRecord00000/FELIX/APA000/Link00',
                   'TriggerRecord00000/FELIX/APA000/Link01']
   },
   {
    'TriggerRecordHeader': 'TriggerRecord00001/TriggerRecordHeader',
     'Fragments': ['TriggerRecord00001/FELIX/APA000/Link00',
                   'TriggerRecord00001/FELIX/APA000/Link01']
   }
]
```

* Step two, follow the order of the assembled list, get byte arrays from HDF5 file, and write them into the output binary file.

No additional information is written to the binary file. Trigger record header itself contains a number of requested components and a list of components, so the total size is calculable. The trigger record header and fragments both have magic words so that verification of data type can be done on the binary blob.  Data is aligned in sequence as:

```
# TRH_X denotes binary blob of a trigger record header
# FG_X denotes binary blob of a fragment

TRH_0 FG_1 FG_2 ... FG_N
TRH_1 FG_1 FG_2 ... FG_M
...
TRH_O FG_1 FG_2 ... FG_P
```

