### PR TITLE
Modified the TRB code to save the reply conection name at INIT time

### DIFF
--- a/plugins/TriggerRecordBuilder.cpp
+++ b/plugins/TriggerRecordBuilder.cpp
@@ -81,6 +81,10 @@ TriggerRecordBuilder::init(const data_t& init_data)
     m_mon_receiver = iom->get_receiver<dfmessages::TRMonRequest>(ci["mon_connection"]);
   }
 
+  // save the data fragment receiver global connection name for later, when it gets
+  // copied into the DataRequests so that data producers know where to send their fragments
+  m_reply_connection = ci["data_fragment_all"];
+
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
 }
 
@@ -134,8 +138,6 @@ TriggerRecordBuilder::do_conf(const data_t& payload)
 
   TLOG() << get_name() << ": timeouts (ms): queue = " << m_queue_timeout.count() << ", loop = " << m_loop_sleep.count();
   m_max_time_window = parsed_conf.max_time_window;
-
-  m_reply_connection = parsed_conf.reply_connection_name;
 
   m_this_trb_source_id.subsystem = daqdataformats::SourceID::Subsystem::kTRBuilder;
   m_this_trb_source_id.id = parsed_conf.source_id;

--- a/schema/dfmodules/triggerrecordbuilder.jsonnet
+++ b/schema/dfmodules/triggerrecordbuilder.jsonnet
@@ -6,8 +6,6 @@ local types = {
     sourceid_number : s.number("sourceid_number", "u4",
                      doc="Source identifier"),
 
-    connection_id : s.string("connection_id", doc="Connection Name to be used with NetworkManager"),
-
     timeout: s.number( "Timeout", "u8", 
                        doc="Queue timeout in milliseconds" ),    
 
@@ -20,8 +18,6 @@ local types = {
                                            doc="Timeout for a TR to be sent incomplete. 0 means no timeout"),
                                    s.field("max_time_window", self.timestamp_diff, 0, 
                                            doc="Maximum time window size for Data requests. 0 means no slicing"),
-                                   s.field("reply_connection_name", self.connection_id, "nwmgr_test.frags_0",
-				   	   doc="" ),
                                    s.field("source_id", self.sourceid_number, doc="Source ID of TRB instance, added to trigger record header"),
                                   ] , 
                    doc="TriggerRecordBuilder configuration")


### PR DESCRIPTION
…and removed the reply_connection_name from the TRB config schema.

This is part of the easy fixes that we are doing as part of the ConnSvc consolidation.

This PR should be tested and review in conjunction with one in the daqconf repo.