### PR TITLE
Update counts of trigger fragments: there are now always exactly 3

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -30,7 +30,7 @@ triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "min_size_bytes": 130, "max_size_bytes": 150}
 triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
-                       "expected_fragment_count": ((number_of_data_producers*number_of_readout_apps)+number_of_readout_apps+1),
+                       "expected_fragment_count": 3,
                        "min_size_bytes": 80, "max_size_bytes": 16000}
 ignored_logfile_problems={"dqm": ["client will not be able to connect to Kafka cluster",
                                   "Unexpected Trigger Decision", "Unexpected Fragment"],

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -25,7 +25,7 @@ wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
 wib1_frag_multi_trig_params={"fragment_type_description": "WIB",
                              "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                              "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
-                             "min_size_bytes": 80, "max_size_bytes": 37200}
+                             "min_size_bytes": 80, "max_size_bytes": 54000}
 triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
                               "expected_fragment_count": 1,

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -31,7 +31,7 @@ triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "min_size_bytes": 130, "max_size_bytes": 150}
 triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
-                       "expected_fragment_count": ((number_of_data_producers*number_of_readout_apps)+number_of_readout_apps+1),
+                       "expected_fragment_count": 3,
                        "min_size_bytes": 80, "max_size_bytes": 16000}
 ignored_logfile_problems={"dqm": ["client will not be able to connect to Kafka cluster"]}
 

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -24,7 +24,7 @@ wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
 wib1_frag_multi_trig_params={"fragment_type_description": "WIB",
                              "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                              "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
-                             "min_size_bytes": 80, "max_size_bytes": 37200}
+                             "min_size_bytes": 80, "max_size_bytes": 54000}
 triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
                               "expected_fragment_count": 1,

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -21,7 +21,7 @@ wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
 wib1_frag_multi_trig_params={"fragment_type_description": "WIB",
                              "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                              "expected_fragment_count": number_of_data_producers,
-                             "min_size_bytes": 80, "max_size_bytes": 37200}
+                             "min_size_bytes": 80, "max_size_bytes": 54000}
 triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
                               "expected_fragment_count": 1,

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -28,7 +28,7 @@ triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "min_size_bytes": 130, "max_size_bytes": 150}
 triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
-                       "expected_fragment_count": number_of_data_producers+2,
+                       "expected_fragment_count": 3,
                        "min_size_bytes": 80, "max_size_bytes": 16000}
 
 # The next three variable declarations *must* be present as globals in the test

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -26,7 +26,7 @@ triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "min_size_bytes": 130, "max_size_bytes": 150}
 triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
-                       "expected_fragment_count": ((number_of_data_producers*number_of_readout_apps)+number_of_readout_apps+1),
+                       "expected_fragment_count": 3,
                        "min_size_bytes": 80, "max_size_bytes": 16000}
 ignored_logfile_problems={"trigger": ["zipped_tpset_q: Unable to push within timeout period"]}
 

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -36,7 +36,7 @@ triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "min_size_bytes": 130, "max_size_bytes": 150}
 triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
-                       "expected_fragment_count": number_of_data_producers+2,
+                       "expected_fragment_count": 3,
                        "min_size_bytes": 80, "max_size_bytes": 16000}
 ignored_logfile_problems={"dqm": ["client will not be able to connect to Kafka cluster",
                                   "Unexpected Trigger Decision", "Unexpected Fragment"],

--- a/integtest/readout_type_scan.py
+++ b/integtest/readout_type_scan.py
@@ -21,7 +21,7 @@ wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
 wib1_frag_multi_trig_params={"fragment_type_description": "WIB",
                              "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                              "expected_fragment_count": number_of_data_producers,
-                             "min_size_bytes": 80, "max_size_bytes": 37200}
+                             "min_size_bytes": 80, "max_size_bytes": 54000}
 wib2_frag_params={"fragment_type_description": "WIB2",
                   "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                   "expected_fragment_count": number_of_data_producers,

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -35,7 +35,7 @@ triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "min_size_bytes": 130, "max_size_bytes": 150}
 triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "hdf5_detector_group": "Trigger", "hdf5_region_prefix": "Region",
-                       "expected_fragment_count": ((number_of_data_producers*number_of_readout_apps)+number_of_readout_apps+1),
+                       "expected_fragment_count": 3,
                        "min_size_bytes": 80, "max_size_bytes": 16000}
 ignored_logfile_problems={"dqm": ["client will not be able to connect to Kafka cluster"]}
 

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -24,7 +24,7 @@ wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
 wib1_frag_multi_trig_params={"fragment_type_description": "WIB",
                              "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                              "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
-                             "min_size_bytes": 80, "max_size_bytes": 37200}
+                             "min_size_bytes": 80, "max_size_bytes": 54000}
 wib1_tpset_params={"fragment_type_description": "TP Stream",
                              "hdf5_detector_group": "TPC", "hdf5_region_prefix": "APA",
                              "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),


### PR DESCRIPTION
Previously, there was one TP/TA trigger fragment for each producer of
those. Now, all of the TPs go into one fragment and all of the TAs go
in another. Along with the TC fragment, that makes 3 trigger fragments
per event