### PR TITLE
Updated TPStreamWriter to use the new TPSet run_number data member to…

### DIFF
--- a/plugins/TPStreamWriter.cpp
+++ b/plugins/TPStreamWriter.cpp
@@ -83,25 +83,6 @@ TPStreamWriter::do_start(const nlohmann::json& payload)
   rcif::cmd::StartParams start_params = payload.get<rcif::cmd::StartParams>();
   m_run_number = start_params.run;
 
-  // 10-Mar-2022, KAB: we have noticed TPSets leaking from one run into the next.
-  // A nice solution would be to check the run number associated with each TPSet
-  // and discard ones from a previous run, but we don't have the run number in
-  // TPSets currently. So, instead, we'll try popping stale TPSets off the queue here.
-  // I don't want this loop to run forever and hang the program if something
-  // changes in the order of App Start commands, so I'll limit its duration to
-  // a second or two...
-  auto start_time = std::chrono::steady_clock::now();
-  auto now = std::chrono::steady_clock::now();
-  trigger::TPSet tpset;
-  while (m_tpset_source->can_pop() && (now - start_time) < std::chrono::seconds(2)) {
-    now = std::chrono::steady_clock::now();
-    try {
-      m_tpset_source->pop(tpset, m_queue_timeout);
-    } catch (appfwk::QueueTimeoutExpired&) {
-      break;
-    }
-  }
-
   // 06-Mar-2022, KAB: added this call to allow DataStore to prepare for the run.
   // I've put this call fairly early in this method because it could throw an
   // exception and abort the run start.  And, it seems sensible to avoid starting
@@ -172,7 +153,17 @@ TPStreamWriter::do_work(std::atomic<bool>& running_flag)
 
     TLOG_DEBUG(21) << "Number of TPs in TPSet is " << tpset.objects.size() << ", GeoID is " << tpset.origin
                    << ", seqno is " << tpset.seqno << ", start timestamp is " << tpset.start_time << ", run number is "
-                   << m_run_number << ", slice id is " << (tpset.start_time / m_accumulation_interval_ticks);
+                   << tpset.run_number << ", slice id is " << (tpset.start_time / m_accumulation_interval_ticks);
+
+    // 30-Mar-2022, KAB: added test for matching run number.  This is to avoid getting
+    // confused by TPSets that happen to be leftover in transit from one run to the
+    // next (which we have observed in v2.10.x systems).
+    if (tpset.run_number != m_run_number) {
+      TLOG_DEBUG(22) << "Discarding TPSet with invalid run number " << tpset.run_number
+                     << " (current is " << m_run_number << "), GeoID is " << tpset.origin
+                     << ", seqno is " << tpset.seqno;
+      continue;
+    }
 
     tp_bundle_handler.add_tpset(std::move(tpset));
 
@@ -213,7 +204,7 @@ TPStreamWriter::do_work(std::atomic<bool>& running_flag)
       first_timestamp = tpset.start_time;
     }
     last_timestamp = tpset.start_time;
-  } // while(true)
+  } // while(running)
 
   auto end_time = steady_clock::now();
   auto time_ms = duration_cast<milliseconds>(end_time - start_time).count();

--- a/plugins/TPStreamWriter.cpp
+++ b/plugins/TPStreamWriter.cpp
@@ -159,9 +159,8 @@ TPStreamWriter::do_work(std::atomic<bool>& running_flag)
     // confused by TPSets that happen to be leftover in transit from one run to the
     // next (which we have observed in v2.10.x systems).
     if (tpset.run_number != m_run_number) {
-      TLOG_DEBUG(22) << "Discarding TPSet with invalid run number " << tpset.run_number
-                     << " (current is " << m_run_number << "), GeoID is " << tpset.origin
-                     << ", seqno is " << tpset.seqno;
+      TLOG_DEBUG(22) << "Discarding TPSet with invalid run number " << tpset.run_number << " (current is "
+                     << m_run_number << "), GeoID is " << tpset.origin << ", seqno is " << tpset.seqno;
       continue;
     }
 


### PR DESCRIPTION
… check for stale TPSets and discard them.

To test my changes, I included the following repos & branches in a software area based on the most recent nightly build:

- dfmodules kbiery/add-tpset-run-number
- fdreadoutlibs philiprodrigues/add-tpset-run-number
- readoutlibs develop
- readoutmodules develop
- trigger philiprodrigues/add-tpset-run-number
- triggeralgs develop

To see the relevant debug messages from TPStreamWriter, I used the following TRACE commands

```
tonM -n TPStreamWriter DEBUG+21
tonM -n TPStreamWriter DEBUG+22
tlvls | grep TPStream  # to confirm that the previous 2 commands worked
```

Of course, we should coordinate with Phil when it comes time to merge this change to _develop_ since it will need to be coordinated with merges in _trigger_ and _fdreadoutlibs_.
