### PR TITLE
Set the det_crate value in hw map to the readout app #

### DIFF
--- a/python/dfmodules/integtest_file_gen.py
+++ b/python/dfmodules/integtest_file_gen.py
@@ -10,8 +10,9 @@ def generate_hwmap_file(n_links, n_apps = 1, det_id = 3):
     for app in range(n_apps):
         for link in range(n_links):
             card = app
+            crate = app
             slr = link // 5
             link_num = link % 5
-            conf+=f"{sid} {sid % 2} {sid // 2} 0 {det_id} localhost {card} {slr} {link_num}\n"
+            conf+=f"{sid} {sid % 2} {sid // 2} {crate} {det_id} localhost {card} {slr} {link_num}\n"
             sid += 1
     return conf


### PR DESCRIPTION
Previously, all links in the hardware map had det_crate set to
zero. The daqconf uses det_crate to decide which links to aggregate
into a TA maker in the trigger. When all the det_crate values are the
same, all of the TP links are aggregated into one TA  maker. This is
fine - it's a perfectly legal configuration - but doesn't exercise the
functionality of having multiple TA makers, which is a more typical
configuration.

I've set the crate value to be the same as the app number, but I see
that the card number is also set to the same value, so I'm not sure
whether this is the right thing to do.