### PR TITLE
DFO Roundrobin

### DIFF
--- a/plugins/DataFlowOrchestrator.cpp
+++ b/plugins/DataFlowOrchestrator.cpp
@@ -206,29 +206,31 @@ DataFlowOrchestrator::find_slot(dfmessages::TriggerDecision decision)
   // this find_slot assings the decision with a round-robin logic
   // across all the available applications.
   // Applications in error are skipped.
-
+  // we only probe the applications once.
+  // if they are all unavailable we retur to the caller 
+  // before looping again
+  
   std::shared_ptr<AssignedTriggerDecision> output = nullptr;
+  unsigned int counter = 0 ;
+ 
+  auto candidate_it = m_last_assignement_it;
+  if (candidate_it == m_dataflow_availability.end())
+    candidate_it = m_dataflow_availability.begin();
 
-  auto last_it = m_last_assignement_it;
-  if (last_it == m_dataflow_availability.end())
-    last_it = m_dataflow_availability.begin();
+  while ( output == nullptr && counter < m_dataflow_availability.size() ) {
 
-  auto candidate_it = last_it;
-
-  do {
-
+    ++counter;
     ++candidate_it;
     if (candidate_it == m_dataflow_availability.end())
       candidate_it = m_dataflow_availability.begin();
-
+    
     if (candidate_it->second.is_busy())
       continue;
-
+    
     output = candidate_it->second.make_assignment(decision);
     m_last_assignement_it = candidate_it;
-    break;
-
-  } while (candidate_it != last_it);
+    
+  }
 
   return output;
 }

--- a/plugins/DataFlowOrchestrator.cpp
+++ b/plugins/DataFlowOrchestrator.cpp
@@ -210,7 +210,7 @@ DataFlowOrchestrator::find_slot(dfmessages::TriggerDecision decision)
   std::shared_ptr<AssignedTriggerDecision> output = nullptr;
 
   auto last_it = m_last_assignement_it;
-  if ( last_t == m_dataflow_availability.end() ) last_it = m_dataflow_availability.begin();
+  if ( last_it == m_dataflow_availability.end() ) last_it = m_dataflow_availability.begin();
 
   auto candidate_it = last_it;
 
@@ -219,13 +219,13 @@ DataFlowOrchestrator::find_slot(dfmessages::TriggerDecision decision)
     ++candidate_it;
     if ( candidate_it == m_dataflow_availability.end() ) candidate_it = m_dataflow_availability.begin();
     
-    if ( candidate_it -> second -> is_in_error() ) continue ;
+    if ( candidate_it -> second.is_in_error() ) continue ;
 
-    output = candidate->second.make_assignment(decision);
-    m_last_assignement_it = candidate;
+    output = candidate_it->second.make_assignment(decision);
+    m_last_assignement_it = candidate_it;
     break ;
     
-  } while ( temp_it != last_it ) ;
+  } while ( candidate_it != last_it ) ;
 
   return output;
 }

--- a/plugins/DataFlowOrchestrator.cpp
+++ b/plugins/DataFlowOrchestrator.cpp
@@ -207,29 +207,28 @@ DataFlowOrchestrator::find_slot(dfmessages::TriggerDecision decision)
   // across all the available applications.
   // Applications in error are skipped.
   // we only probe the applications once.
-  // if they are all unavailable we retur to the caller 
+  // if they are all unavailable we return to the caller
   // before looping again
-  
+
   std::shared_ptr<AssignedTriggerDecision> output = nullptr;
-  unsigned int counter = 0 ;
- 
+  unsigned int counter = 0;
+
   auto candidate_it = m_last_assignement_it;
   if (candidate_it == m_dataflow_availability.end())
     candidate_it = m_dataflow_availability.begin();
 
-  while ( output == nullptr && counter < m_dataflow_availability.size() ) {
+  while (output == nullptr && counter < m_dataflow_availability.size()) {
 
     ++counter;
     ++candidate_it;
     if (candidate_it == m_dataflow_availability.end())
       candidate_it = m_dataflow_availability.begin();
-    
+
     if (candidate_it->second.is_busy())
       continue;
-    
+
     output = candidate_it->second.make_assignment(decision);
     m_last_assignement_it = candidate_it;
-    
   }
 
   return output;

--- a/plugins/DataFlowOrchestrator.cpp
+++ b/plugins/DataFlowOrchestrator.cpp
@@ -106,7 +106,7 @@ DataFlowOrchestrator::do_start(const data_t& payload)
   m_running_status.store(true);
   m_last_notified_busy.store(false);
   m_last_assignement_it = m_dataflow_availability.end();
-  
+
   m_last_token_received = m_last_td_received = std::chrono::steady_clock::now();
 
   networkmanager::NetworkManager::get().register_callback(
@@ -210,22 +210,25 @@ DataFlowOrchestrator::find_slot(dfmessages::TriggerDecision decision)
   std::shared_ptr<AssignedTriggerDecision> output = nullptr;
 
   auto last_it = m_last_assignement_it;
-  if ( last_it == m_dataflow_availability.end() ) last_it = m_dataflow_availability.begin();
+  if (last_it == m_dataflow_availability.end())
+    last_it = m_dataflow_availability.begin();
 
   auto candidate_it = last_it;
 
   do {
 
     ++candidate_it;
-    if ( candidate_it == m_dataflow_availability.end() ) candidate_it = m_dataflow_availability.begin();
-    
-    if ( candidate_it -> second.is_in_error() ) continue ;
+    if (candidate_it == m_dataflow_availability.end())
+      candidate_it = m_dataflow_availability.begin();
+
+    if (candidate_it->second.is_in_error())
+      continue;
 
     output = candidate_it->second.make_assignment(decision);
     m_last_assignement_it = candidate_it;
-    break ;
-    
-  } while ( candidate_it != last_it ) ;
+    break;
+
+  } while (candidate_it != last_it);
 
   return output;
 }

--- a/plugins/DataFlowOrchestrator.cpp
+++ b/plugins/DataFlowOrchestrator.cpp
@@ -221,7 +221,7 @@ DataFlowOrchestrator::find_slot(dfmessages::TriggerDecision decision)
     if (candidate_it == m_dataflow_availability.end())
       candidate_it = m_dataflow_availability.begin();
 
-    if (candidate_it->second.is_in_error())
+    if (candidate_it->second.is_busy())
       continue;
 
     output = candidate_it->second.make_assignment(decision);

--- a/plugins/DataFlowOrchestrator.hpp
+++ b/plugins/DataFlowOrchestrator.hpp
@@ -67,9 +67,11 @@ public:
 
 protected:
   virtual std::shared_ptr<AssignedTriggerDecision> find_slot(dfmessages::TriggerDecision decision);
+  // find_slot operates on a round-robin logic
 
-  std::map<std::string, TriggerRecordBuilderData> m_dataflow_availability;
-  // std::map<std::string, TriggerRecordBuilderData>::iterator m_last_assignement_it;
+  using data_structure_t = std::map<std::string, TriggerRecordBuilderData>;
+  data_structure_t m_dataflow_availability;
+  data_structure_t::iterator m_last_assignement_it;
   std::function<void(nlohmann::json&)> m_metadata_function;
 
 private:
@@ -103,8 +105,7 @@ private:
   // atomic<bool> m_last_notifiled_status{false};
   std::atomic<bool> m_running_status{ false };
   mutable std::atomic<bool> m_last_notified_busy{ false };
-  std::string m_last_sent_td_connection;
-  std::chrono::steady_clock::time_point m_last_token_received;
+OA  std::chrono::steady_clock::time_point m_last_token_received;
   std::chrono::steady_clock::time_point m_last_td_received;
 
   // Statistics

--- a/plugins/DataFlowOrchestrator.hpp
+++ b/plugins/DataFlowOrchestrator.hpp
@@ -105,7 +105,7 @@ private:
   // atomic<bool> m_last_notifiled_status{false};
   std::atomic<bool> m_running_status{ false };
   mutable std::atomic<bool> m_last_notified_busy{ false };
-OA  std::chrono::steady_clock::time_point m_last_token_received;
+  std::chrono::steady_clock::time_point m_last_token_received;
   std::chrono::steady_clock::time_point m_last_td_received;
 
   // Statistics


### PR DESCRIPTION
this solves #159 
I tested running two cases:
 - single DF application with standard 1Hz rate
 - 6 DF applications with with 1Hz rate
 
 All the applications were used successfully. 
 
 I implemented the logic so that the cycle start from scratch on each stop -> start transition. 

I attach the plots to show that applications were used with the same rate. 
![Screenshot from 2022-04-14 11-54-23](https://user-images.githubusercontent.com/31312964/163377431-0944d366-ceca-42b2-88a2-e1ef2e561b05.png)
![Screenshot from 2022-04-14 11-53-51](https://user-images.githubusercontent.com/31312964/163377433-c7ed3dd4-aff8-40de-b14b-49ff7ec7fdff.png)
