### PR TITLE
Updated integtest/minimal_system_quick_test.py to continue to work

### DIFF
--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -10,6 +10,9 @@ import integrationtest.config_file_gen as config_file_gen
 number_of_data_producers=2
 data_rate_slowdown_factor=10
 run_duration=20  # seconds
+readout_window_time_before=1000
+readout_window_time_after=1001
+clock_speed_hz=50000000
 
 # Default values for validation parameters
 expected_number_of_data_files=1
@@ -20,7 +23,7 @@ wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
                            "fragment_type": "ProtoWIB",
                            "hdf5_source_subsystem": "Detector_Readout",
                            "expected_fragment_count": number_of_data_producers,
-                           "min_size_bytes": 37192, "max_size_bytes": 37192}
+                           "min_size_bytes": 37656, "max_size_bytes": 37656}
 triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "fragment_type": "Trigger_Candidate",
                               "hdf5_source_subsystem": "Trigger",
@@ -52,6 +55,9 @@ try:
 except:
   conf_dict["boot"]["use_connectivity_service"] = False
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
+conf_dict["readout"]["clock_speed_hz"] = clock_speed_hz
+conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before
+conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
 
 confgen_arguments={"MinimalSystem": conf_dict}
 # The commands to run in nanorc, as a list


### PR DESCRIPTION
…after the changes in readoutlibs for better time window matching.

The changes here included increasing the expected WIB fragment size to include 81 frames (81 * 464 + 72 = 37656) and the minor tweak to the before/after request window times to try to ensure that we always get 81 frames no matter how the request windows line up with the WIB frame boundaries.  

2001 tick window / 25 clock ticks per frame = 80.04 frames, which results in 81 full frames being read out...