### PR TITLE
dfmodules integtest changes for the switch to the daqconf package

### DIFF
--- a/integtest/command_order_test.py
+++ b/integtest/command_order_test.py
@@ -11,7 +11,7 @@ number_of_data_producers=2
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="minidaqapp.newconf.mdapp_multiru_gen"
+confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 confgen_arguments_base=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "--host-ru", "localhost"]

--- a/integtest/four_process_disabled_output_test.py
+++ b/integtest/four_process_disabled_output_test.py
@@ -36,7 +36,7 @@ triggertp_frag_params={"fragment_type_description": "Trigger TP",
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="minidaqapp.newconf.mdapp_multiru_gen"
+confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 confgen_arguments_base=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "--host-ru", "localhost"]

--- a/integtest/four_process_quick_test.py
+++ b/integtest/four_process_quick_test.py
@@ -22,7 +22,7 @@ wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="minidaqapp.newconf.mdapp_multiru_gen"
+confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 confgen_arguments=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "--host-ru", "localhost"]

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -49,7 +49,7 @@ ignored_logfile_problems={"dqm": ["client will not be able to connect to Kafka c
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="minidaqapp.newconf.mdapp_multiru_gen"
+confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 confgen_arguments_base=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "--host-ru", "localhost"]

--- a/integtest/six_process_multi_file_test.py
+++ b/integtest/six_process_multi_file_test.py
@@ -35,7 +35,7 @@ ignored_logfile_problems={"trigger": ["zipped_tpset_q: Unable to push within tim
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="minidaqapp.newconf.mdapp_multiru_gen"
+confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 confgen_arguments_base=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "-t", "10.0", "--max-file-size", "1074000000", "--latency-buffer-size", "200000"] + [ "--host-ru", "localhost" ] * number_of_readout_apps

--- a/integtest/six_process_multi_file_test.py
+++ b/integtest/six_process_multi_file_test.py
@@ -38,7 +38,7 @@ ignored_logfile_problems={"trigger": ["zipped_tpset_q: Unable to push within tim
 confgen_name="minidaqapp.newconf.mdapp_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-confgen_arguments_base=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "-t", "10.0", "--max-file-size", "1074000000"] + [ "--host-ru", "localhost" ] * number_of_readout_apps
+confgen_arguments_base=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "-t", "10.0", "--max-file-size", "1074000000", "--latency-buffer-size", "200000"] + [ "--host-ru", "localhost" ] * number_of_readout_apps
 confgen_arguments={"WIB1_System": confgen_arguments_base,
                    "Software_TPG_System": confgen_arguments_base+["--enable-software-tpg"]}
 # The commands to run in nanorc, as a list

--- a/integtest/six_process_stop_start_test.py
+++ b/integtest/six_process_stop_start_test.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 import re
-import psutil
+#import psutil
 
 import dfmodules.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
@@ -42,9 +42,9 @@ ignored_logfile_problems={"dqm": ["client will not be able to connect to Kafka c
 sufficient_resources_on_this_computer=True
 cpu_count=os.cpu_count()
 hostname=os.uname().nodename
-mem_obj=psutil.virtual_memory()
-free_mem=round((mem_obj.available/(1024*1024*1024)), 2)
-total_mem=round((mem_obj.total/(1024*1024*1024)), 2)
+#mem_obj=psutil.virtual_memory()
+free_mem=999  #round((mem_obj.available/(1024*1024*1024)), 2)
+total_mem=999 #round((mem_obj.total/(1024*1024*1024)), 2)
 print(f"DEBUG: CPU count is {cpu_count}, free and total memory are {free_mem} GB and {total_mem} GB.")
 if cpu_count < 18 or free_mem < 24:
     sufficient_resources_on_this_computer=False
@@ -54,7 +54,7 @@ if cpu_count < 18 or free_mem < 24:
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="minidaqapp.newconf.mdapp_multiru_gen"
+confgen_name="daqconf_multiru_gen"
 
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)

--- a/integtest/six_process_stop_start_test.py
+++ b/integtest/six_process_stop_start_test.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 import re
+import psutil
 
 import dfmodules.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
@@ -11,7 +12,7 @@ number_of_readout_apps=3
 run_duration=20  # seconds
 
 # Default values for validation parameters
-expected_number_of_data_files=4
+expected_number_of_data_files=3
 check_for_logfile_errors=True
 expected_event_count=run_duration
 expected_event_count_tolerance=2
@@ -37,30 +38,49 @@ ignored_logfile_problems={"dqm": ["client will not be able to connect to Kafka c
                           "ruemu": [r"Trigger Matching result with empty fragment: TS match result on link .+Requestor=\S+fragx_dqm"],
                          }
 
+# Determine if this computer is powerful enough for these tests
+sufficient_resources_on_this_computer=True
+cpu_count=os.cpu_count()
+hostname=os.uname().nodename
+mem_obj=psutil.virtual_memory()
+free_mem=round((mem_obj.available/(1024*1024*1024)), 2)
+total_mem=round((mem_obj.total/(1024*1024*1024)), 2)
+print(f"DEBUG: CPU count is {cpu_count}, free and total memory are {free_mem} GB and {total_mem} GB.")
+if cpu_count < 18 or free_mem < 24:
+    sufficient_resources_on_this_computer=False
+
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
 confgen_name="minidaqapp.newconf.mdapp_multiru_gen"
+
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-confgen_arguments_base=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "--latency-buffer-size", "200000"] + [ "--host-ru", "localhost" ] * number_of_readout_apps
-confgen_arguments={"WIB1_System": confgen_arguments_base,
-                   "Software_TPG_System": confgen_arguments_base+["--enable-software-tpg"],
-                   "DQM_System": confgen_arguments_base+["--enable-dqm"],
-                   "Software_TPG_and_DQM_System": confgen_arguments_base+["--enable-software-tpg", "--enable-dqm"]
-                  }
+if sufficient_resources_on_this_computer:
+    confgen_arguments_base=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "--latency-buffer-size", "200000"] + [ "--host-ru", "localhost" ] * number_of_readout_apps
+    confgen_arguments={"WIB1_System": confgen_arguments_base,
+                       "Software_TPG_System": confgen_arguments_base+["--enable-software-tpg"],
+                       "DQM_System": confgen_arguments_base+["--enable-dqm"],
+                       #"Software_TPG_and_DQM_System": confgen_arguments_base+["--enable-software-tpg", "--enable-dqm"]
+                      }
+else:
+    confgen_arguments=["-d", "./frames.bin", "-o", ".", "-s", "10"]
+
 # The commands to run in nanorc, as a list
 # (the first run [#100] is included to warm up the DAQ processes and avoid warnings and errors caused by
 # startup sluggishness seen on slower test computers)
-nanorc_command_list="boot init conf".split()
-nanorc_command_list+="start --disable-data-storage 100 wait 1 pause wait 3 resume wait 1 pause wait 3 stop wait 2".split()
-nanorc_command_list+="start                 101 wait ".split() + [str(run_duration)] + "stop --stop-wait 2 wait 2".split()
-nanorc_command_list+="start --resume-wait 4 102 wait ".split() + [str(run_duration)] + "stop               wait 2".split()
-nanorc_command_list+="start --resume-wait 2 103 wait ".split() + [str(run_duration)] + "stop --stop-wait 1 wait 2".split()
-nanorc_command_list+="start --resume-wait 1 104 wait ".split() + [str(run_duration)] + "stop --stop-wait 4 wait 2".split()
-nanorc_command_list+="scrap terminate".split()
+if sufficient_resources_on_this_computer:
+    nanorc_command_list="boot init conf".split()
+    #nanorc_command_list+="start --disable-data-storage 100 wait 1 pause wait 3 resume wait 1 pause wait 3 stop wait 2".split()
+    nanorc_command_list+="start --resume-wait 1 101 wait ".split() + [str(run_duration)] + "stop               wait 2".split()
+    nanorc_command_list+="start --resume-wait 2 102 wait ".split() + [str(run_duration)] + "stop --stop-wait 1 wait 2".split()
+    nanorc_command_list+="start                 103 wait ".split() + [str(run_duration)] + "stop --stop-wait 2 wait 2".split()
+    #nanorc_command_list+="start --resume-wait 1 104 wait ".split() + [str(run_duration)] + "stop --stop-wait 4 wait 2".split()
+    nanorc_command_list+="scrap terminate".split()
+else:
+    nanorc_command_list=["boot", "terminate"]
 
 # The tests themselves
 
@@ -77,13 +97,16 @@ def test_nanorc_success(run_nanorc):
     assert run_nanorc.completed_process.returncode==0
 
 def test_log_files(run_nanorc):
-    local_check_flag=check_for_logfile_errors
-
-    if local_check_flag:
+    if check_for_logfile_errors and sufficient_resources_on_this_computer:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(run_nanorc.log_files, True, True, ignored_logfile_problems)
 
 def test_data_file(run_nanorc):
+    if not sufficient_resources_on_this_computer:
+        print(f"This computer ({hostname}) does not have enough resources to run this test.")
+        print(f"    (CPU count is {cpu_count}, free and total memory are {free_mem} GB and {total_mem} GB.)")
+        return
+
     local_expected_event_count=expected_event_count
     local_event_count_tolerance=expected_event_count_tolerance
     fragment_check_list=[]


### PR DESCRIPTION
The primary purposes of these changes is to switch the use of the daqconf_multiru_gen script in the daqconf repo.

There are also some reliability and usability improvements in six_process_stop_start_test.py which are unrelated, but useful.