### PR TITLE
Always set the FragmentType to kSW_TriggerPrimitive in the TPStreamWriter

### DIFF
--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -20,7 +20,7 @@ check_for_logfile_errors=True
 expected_event_count=run_duration
 expected_event_count_tolerance=2
 wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", 
-                           "fragment_type": "Unknown",
+                           "fragment_type": "ProtoWIB",
                            "hdf5_source_subsystem": "Detector_Readout",
                            "expected_fragment_count": number_of_data_producers,
                            "min_size_bytes": baseline_fragment_size_bytes, 

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -20,7 +20,7 @@ check_for_logfile_errors=True
 expected_event_count=run_duration
 expected_event_count_tolerance=2
 wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", 
-                           "fragment_type": "ProtoWIB",
+                           "fragment_type": "Unknown",
                            "hdf5_source_subsystem": "Detector_Readout",
                            "expected_fragment_count": number_of_data_producers,
                            "min_size_bytes": baseline_fragment_size_bytes, 

--- a/src/TPBundleHandler.cpp
+++ b/src/TPBundleHandler.cpp
@@ -96,11 +96,7 @@ TimeSliceAccumulator::get_timeslice()
     frag->set_window_end(m_end_time);
     frag->set_element_id(sourceid);
     frag->set_detector_id(static_cast<uint16_t>(detdataformats::DetID::Subdetector::kDAQ));
-    if (m_fw_tpg_enabled) {
-      frag->set_type(daqdataformats::FragmentType::kFW_TriggerPrimitive);
-    } else {
-      frag->set_type(daqdataformats::FragmentType::kSW_TriggerPrimitive);
-    }
+    frag->set_type(daqdataformats::FragmentType::kSW_TriggerPrimitive);
 
     size_t frag_payload_size = frag->get_size() - sizeof(dunedaq::daqdataformats::FragmentHeader);
     TLOG_DEBUG(21) << "In get_timeslice, Source ID is " << sourceid << ", number of pieces is " << list_of_pieces.size()


### PR DESCRIPTION
This branch has the minimal fix for Issue 231.

We can make more thorough changes to remove knowledge of the TP source from the TPStreamWriter code now (as part of v3.2.0) or later.  Let me know if we want that to be done as part of v3.2.0.  It will affect dfmodules and daqconf.

I haven't yet updated the "base" branch for this PR to be the v3.2.0 release-prep branch, but I can create the release-prep branch and update this PR, if that is desired.