### PR TITLE
dfmodules integtest changes

### DIFF
--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -1,0 +1,79 @@
+import pytest
+import os
+import re
+
+import dfmodules.data_file_checks as data_file_checks
+import integrationtest.log_file_checks as log_file_checks
+
+# Values that help determine the running conditions
+number_of_data_producers=2
+run_duration=62  # seconds
+number_of_readout_apps=1
+number_of_dataflow_apps=1
+trigger_rate=0.2 # Hz
+
+# Default values for validation parameters
+expected_number_of_data_files=3*number_of_dataflow_apps
+check_for_logfile_errors=True
+expected_event_count=3*run_duration*trigger_rate/number_of_dataflow_apps
+expected_event_count_tolerance=6
+wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
+                           "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
+                           "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
+                           "min_size_bytes": 240000, "max_size_bytes": 251000}
+
+# The next three variable declarations *must* be present as globals in the test
+# file. They're read by the "fixtures" in conftest.py to determine how
+# to run the config generation and nanorc
+
+# The name of the python module for the config generation
+confgen_name="daqconf_multiru_gen"
+# The arguments to pass to the config generator, excluding the json
+# output directory (the test framework handles that)
+confgen_arguments_base=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "20000", "-a", "20000", "-t", str(trigger_rate), "--latency-buffer-size", "200000"] + [ "--host-ru", "localhost" ] * number_of_readout_apps + [ "--host-df", "localhost" ] * number_of_dataflow_apps
+confgen_arguments={#"No_TR_Splitting": confgen_arguments_base,
+                   "With_TR_Splitting": confgen_arguments_base+["--max-trigger-record-window", "13500"],
+                  }
+# The commands to run in nanorc, as a list
+nanorc_command_list="boot init conf".split()
+nanorc_command_list+="start                 101 wait ".split() + [str(run_duration)] + "stop --stop-wait 2 wait 2".split()
+nanorc_command_list+="start --resume-wait 1 102 wait ".split() + [str(run_duration)] + "stop               wait 2".split()
+nanorc_command_list+="start --resume-wait 2 103 wait ".split() + [str(run_duration)] + "stop --stop-wait 1 wait 2".split()
+nanorc_command_list+="scrap terminate".split()
+
+# The tests themselves
+
+def test_nanorc_success(run_nanorc):
+    current_test=os.environ.get('PYTEST_CURRENT_TEST')
+    match_obj = re.search(r".*\[(.+)\].*", current_test)
+    if match_obj:
+        current_test = match_obj.group(1)
+    banner_line = re.sub(".", "=", current_test)
+    print(banner_line)
+    print(current_test)
+    print(banner_line)
+    # Check that nanorc completed correctly
+    assert run_nanorc.completed_process.returncode==0
+
+def test_log_files(run_nanorc):
+    if check_for_logfile_errors:
+        # Check that there are no warnings or errors in the log files
+        assert log_file_checks.logs_are_error_free(run_nanorc.log_files)
+
+def test_data_file(run_nanorc):
+    local_expected_event_count=expected_event_count
+    local_event_count_tolerance=expected_event_count_tolerance
+    fragment_check_list=[]
+    fragment_check_list.append(wib1_frag_hsi_trig_params)
+
+    # Run some tests on the output data file
+    assert len(run_nanorc.data_files)==expected_number_of_data_files
+
+    for idx in range(len(run_nanorc.data_files)):
+        data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
+        assert data_file_checks.sanity_check(data_file)
+        assert data_file_checks.check_file_attributes(data_file)
+        assert data_file_checks.check_event_count(data_file, local_expected_event_count, local_event_count_tolerance)
+        for jdx in range(len(fragment_check_list)):
+            assert data_file_checks.check_fragment_count(data_file, fragment_check_list[jdx])
+            assert data_file_checks.check_fragment_sizes(data_file, fragment_check_list[jdx])

--- a/integtest/six_process_stop_start_test.py
+++ b/integtest/six_process_stop_start_test.py
@@ -57,23 +57,18 @@ confgen_name="daqconf_multiru_gen"
 if sufficient_resources_on_this_computer:
     confgen_arguments_base=[ "-d", "./frames.bin", "-o", ".", "-s", "10", "-n", str(number_of_data_producers), "-b", "1000", "-a", "1000", "--latency-buffer-size", "200000"] + [ "--host-ru", "localhost" ] * number_of_readout_apps
     confgen_arguments={"WIB1_System": confgen_arguments_base,
-                       "Software_TPG_System": confgen_arguments_base+["--enable-software-tpg"],
+                       "Software_TPG_System": confgen_arguments_base+["--enable-software-tpg", "-c", str(3*number_of_data_producers*number_of_readout_apps)],
                        "DQM_System": confgen_arguments_base+["--enable-dqm"],
-                       #"Software_TPG_and_DQM_System": confgen_arguments_base+["--enable-software-tpg", "--enable-dqm"]
                       }
 else:
     confgen_arguments=["-d", "./frames.bin", "-o", ".", "-s", "10"]
 
 # The commands to run in nanorc, as a list
-# (the first run [#100] is included to warm up the DAQ processes and avoid warnings and errors caused by
-# startup sluggishness seen on slower test computers)
 if sufficient_resources_on_this_computer:
     nanorc_command_list="boot init conf".split()
-    #nanorc_command_list+="start --disable-data-storage 100 wait 1 pause wait 3 resume wait 1 pause wait 3 stop wait 2".split()
     nanorc_command_list+="start --resume-wait 1 101 wait ".split() + [str(run_duration)] + "stop               wait 2".split()
     nanorc_command_list+="start --resume-wait 2 102 wait ".split() + [str(run_duration)] + "stop --stop-wait 1 wait 2".split()
     nanorc_command_list+="start                 103 wait ".split() + [str(run_duration)] + "stop --stop-wait 2 wait 2".split()
-    #nanorc_command_list+="start --resume-wait 1 104 wait ".split() + [str(run_duration)] + "stop --stop-wait 4 wait 2".split()
     nanorc_command_list+="scrap terminate".split()
 else:
     nanorc_command_list=["boot", "terminate"]

--- a/python/dfmodules/data_file_checks.py
+++ b/python/dfmodules/data_file_checks.py
@@ -74,10 +74,16 @@ def check_file_attributes(datafile):
                     print(f"The value in Attribute '{expected_attr_name}' ({attr_value}) does not match the value in the filename ({base_filename})")
         elif expected_attr_name == "creation_timestamp":
             attr_value = datafile.h5file.attrs.get(expected_attr_name)
-            date_obj = datetime.datetime.fromtimestamp(int(attr_value) / 1000, datetime.timezone.utc)
+            date_obj = datetime.datetime.fromtimestamp((int(attr_value)-1) / 1000, datetime.timezone.utc)
             date_string = date_obj.strftime("%Y%m%dT%H%M%S")
-            pattern = f".*{date_string}.*"
-            if not re.match(pattern, base_filename):
+            pattern_low = f".*{date_string}.*"
+            date_obj = datetime.datetime.fromtimestamp((int(attr_value)+1) / 1000, datetime.timezone.utc)
+            date_string = date_obj.strftime("%Y%m%dT%H%M%S")
+            pattern_high = f".*{date_string}.*"
+            date_obj = datetime.datetime.fromtimestamp((int(attr_value)+0) / 1000, datetime.timezone.utc)
+            date_string = date_obj.strftime("%Y%m%dT%H%M%S")
+            pattern_exact = f".*{date_string}.*"
+            if not re.match(pattern_exact, base_filename) and not re.match(pattern_low, base_filename) and not re.match(pattern_high, base_filename):
                 passed=False
                 print(f"The value in Attribute '{expected_attr_name}' ({date_string}) does not match the value in the filename ({base_filename})")
     if passed:


### PR DESCRIPTION
This PR has three changes:

- an initial, simple integtest for long-window-readout
- a fix for occasional problems when comparing the value of the creation_timestamp HDF5 Attribute with the time string in the filename
- an increase in the number of tokens when running with SW TPG in six_process_stop_start_test, to avoid unnecessary warnings about trigger inhibits.