### PR TITLE
fixed the assignment of the token count in several integration tests

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -93,7 +93,7 @@ conf_dict["readout"]["default_data_file"] = "asset://?label=ProtoWIB&subsystem=r
 
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["enable_software_tpg"] = True
-swtpg_conf["dataflow"]["apps"][0]["token_count"] = max(10, 3*number_of_data_producers*number_of_readout_apps)
+swtpg_conf["dataflow"]["token_count"] = max(10, 3*number_of_data_producers*number_of_readout_apps)
 
 dqm_conf = copy.deepcopy(conf_dict)
 dqm_conf["dqm"]["enable_dqm"] = True

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -84,8 +84,7 @@ for df_app in range(number_of_dataflow_apps):
 
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["enable_software_tpg"] = True
-for df_app in range(number_of_dataflow_apps):
-    swtpg_conf["dataflow"]["apps"][df_app]["token_count"] = int(math.ceil(max(10, 3*number_of_data_producers*number_of_readout_apps)/number_of_dataflow_apps))
+swtpg_conf["dataflow"]["token_count"] = int(math.ceil(max(10, 3*number_of_data_producers*number_of_readout_apps)/number_of_dataflow_apps))
 
 dqm_conf = copy.deepcopy(conf_dict)
 dqm_conf["dqm"]["enable_dqm"] = True

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -85,6 +85,7 @@ conf_dict["trigger"]["trigger_rate_hz"] = trigger_rate
 conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before
 conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
 
+conf_dict["dataflow"]["token_count"] = token_count
 conf_dict["dataflow"]["apps"] = [] # Remove preconfigured dataflow0 app
 for df_app in range(number_of_dataflow_apps):
     dfapp_conf = {}

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -75,7 +75,7 @@ conf_dict["dataflow"]["apps"][0]["max_file_size"] = 1074000000
 
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["enable_software_tpg"] = True
-swtpg_conf["dataflow"]["apps"][0]["token_count"] = max(10, 3*number_of_data_producers*number_of_readout_apps)
+swtpg_conf["dataflow"]["token_count"] = max(10, 3*number_of_data_producers*number_of_readout_apps)
 
 confgen_arguments={"WIB1_System": conf_dict,
                    "Software_TPG_System": swtpg_conf,

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 import re
+import math
 import urllib.request
 
 import dfmodules.data_file_checks as data_file_checks

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -83,12 +83,12 @@ conf_dict["trigger"]["enable_tpset_writing"] = True
 conf_dict["trigger"]["tpset_output_path"] = output_dir
 conf_dict["readout"]["enable_software_tpg"] = True
 
+conf_dict["dataflow"]["token_count"] = 3*number_of_readout_apps
 conf_dict["dataflow"]["apps"] = [] # Remove preconfigured dataflow0 app
 for df_app in range(number_of_dataflow_apps):
     dfapp_conf = {}
     dfapp_conf["app_name"] = f"dataflow{df_app}"
     dfapp_conf["output_path"] = output_dir
-    dfapp_conf["token_count"] = 3*number_of_readout_apps
     conf_dict["dataflow"]["apps"].append(dfapp_conf)
 
 confgen_arguments={"Software_TPG_System": conf_dict                  }

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -83,7 +83,7 @@ conf_dict["trigger"]["enable_tpset_writing"] = True
 conf_dict["trigger"]["tpset_output_path"] = output_dir
 conf_dict["readout"]["enable_software_tpg"] = True
 
-conf_dict["dataflow"]["token_count"] = 3*number_of_readout_apps
+conf_dict["dataflow"]["token_count"] = int(math.ceil(max(10, 3*number_of_data_producers*number_of_readout_apps)/number_of_dataflow_apps))
 conf_dict["dataflow"]["apps"] = [] # Remove preconfigured dataflow0 app
 for df_app in range(number_of_dataflow_apps):
     dfapp_conf = {}

--- a/integtest/z.insufficient_disk_space_test.not_yet_working
+++ b/integtest/z.insufficient_disk_space_test.not_yet_working
@@ -80,6 +80,7 @@ conf_dict["trigger"]["trigger_rate_hz"] = trigger_rate
 conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before
 conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
 
+conf_dict["dataflow"]["token_count"] = token_count
 conf_dict["dataflow"]["apps"] = [] # Remove preconfigured dataflow0 app
 for df_app in range(number_of_dataflow_apps):
     dfapp_conf = {}

--- a/integtest/z.large_trigger_record_test.not_yet_working
+++ b/integtest/z.large_trigger_record_test.not_yet_working
@@ -62,6 +62,7 @@ conf_dict["trigger"]["trigger_rate_hz"] = trigger_rate
 conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before
 conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
 
+conf_dict["dataflow"]["token_count"] = token_count
 conf_dict["dataflow"]["apps"] = [] # Remove preconfigured dataflow0 app
 for df_app in range(number_of_dataflow_apps):
     dfapp_conf = {}


### PR DESCRIPTION
I recently noticed that the multi_output_file_test occasionally generates "trigger inhibit" warnings when running the SWTPG part of its testing.  As part of investigating this, I noticed that the token count that is being requested in the integtest script was not being taken into account.  The problem was that the location of the token_count parameter in the dataflow daqconf schema tree changed, but the integtests were not correspondingly updated  I fixed that problem and tweaked a couple of the token_count calculations.  With these changes, the multi_output_file_test integtest runs more reliably without trigger inhibit warnings.  To test these changes, I ran each of the 5 modified integtests from the develop branch and then from the kbiery/integtest_token_count_fix branch and compared the generated configurations under /tmp/pytest_of_<user>/pytest_N/jsonX and /tmp/pytest_of_<user>/pytest_N-1/jsonX to confirm that values for the DFO busy and free parameters were different from the default values (which were being used before the changes).