### PR TITLE
Updated the allowed ProtoWIB fragment sizes in multi_output_file_test.py

### DIFF
--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -21,7 +21,7 @@ wib1_frag_hsi_trig_params={"fragment_type_description": "WIB",
                            "fragment_type": "ProtoWIB",
                            "hdf5_source_subsystem": "Detector_Readout",
                            "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
-                           "min_size_bytes": 37192, "max_size_bytes": 185960}
+                           "min_size_bytes": 37192, "max_size_bytes": 186136}
 wib1_frag_multi_trig_params={"fragment_type_description": "WIB",
                              "fragment_type": "ProtoWIB",
                              "hdf5_source_subsystem": "Detector_Readout",


### PR DESCRIPTION
There still seems to be a problem with trigger inhibits in these tests, but I'll look at those separately.