### PR TITLE
Added a warning message at configure time when an invalid output path is specified

### DIFF
--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -147,6 +147,14 @@ public:
       std::string tmpstr(appname_ptr);
       m_application_name = tmpstr;
     }
+
+    // 05-Apr-2022, KAB: added warning message when the output destination
+    // is not a valid directory.
+    struct statvfs vfs_results;
+    int retval = statvfs(m_path.c_str(), &vfs_results);
+    if (retval != 0) {
+      ers::warning(InvalidOutputPath(ERS_HERE, get_name(), m_path));
+    }
   }
 
   /**


### PR DESCRIPTION
This code change is intended to address the residual elements of Issue #17 ...

Eric, in asking for your review of this PR, I'm asking that you check whether the code does what is intended.

Roland, in asking for your review of this PR, I'm asking if you are OK with a warning message a Configure time.  I'd like to avoid a fatal error at Configure time when a bad output destination is specified in the configuration because that would prevent someone from using that configuration and the `nanorc start --disable-data-storage` option to start a run.
The existing fatal error still exists when A) there is a bad path specified and B) disk-writing is enabled at Start time.  (And, by 'fatal error', I mean that the run is prevented from starting, but nothing crashes.)