### PR TITLE
Remove references to NetworkManager

### DIFF
--- a/plugins/DataWriter.cpp
+++ b/plugins/DataWriter.cpp
@@ -42,8 +42,6 @@ enum
 namespace dunedaq {
 namespace dfmodules {
 
-using networkmanager::NetworkManager;
-
 DataWriter::DataWriter(const std::string& name)
   : dunedaq::appfwk::DAQModule(name)
   , m_queue_timeout(100)

--- a/plugins/TriggerRecordBuilder.cpp
+++ b/plugins/TriggerRecordBuilder.cpp
@@ -44,7 +44,6 @@ namespace dunedaq {
 namespace dfmodules {
 
 using daqdataformats::TriggerRecordErrorBits;
-using networkmanager::NetworkManager;
 
 TriggerRecordBuilder::TriggerRecordBuilder(const std::string& name)
   : dunedaq::appfwk::DAQModule(name)


### PR DESCRIPTION
This PR does *not* depend on https://github.com/DUNE-DAQ/iomanager/pull/21, and can be merged at any time.