### PR TITLE
put application name and module name in filename to support multiple …

### DIFF
--- a/plugins/DataWriter.hpp
+++ b/plugins/DataWriter.hpp
@@ -70,11 +70,17 @@ private:
 
   // Connections
   iomanager::connection::ConnectionRef m_trigger_record_connection;
+  using tr_receiver_ct = iomanager::ReceiverConcept<std::unique_ptr<daqdataformats::TriggerRecord>>;
+  std::shared_ptr<tr_receiver_ct> m_tr_receiver;
+
   using token_sender_t = iomanager::SenderConcept<dfmessages::TriggerDecisionToken>;
   std::shared_ptr<token_sender_t> m_token_output;
   std::string m_trigger_decision_connection;
 
   // Worker(s)
+  dunedaq::utilities::WorkerThread m_thread;
+  void do_work(std::atomic<bool>&);
+
   std::unique_ptr<DataStore> m_data_writer;
 
   // Metrics

--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -142,13 +142,6 @@ public:
       throw InvalidOperationMode(ERS_HERE, get_name(), m_operation_mode);
     }
 
-    m_application_name = "Unknown";
-    char* appname_ptr = getenv("DUNEDAQ_APPLICATION_NAME");
-    if (appname_ptr != nullptr) {
-      std::string tmpstr(appname_ptr);
-      m_application_name = tmpstr;
-    }
-
     // 05-Apr-2022, KAB: added warning message when the output destination
     // is not a valid directory.
     struct statvfs vfs_results;
@@ -310,7 +303,6 @@ private:
   std::string m_basic_name_of_open_file;
   unsigned m_open_flags_of_open_file;
   daqdataformats::run_number_t m_run_number;
-  std::string m_application_name;
   std::string m_hardware_map_file;
 
   // Total number of generated files
@@ -360,7 +352,7 @@ private:
       work_oss << std::setw(m_config_params.filename_parameters.digits_for_file_index) << std::setfill('0')
                << m_file_index;
     }
-
+    work_oss << "_" << m_config_params.filename_parameters.writer_identifier;
     work_oss << ".hdf5";
     return work_oss.str();
   }
@@ -383,15 +375,9 @@ private:
       std::string unique_filename = file_name;
       time_t now = time(0);
       std::string file_creation_timestamp = boost::posix_time::to_iso_string(boost::posix_time::from_time_t(now));
-      // app_name substring
-      size_t ufn_len = unique_filename.length();
-      if (ufn_len > 6) { // len GT 6 gives us some confidence that we have at least x.hdf5
-        std::string appname_substring = "_" + m_application_name;
-        unique_filename.insert(ufn_len - 5, appname_substring);
-      }
       if (!m_disable_unique_suffix) {
         // timestamp substring
-        ufn_len = unique_filename.length();
+        size_t ufn_len = unique_filename.length();
         if (ufn_len > 6) { // len GT 6 gives us some confidence that we have at least x.hdf5
           std::string timestamp_substring = "_" + file_creation_timestamp;
           TLOG_DEBUG(TLVL_BASIC) << get_name() << ": timestamp substring for filename: " << timestamp_substring;
@@ -423,7 +409,7 @@ private:
         m_file_handle.reset(new hdf5libs::HDF5RawDataFileSid(unique_filename,
                                                              m_run_number,
                                                              m_file_index,
-                                                             m_application_name,
+                                                             m_config_params.filename_parameters.writer_identifier,
                                                              m_file_layout_params,
                                                              hw_map_svc,
                                                              ".writing",

--- a/schema/dfmodules/hdf5datastore.jsonnet
+++ b/schema/dfmodules/hdf5datastore.jsonnet
@@ -27,6 +27,8 @@ local types = {
                 doc="Prefix for the file index part of the filename"),
         s.field("digits_for_file_index", self.count, 4,
                 doc="Number of digits to use for the file index when formatting the filename"),
+        s.field("writer_identifier", self.ds_string, "",
+                doc="String identifying the writer in the filename"),
         s.field("trigger_number_prefix", self.ds_string, "",
                 doc="Prefix for the trigger number part of the filename"),
         s.field("digits_for_trigger_number", self.count, 6,


### PR DESCRIPTION
…data writers per dataflow application; changed from callback to receive API to use the properties of a MPMC queue between TRB and data writer modules