### PR TITLE
Integtest changes to check for TC Fragments in non-SWTPG TRs and fix the number of expected fragments in a few tests

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -24,7 +24,11 @@ wib1_frag_multi_trig_params={"fragment_type_description": "WIB",
                              "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                              "expected_fragment_count": ((number_of_data_producers*number_of_readout_apps)+number_of_readout_apps+1),
                              "min_size_bytes": 80, "max_size_bytes": 37200}
-triggertp_frag_params={"fragment_type_description": "Trigger TP",
+triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
+                              "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
+                              "expected_fragment_count": 1,
+                              "min_size_bytes": 130, "max_size_bytes": 150}
+triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
                        "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
                        "min_size_bytes": 80, "max_size_bytes": 16000}
@@ -108,8 +112,9 @@ def test_data_file(run_nanorc):
         local_event_count_tolerance+=(10*number_of_data_producers*number_of_readout_apps*run_duration/100)
         fragment_check_list.append(wib1_frag_multi_trig_params)
         fragment_check_list.append(triggertp_frag_params)
-    if len(fragment_check_list) == 0:
+    else:
         fragment_check_list.append(wib1_frag_hsi_trig_params)
+        fragment_check_list.append(triggercandidate_frag_params)
 
     # Run some tests on the output data file
     assert len(run_nanorc.data_files)==expected_number_of_data_files

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -25,7 +25,11 @@ wib1_frag_multi_trig_params={"fragment_type_description": "WIB",
                              "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                              "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
                              "min_size_bytes": 80, "max_size_bytes": 37200}
-triggertp_frag_params={"fragment_type_description": "Trigger TP",
+triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
+                              "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
+                              "expected_fragment_count": 1,
+                              "min_size_bytes": 130, "max_size_bytes": 150}
+triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
                        "expected_fragment_count": ((number_of_data_producers*number_of_readout_apps)+number_of_readout_apps+1),
                        "min_size_bytes": 80, "max_size_bytes": 16000}
@@ -87,8 +91,8 @@ def test_data_file(run_nanorc):
         low_number_of_files-=number_of_dataflow_apps
         if low_number_of_files < 1:
             low_number_of_files=1
-    if len(fragment_check_list) == 0:
         fragment_check_list.append(wib1_frag_hsi_trig_params)
+        fragment_check_list.append(triggercandidate_frag_params)
 
     # Run some tests on the output data file
     assert len(run_nanorc.data_files)==high_number_of_files or len(run_nanorc.data_files)==low_number_of_files

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -28,7 +28,7 @@ triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "min_size_bytes": 130, "max_size_bytes": 150}
 triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
-                       "expected_fragment_count": number_of_data_producers,
+                       "expected_fragment_count": number_of_data_producers+2,
                        "min_size_bytes": 80, "max_size_bytes": 16000}
 
 # The next three variable declarations *must* be present as globals in the test

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -22,7 +22,11 @@ wib1_frag_multi_trig_params={"fragment_type_description": "WIB",
                              "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                              "expected_fragment_count": number_of_data_producers,
                              "min_size_bytes": 80, "max_size_bytes": 37200}
-triggertp_frag_params={"fragment_type_description": "Trigger TP",
+triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
+                              "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
+                              "expected_fragment_count": 1,
+                              "min_size_bytes": 130, "max_size_bytes": 150}
+triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
                        "expected_fragment_count": number_of_data_producers,
                        "min_size_bytes": 80, "max_size_bytes": 16000}
@@ -74,8 +78,9 @@ def test_data_file(run_nanorc):
         local_event_count_tolerance+=(10*number_of_data_producers*run_duration/100)
         fragment_check_list.append(wib1_frag_multi_trig_params)
         fragment_check_list.append(triggertp_frag_params)
-    if len(fragment_check_list) == 0:
+    else:
         fragment_check_list.append(wib1_frag_hsi_trig_params)
+        fragment_check_list.append(triggercandidate_frag_params)
 
     # Run some tests on the output data file
     assert len(run_nanorc.data_files)==expected_number_of_data_files

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -21,6 +21,10 @@ wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
                            "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                            "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
                            "min_size_bytes": 240000, "max_size_bytes": 251000}
+triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
+                              "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
+                              "expected_fragment_count": 1,
+                              "min_size_bytes": 80, "max_size_bytes": 150}
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -65,6 +69,7 @@ def test_data_file(run_nanorc):
     local_event_count_tolerance=expected_event_count_tolerance
     fragment_check_list=[]
     fragment_check_list.append(wib1_frag_hsi_trig_params)
+    fragment_check_list.append(triggercandidate_frag_params)
 
     # Run some tests on the output data file
     assert len(run_nanorc.data_files)==expected_number_of_data_files

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -20,7 +20,11 @@ wib1_frag_multi_trig_params={"fragment_type_description": "WIB",
                              "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                              "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
                              "min_size_bytes": 80, "max_size_bytes": 185680}
-triggertp_frag_params={"fragment_type_description": "Trigger TP",
+triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
+                              "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
+                              "expected_fragment_count": 1,
+                              "min_size_bytes": 130, "max_size_bytes": 150}
+triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
                        "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
                        "min_size_bytes": 80, "max_size_bytes": 16000}
@@ -66,8 +70,9 @@ def test_data_file(run_nanorc):
         local_file_count=5
         fragment_check_list.append(wib1_frag_multi_trig_params)
         fragment_check_list.append(triggertp_frag_params)
-    if len(fragment_check_list) == 0:
+    else:
         fragment_check_list.append(wib1_frag_hsi_trig_params)
+        fragment_check_list.append(triggercandidate_frag_params)
 
     # Run some tests on the output data file
     assert len(run_nanorc.data_files)==local_file_count

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -26,7 +26,7 @@ triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "min_size_bytes": 130, "max_size_bytes": 150}
 triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
-                       "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
+                       "expected_fragment_count": ((number_of_data_producers*number_of_readout_apps)+number_of_readout_apps+1),
                        "min_size_bytes": 80, "max_size_bytes": 16000}
 ignored_logfile_problems={"trigger": ["zipped_tpset_q: Unable to push within timeout period"]}
 


### PR DESCRIPTION
There are still warning messages being reported by various dfmodules integration tests, but this PR is to update the tests to take into account the addition of TC Fragments to all TriggerRecords.  I believe that all relevant integtests are now checking TC Fragment presence and size.

The known warning messages are the following:

- 3ru_3df_multirun_test: tazipper warnings in the SWTPG part of the test; lots of warnings of various types in the DQM part of the test
- 3ru_1df_multirun_test: lots of troubles in the SWTPG part (TriggerInhibits, tazipper warnings, fewer TRs than expected); lots of warnings of various types in the DQM part of the test (same as 3ru_3df)
- multi_output_file_test.py: tazipper warnings in the SWTPG part of the test