### PR TITLE
Integtest fixes, mainly in the multi_output_file_test

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -86,7 +86,7 @@ conf_dict["readout"]["latency_buffer_size"] = 200000
 
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["enable_software_tpg"] = True
-swtpg_conf["dataflow"]["apps"][0]["token_count"] = 3*number_of_readout_apps
+swtpg_conf["dataflow"]["apps"][0]["token_count"] = max(10, 3*number_of_data_producers*number_of_readout_apps)
 
 dqm_conf = copy.deepcopy(conf_dict)
 dqm_conf["dqm"]["enable_dqm"] = True

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import re
 import copy
+import math
 
 import dfmodules.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
@@ -77,7 +78,7 @@ for df_app in range(number_of_dataflow_apps):
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["enable_software_tpg"] = True
 for df_app in range(number_of_dataflow_apps):
-    swtpg_conf["dataflow"]["apps"][df_app]["token_count"] = 3*number_of_readout_apps
+    swtpg_conf["dataflow"]["apps"][df_app]["token_count"] = int(math.ceil(max(10, 3*number_of_data_producers*number_of_readout_apps)/number_of_dataflow_apps))
 
 dqm_conf = copy.deepcopy(conf_dict)
 dqm_conf["dqm"]["enable_dqm"] = True

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -20,12 +20,12 @@ wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
                            "fragment_type": "ProtoWIB",
                            "hdf5_source_subsystem": "Detector_Readout",
                            "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
-                           "min_size_bytes": 37192, "max_size_bytes": 185680}
+                           "min_size_bytes": 37192, "max_size_bytes": 185960}
 wib1_frag_multi_trig_params={"fragment_type_description": "WIB",
                              "fragment_type": "ProtoWIB",
                              "hdf5_source_subsystem": "Detector_Readout",
                              "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
-                             "min_size_bytes": 72, "max_size_bytes": 185680}
+                             "min_size_bytes": 72, "max_size_bytes": 270000}
 triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "fragment_type": "Trigger_Candidate",
                               "hdf5_source_subsystem": "Trigger",
@@ -35,11 +35,11 @@ triggeractivity_frag_params={"fragment_type_description": "Trigger Activity",
                               "fragment_type": "Trigger_Activity",
                               "hdf5_source_subsystem": "Trigger",
                               "expected_fragment_count": number_of_readout_apps,
-                              "min_size_bytes": 72, "max_size_bytes": 216}
+                              "min_size_bytes": 72, "max_size_bytes": 520}
 triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
                        "fragment_type": "SW_Trigger_Primitive",
                        "hdf5_source_subsystem": "Trigger",
-                       "expected_fragment_count": ((number_of_data_producers*number_of_readout_apps)+number_of_readout_apps+1),
+                       "expected_fragment_count": ((number_of_data_producers*number_of_readout_apps)),
                        "min_size_bytes": 72, "max_size_bytes": 16000}
 hsi_frag_params ={"fragment_type_description": "HSI",
                              "fragment_type": "Hardware_Signal",
@@ -68,7 +68,7 @@ conf_dict["dataflow"]["apps"][0]["max_file_size"] = 1074000000
 
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["enable_software_tpg"] = True
-swtpg_conf["dataflow"]["apps"][0]["token_count"] = 3*number_of_readout_apps
+swtpg_conf["dataflow"]["apps"][0]["token_count"] = 5*number_of_readout_apps
 
 confgen_arguments={"WIB1_System": conf_dict,
                    "Software_TPG_System": swtpg_conf,

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -68,7 +68,7 @@ conf_dict["dataflow"]["apps"][0]["max_file_size"] = 1074000000
 
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["enable_software_tpg"] = True
-swtpg_conf["dataflow"]["apps"][0]["token_count"] = 5*number_of_readout_apps
+swtpg_conf["dataflow"]["apps"][0]["token_count"] = max(10, 3*number_of_data_producers*number_of_readout_apps)
 
 confgen_arguments={"WIB1_System": conf_dict,
                    "Software_TPG_System": swtpg_conf,

--- a/plugins/DataFlowOrchestrator.cpp
+++ b/plugins/DataFlowOrchestrator.cpp
@@ -199,7 +199,8 @@ DataFlowOrchestrator::receive_trigger_decision(const dfmessages::TriggerDecision
     }
 
     TLOG_DEBUG(TLVL_TRIGDEC_RECEIVED) << get_name() << " Slot found for trigger_number " << decision.trigger_number
-                                      << " on connection " << assignment->connection_name;
+                                      << " on connection " << assignment->connection_name
+                                      << ", number of used slots is " << used_slots();
     decision_assigned = std::chrono::steady_clock::now();
     auto dispatch_successful = dispatch(assignment);
 


### PR DESCRIPTION
This PR has several changes

Several fragment size ranges were updated in the multi_output_file_test to take into account the larger readout window that is used in this test (compared to 3ru_3df*test, for example).

The calculation of the configured number of tokens was fixed in three integtests.  That seems to have become broken in the conversion to daqconf.json.

I added debug printout of the used_slots (count) in DataFlowOrchestrator.cpp.