### PR TITLE
Added a check in the DataWriter code that TriggerRecords have the expected run number

### DIFF
--- a/plugins/DataWriter.cpp
+++ b/plugins/DataWriter.cpp
@@ -207,8 +207,16 @@ DataWriter::receive_trigger_record(std::unique_ptr<daqdataformats::TriggerRecord
   TLOG_DEBUG(TLVL_WORK_STEPS) << get_name() << ": Obtained the TriggerRecord for trigger number "
 			      << trigger_record_ptr->get_header_ref().get_trigger_number() << "."
 			      << trigger_record_ptr->get_header_ref().get_sequence_number()
+			      << ", run number " << trigger_record_ptr->get_header_ref().get_run_number()
 			      << " off the input connection";
-  
+
+  if (trigger_record_ptr->get_header_ref().get_run_number() != m_run_number) {
+    ers::error(InvalidRunNumber(ERS_HERE, get_name(), "TriggerRecord", trigger_record_ptr->get_header_ref().get_run_number(),
+                                m_run_number, trigger_record_ptr->get_header_ref().get_trigger_number(),
+                                trigger_record_ptr->get_header_ref().get_sequence_number()));
+    return;
+  }
+
   // 03-Feb-2021, KAB: adding support for a data-storage prescale.
   // In this "if" statement, I deliberately compare the result of (N mod prescale) to 1
   // instead of zero, since I think that it would be nice to always get the first event
@@ -231,6 +239,7 @@ DataWriter::receive_trigger_record(std::unique_ptr<daqdataformats::TriggerRecord
 	  ers::error(DataWritingProblem(ERS_HERE,
 					get_name(),
 					trigger_record_ptr->get_header_ref().get_trigger_number(),
+					trigger_record_ptr->get_header_ref().get_sequence_number(),
 					trigger_record_ptr->get_header_ref().get_run_number(),
 					excpt));
 	  if (retry_wait_usec > m_max_write_retry_time_usec) {
@@ -242,6 +251,7 @@ DataWriter::receive_trigger_record(std::unique_ptr<daqdataformats::TriggerRecord
 	  ers::error(DataWritingProblem(ERS_HERE,
 					get_name(),
 					trigger_record_ptr->get_header_ref().get_trigger_number(),
+					trigger_record_ptr->get_header_ref().get_sequence_number(),
 					trigger_record_ptr->get_header_ref().get_run_number(),
 					excpt));
 	}

--- a/plugins/DataWriter.hpp
+++ b/plugins/DataWriter.hpp
@@ -12,10 +12,10 @@
 #include "dfmodules/DataStore.hpp"
 
 #include "appfwk/DAQModule.hpp"
-#include "iomanager/Sender.hpp"
-#include "iomanager/Receiver.hpp"
 #include "daqdataformats/TriggerRecord.hpp"
 #include "dfmessages/TriggerDecisionToken.hpp"
+#include "iomanager/Receiver.hpp"
+#include "iomanager/Sender.hpp"
 #include "utilities/WorkerThread.hpp"
 
 #include <chrono>
@@ -55,7 +55,7 @@ private:
   void do_scrap(const data_t&);
 
   // Callback
-  void receive_trigger_record(std::unique_ptr<daqdataformats::TriggerRecord> &);
+  void receive_trigger_record(std::unique_ptr<daqdataformats::TriggerRecord>&);
   std::atomic<bool> m_running = false;
 
   // Configuration
@@ -73,17 +73,17 @@ private:
   using token_sender_t = iomanager::SenderConcept<dfmessages::TriggerDecisionToken>;
   std::shared_ptr<token_sender_t> m_token_output;
   std::string m_trigger_decision_connection;
-  
+
   // Worker(s)
   std::unique_ptr<DataStore> m_data_writer;
-  
+
   // Metrics
   std::atomic<uint64_t> m_records_received = { 0 };     // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_records_received_tot = { 0 }; // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_records_written = { 0 };      // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_records_written_tot = { 0 };  // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_bytes_output = { 0 };         // NOLINT(build/unsigned)
-  
+
   // Other
   std::map<daqdataformats::trigger_number_t, size_t> m_seqno_counts;
 
@@ -94,7 +94,7 @@ private:
   }
 };
 } // namespace dfmodules
-  
+
 ERS_DECLARE_ISSUE_BASE(dfmodules,
                        InvalidDataWriter,
                        appfwk::GeneralDAQModuleIssue,
@@ -106,9 +106,20 @@ ERS_DECLARE_ISSUE_BASE(dfmodules,
 ERS_DECLARE_ISSUE_BASE(dfmodules,
                        DataWritingProblem,
                        appfwk::GeneralDAQModuleIssue,
-                       "A problem was encountered when writing TriggerRecord number " << trnum << " in run " << runnum,
+                       "A problem was encountered when writing TriggerRecord number " << trnum << "." << seqnum
+                                                                                      << " in run " << runnum,
                        ((std::string)name),
-                       ((size_t)trnum)((size_t)runnum))
+                       ((size_t)trnum)((size_t)seqnum)((size_t)runnum))
+
+ERS_DECLARE_ISSUE_BASE(dfmodules,
+                       InvalidRunNumber,
+                       appfwk::GeneralDAQModuleIssue,
+                       "An invalid run number was received in a "
+                         << msg_type << "message, "
+                         << "received=" << received << ", expected=" << expected << ", trig/seq_number=" << trnum << "."
+                         << seqnum,
+                       ((std::string)name),
+                       ((std::string)msg_type)((size_t)received)((size_t)expected)((size_t)trnum)((size_t)seqnum))
 
 } // namespace dunedaq
 


### PR DESCRIPTION
also ran clang-format on the header; also added run number to several messages.

These changes were helpful in testing iomanager PR #22.
