### PR TITLE
Removed knowledge of FW TPs in the TPStreamWriter

### DIFF
--- a/plugins/TPStreamWriter.cpp
+++ b/plugins/TPStreamWriter.cpp
@@ -75,7 +75,6 @@ TPStreamWriter::do_conf(const data_t& payload)
   tpstreamwriter::ConfParams conf_params = payload.get<tpstreamwriter::ConfParams>();
   m_accumulation_interval_ticks = conf_params.tp_accumulation_interval_ticks;
   m_source_id = conf_params.source_id;
-  m_fw_tpg_enabled = conf_params.firmware_tpg_enabled;
 
   // create the DataStore instance here
   try {
@@ -156,7 +155,7 @@ TPStreamWriter::do_work(std::atomic<bool>& running_flag)
   daqdataformats::timestamp_t first_timestamp = 0;
   daqdataformats::timestamp_t last_timestamp = 0;
 
-  TPBundleHandler tp_bundle_handler(m_accumulation_interval_ticks, m_run_number, std::chrono::seconds(1), m_fw_tpg_enabled);
+  TPBundleHandler tp_bundle_handler(m_accumulation_interval_ticks, m_run_number, std::chrono::seconds(1));
 
   while (running_flag.load()) {
     trigger::TPSet tpset;

--- a/plugins/TPStreamWriter.hpp
+++ b/plugins/TPStreamWriter.hpp
@@ -61,7 +61,6 @@ private:
   size_t m_accumulation_interval_ticks;
   daqdataformats::run_number_t m_run_number;
   uint32_t m_source_id; // NOLINT(build/unsigned)
-  bool m_fw_tpg_enabled;
 
   // Queue sources and sinks
   using incoming_t = trigger::TPSet;

--- a/schema/dfmodules/tpstreamwriter.jsonnet
+++ b/schema/dfmodules/tpstreamwriter.jsonnet
@@ -9,15 +9,12 @@ local types = {
 
     sourceid_number : s.number("sourceid_number", "u4", doc="Source identifier"),
 
-    flag: s.boolean("Flag", doc="Parameter that can be used to enable or disable functionality"),
-
     conf: s.record("ConfParams", [
         s.field("tp_accumulation_interval_ticks", self.size, 50000000,
                 doc="Size of the TP accumulation window, measured in clock ticks"),
         s.field("data_store_parameters", self.dsparams,
                 doc="Parameters that configure the DataStore associated with this TPStreamWriter"),
         s.field("source_id", self.sourceid_number, 999, doc="Source ID of TPSW instance, added to time slice header"),
-        s.field("firmware_tpg_enabled", self.flag, 0, doc="Indicates whether firmware TP generation is enabled"),
     ], doc="TPStreamWriter configuration parameters"),
 
 };

--- a/src/TPBundleHandler.cpp
+++ b/src/TPBundleHandler.cpp
@@ -134,8 +134,7 @@ TPBundleHandler::add_tpset(trigger::TPSet&& tpset)
         TimeSliceAccumulator accum(tsidx * m_slice_interval,
                                    (tsidx + 1) * m_slice_interval,
                                    tsidx - m_slice_index_offset,
-                                   m_run_number,
-                                   m_fw_tpg_enabled);
+                                   m_run_number);
         m_timeslice_accumulators[tsidx] = accum;
       }
     }
@@ -150,8 +149,7 @@ TPBundleHandler::add_tpset(trigger::TPSet&& tpset)
       TimeSliceAccumulator accum(tsidx_from_begin_time * m_slice_interval,
                                  (tsidx_from_begin_time + 1) * m_slice_interval,
                                  tsidx_from_begin_time - m_slice_index_offset,
-                                 m_run_number,
-                                 m_fw_tpg_enabled);
+                                 m_run_number);
       m_timeslice_accumulators[tsidx_from_begin_time] = accum;
     }
   }

--- a/src/dfmodules/TPBundleHandler.hpp
+++ b/src/dfmodules/TPBundleHandler.hpp
@@ -46,13 +46,11 @@ public:
   TimeSliceAccumulator(daqdataformats::timestamp_t begin_time,
                        daqdataformats::timestamp_t end_time,
                        daqdataformats::timeslice_number_t slice_number,
-                       daqdataformats::run_number_t run_number,
-                       bool firmware_tpg_enabled)
+                       daqdataformats::run_number_t run_number)
     : m_begin_time(begin_time)
     , m_end_time(end_time)
     , m_slice_number(slice_number)
     , m_run_number(run_number)
-    , m_fw_tpg_enabled(firmware_tpg_enabled)
     , m_update_time(std::chrono::steady_clock::now())
   {}
 
@@ -66,7 +64,6 @@ public:
       m_end_time = other.m_end_time;
       m_slice_number = other.m_slice_number;
       m_run_number = other.m_run_number;
-      m_fw_tpg_enabled = other.m_fw_tpg_enabled;
       m_update_time = other.m_update_time;
       m_tpbundles_by_sourceid_and_start_time = other.m_tpbundles_by_sourceid_and_start_time;
     }
@@ -88,7 +85,6 @@ private:
   daqdataformats::timestamp_t m_end_time;
   daqdataformats::timeslice_number_t m_slice_number;
   daqdataformats::run_number_t m_run_number;
-  bool m_fw_tpg_enabled;
   std::chrono::steady_clock::time_point m_update_time;
   typedef std::map<daqdataformats::timestamp_t, trigger::TPSet> tpbundles_by_start_time_t;
   typedef std::map<daqdataformats::SourceID, tpbundles_by_start_time_t> bundles_by_sourceid_t;
@@ -101,12 +97,10 @@ class TPBundleHandler
 public:
   TPBundleHandler(daqdataformats::timestamp_t slice_interval,
                   daqdataformats::run_number_t run_number,
-                  std::chrono::steady_clock::duration cooling_off_time,
-                  bool firmware_tpg_enabled)
+                  std::chrono::steady_clock::duration cooling_off_time)
     : m_slice_interval(slice_interval)
     , m_run_number(run_number)
     , m_cooling_off_time(cooling_off_time)
-    , m_fw_tpg_enabled(firmware_tpg_enabled)
     , m_slice_index_offset(0)
   {}
 
@@ -123,7 +117,6 @@ private:
   daqdataformats::timestamp_t m_slice_interval;
   daqdataformats::run_number_t m_run_number;
   std::chrono::steady_clock::duration m_cooling_off_time;
-  bool m_fw_tpg_enabled;
   size_t m_slice_index_offset;
   std::map<daqdataformats::timestamp_t, TimeSliceAccumulator> m_timeslice_accumulators;
   mutable std::mutex m_accumulator_map_mutex;


### PR DESCRIPTION
since it should only write 'SW' TPs.

This is a more thorough fix for Issue #231.  It is for consideration **after** v3.2.0.  It will be coupled with a PR in the `daqconf` repo.

I created this branch from the v2.9.1 tag of the `dfmodules` repo so that I could get the advantage of the fixes that have been made in testing of the v3.2.0 release.  So, in comparisons with the `develop` branch, we will see the TPStreamWriter changes plus a couple more.