### PR TITLE
Draft integtests that may be useful for testing dunedaq-v4.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ Structs.hpp
 # integtest temporary files
 frames.bin
 wib2-frames.bin
-integtest/__pycache__
+__pycache__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(dfmodules VERSION 2.10.0)
+project(dfmodules VERSION 2.10.1)
 
 find_package(daq-cmake REQUIRED)
 daq_setup_environment()

--- a/integtest/drafts/new_3ru_3df_multirun_test.py
+++ b/integtest/drafts/new_3ru_3df_multirun_test.py
@@ -1,0 +1,151 @@
+import pytest
+import os
+import re
+import copy
+import math
+import urllib.request
+
+import dfmodules.data_file_checks as data_file_checks
+import integrationtest.log_file_checks as log_file_checks
+import integrationtest.config_file_gen as config_file_gen
+import dfmodules.integtest_file_gen as integtest_file_gen
+
+# Values that help determine the running conditions
+number_of_data_producers=2
+number_of_readout_apps=3
+number_of_dataflow_apps=3
+trigger_rate=3.0 # Hz
+run_duration=20  # seconds
+data_rate_slowdown_factor=10
+
+# Default values for validation parameters
+expected_number_of_data_files=3*number_of_dataflow_apps
+check_for_logfile_errors=True
+expected_event_count=run_duration*trigger_rate/number_of_dataflow_apps
+expected_event_count_tolerance=expected_event_count/10
+wib2_frag_hsi_trig_params={"fragment_type_description": "WIB", 
+                           "fragment_type": "WIB",
+                           "hdf5_source_subsystem": "Detector_Readout",
+                           "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
+                           "min_size_bytes": 29808, "max_size_bytes": 30280}
+wib2_frag_multi_trig_params={"fragment_type_description": "WIB",
+                             "fragment_type": "WIB",
+                             "hdf5_source_subsystem": "Detector_Readout",
+                             "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
+                             "min_size_bytes": 72, "max_size_bytes": 54000}
+triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
+                              "fragment_type": "Trigger_Candidate",
+                              "hdf5_source_subsystem": "Trigger",
+                              "expected_fragment_count": 1,
+                              "min_size_bytes": 72, "max_size_bytes": 280}
+triggeractivity_frag_params={"fragment_type_description": "Trigger Activity",
+                              "fragment_type": "Trigger_Activity",
+                              "hdf5_source_subsystem": "Trigger",
+                              "expected_fragment_count": number_of_readout_apps,
+                              "min_size_bytes": 72, "max_size_bytes": 400}
+triggertp_frag_params={"fragment_type_description": "Trigger with TPs",
+                       "fragment_type": "Trigger_Primitive",
+                       "hdf5_source_subsystem": "Trigger",
+                       "expected_fragment_count": ((number_of_data_producers*number_of_readout_apps)),
+                       "min_size_bytes": 72, "max_size_bytes": 16000}
+hsi_frag_params ={"fragment_type_description": "HSI",
+                             "fragment_type": "Hardware_Signal",
+                             "hdf5_source_subsystem": "HW_Signals_Interface",
+                             "expected_fragment_count": 1,
+                             "min_size_bytes": 72, "max_size_bytes": 100}
+ignored_logfile_problems={"dqm": ["client will not be able to connect to Kafka cluster"]}
+
+# The next three variable declarations *must* be present as globals in the test
+# file. They're read by the "fixtures" in conftest.py to determine how
+# to run the config generation and nanorc
+
+# The name of the python module for the config generation
+confgen_name="daqconf_multiru_gen"
+# The arguments to pass to the config generator, excluding the json
+# output directory (the test framework handles that)
+hardware_map_contents = integtest_file_gen.generate_hwmap_file(number_of_data_producers, number_of_readout_apps)
+
+conf_dict = config_file_gen.get_default_config_dict()
+conf_dict["boot"]["use_connectivity_service"] = True
+conf_dict["boot"]["start_connectivity_service"] = True
+conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
+conf_dict["readout"]["latency_buffer_size"] = 200000
+conf_dict["readout"]["clock_speed_hz"] = 62500000
+conf_dict["readout"]["default_data_file"] = "asset://?checksum=e2f7a4d6ae354c2d6529c190ec8335f3"
+conf_dict["trigger"]["trigger_rate_hz"] = trigger_rate
+conf_dict["trigger"]["trigger_window_before_ticks"] = 1000
+conf_dict["trigger"]["trigger_window_after_ticks"] = 1000
+
+conf_dict["dataflow"]["apps"] = [] # Remove preconfigured dataflow0 app
+for df_app in range(number_of_dataflow_apps):
+    dfapp_conf = {}
+    dfapp_conf["app_name"] = f"dataflow{df_app}"
+    conf_dict["dataflow"]["apps"].append(dfapp_conf)
+
+swtpg_conf = copy.deepcopy(conf_dict)
+swtpg_conf["readout"]["enable_software_tpg"] = True
+swtpg_conf["readout"]["software_tpg_threshold"] = 150
+swtpg_conf["dataflow"]["token_count"] = int(math.ceil(max(10, 3*number_of_data_producers*number_of_readout_apps)/number_of_dataflow_apps))
+
+dqm_conf = copy.deepcopy(conf_dict)
+dqm_conf["dqm"]["enable_dqm"] = True
+
+confgen_arguments={"WIB2_System": conf_dict,
+                   "Software_TPG_System": swtpg_conf,
+                   "DQM_System": dqm_conf,
+                  }
+# The commands to run in nanorc, as a list
+nanorc_command_list="integtest-partition boot conf".split()
+nanorc_command_list+="start 101 enable_triggers wait ".split() + [str(run_duration)] + "stop_run wait 2".split()
+nanorc_command_list+="start 102 wait 1 enable_triggers wait ".split() + [str(run_duration)] + "disable_triggers wait 1 stop_run".split()
+nanorc_command_list+="start_run 103 wait ".split() + [str(run_duration)] + "disable_triggers wait 1 drain_dataflow wait 1 stop_trigger_sources wait 1 stop wait 2".split()
+nanorc_command_list+="shutdown".split()
+
+# The tests themselves
+
+def test_nanorc_success(run_nanorc):
+    current_test=os.environ.get('PYTEST_CURRENT_TEST')
+    match_obj = re.search(r".*\[(.+)\].*", current_test)
+    if match_obj:
+        current_test = match_obj.group(1)
+    banner_line = re.sub(".", "=", current_test)
+    print(banner_line)
+    print(current_test)
+    print(banner_line)
+    # Check that nanorc completed correctly
+    assert run_nanorc.completed_process.returncode==0
+
+def test_log_files(run_nanorc):
+    if check_for_logfile_errors:
+        # Check that there are no warnings or errors in the log files
+        assert log_file_checks.logs_are_error_free(run_nanorc.log_files, True, True, ignored_logfile_problems)
+
+def test_data_files(run_nanorc):
+    local_expected_event_count=expected_event_count
+    local_event_count_tolerance=expected_event_count_tolerance
+    low_number_of_files=expected_number_of_data_files
+    high_number_of_files=expected_number_of_data_files
+    fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
+    if "enable_software_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_software_tpg"]:
+        local_expected_event_count+=(265*number_of_data_producers*number_of_readout_apps*run_duration/(100*number_of_dataflow_apps))
+        local_event_count_tolerance+=(10*number_of_data_producers*number_of_readout_apps*run_duration/(100*number_of_dataflow_apps))
+        fragment_check_list.append(wib2_frag_multi_trig_params)
+        fragment_check_list.append(triggertp_frag_params)
+        fragment_check_list.append(triggeractivity_frag_params)
+    else:
+        low_number_of_files-=number_of_dataflow_apps
+        if low_number_of_files < 1:
+            low_number_of_files=1
+        fragment_check_list.append(wib2_frag_hsi_trig_params)
+
+    # Run some tests on the output data file
+    assert len(run_nanorc.data_files)==high_number_of_files or len(run_nanorc.data_files)==low_number_of_files
+
+    for idx in range(len(run_nanorc.data_files)):
+        data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
+        assert data_file_checks.sanity_check(data_file)
+        assert data_file_checks.check_file_attributes(data_file)
+        assert data_file_checks.check_event_count(data_file, local_expected_event_count, local_event_count_tolerance)
+        for jdx in range(len(fragment_check_list)):
+            assert data_file_checks.check_fragment_count(data_file, fragment_check_list[jdx])
+            assert data_file_checks.check_fragment_sizes(data_file, fragment_check_list[jdx])

--- a/integtest/drafts/new_minimal_system_quick_test.py
+++ b/integtest/drafts/new_minimal_system_quick_test.py
@@ -1,0 +1,90 @@
+import pytest
+import urllib.request
+
+import dfmodules.data_file_checks as data_file_checks
+import dfmodules.integtest_file_gen as integtest_file_gen
+import integrationtest.log_file_checks as log_file_checks
+import integrationtest.config_file_gen as config_file_gen
+
+# Values that help determine the running conditions
+number_of_data_producers=2
+data_rate_slowdown_factor=10
+run_duration=20  # seconds
+readout_window_time_before=1000
+readout_window_time_after=1001
+clock_speed_hz=50000000
+
+# Default values for validation parameters
+expected_number_of_data_files=1
+check_for_logfile_errors=True
+expected_event_count=run_duration
+expected_event_count_tolerance=2
+wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", 
+                           "fragment_type": "ProtoWIB",
+                           "hdf5_source_subsystem": "Detector_Readout",
+                           "expected_fragment_count": number_of_data_producers,
+                           "min_size_bytes": 37656, "max_size_bytes": 37656}
+triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
+                              "fragment_type": "Trigger_Candidate",
+                              "hdf5_source_subsystem": "Trigger",
+                              "expected_fragment_count": 1,
+                              "min_size_bytes": 72, "max_size_bytes": 216}
+hsi_frag_params ={"fragment_type_description": "HSI",
+                             "fragment_type": "Hardware_Signal",
+                             "hdf5_source_subsystem": "HW_Signals_Interface",
+                             "expected_fragment_count": 1,
+                             "min_size_bytes": 72, "max_size_bytes": 100}
+ignored_logfile_problems={"connectionservice": ["Searching for connections matching uid_regex<errored_frames_q> and data_type Unknown"]}
+
+# The next three variable declarations *must* be present as globals in the test
+# file. They're read by the "fixtures" in conftest.py to determine how
+# to run the config generation and nanorc
+
+# The name of the python module for the config generation
+confgen_name="daqconf_multiru_gen"
+# The arguments to pass to the config generator, excluding the json
+# output directory (the test framework handles that)
+
+hardware_map_contents = integtest_file_gen.generate_hwmap_file( number_of_data_producers)
+
+conf_dict = config_file_gen.get_default_config_dict()
+conf_dict["boot"]["op_env"] = "integtest"
+conf_dict["boot"]["use_connectivity_service"] = True
+conf_dict["boot"]["start_connectivity_service"] = True
+conf_dict["boot"]["connectivity_service_port"] = 12345   # just to try something other than the default...
+conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
+conf_dict["readout"]["default_data_file"] = "asset://?label=ProtoWIB&subsystem=readout"
+conf_dict["readout"]["clock_speed_hz"] = clock_speed_hz
+conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before
+conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
+
+confgen_arguments={"MinimalSystem": conf_dict}
+# The commands to run in nanorc, as a list
+nanorc_command_list="integtest-partition boot conf start 101 wait 1 enable_triggers wait ".split() + [str(run_duration)] + "disable_triggers wait 2 stop_run wait 2 scrap terminate".split()
+
+# The tests themselves
+
+def test_nanorc_success(run_nanorc):
+    # Check that nanorc completed correctly
+    assert run_nanorc.completed_process.returncode==0
+
+def test_log_files(run_nanorc):
+    if check_for_logfile_errors:
+        # Check that there are no warnings or errors in the log files
+        assert log_file_checks.logs_are_error_free(run_nanorc.log_files, True, True, ignored_logfile_problems)
+
+def test_data_files(run_nanorc):
+    # Run some tests on the output data file
+    assert len(run_nanorc.data_files)==expected_number_of_data_files
+
+    fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
+    fragment_check_list.append(wib1_frag_hsi_trig_params)
+
+    for idx in range(len(run_nanorc.data_files)):
+        data_file=data_file_checks.DataFile(run_nanorc.data_files[idx])
+        assert data_file_checks.sanity_check(data_file)
+        assert data_file_checks.check_file_attributes(data_file)
+        assert data_file_checks.check_event_count(data_file, expected_event_count, expected_event_count_tolerance)
+        for jdx in range(len(fragment_check_list)):
+            assert data_file_checks.check_fragment_count(data_file, fragment_check_list[jdx])
+            assert data_file_checks.check_fragment_sizes(data_file, fragment_check_list[jdx])


### PR DESCRIPTION
…but are primarily targeted for v4.1.0.

My current thought is that we should keep the existing dfmodules/integtests unchanged at this point in time, since we are already in the testing phase of the v4.0.0 software release.  However, there are tests that have been shown to be useful *and* are in line with changes that we want to make early in the v4.1.0 development cycle, so my idea is to contribute them to a "drafts" subdirectory under the "dfmodules/integtest" directory.

The new version of the minimal_system_quick_test always uses the Connectivity Service.  This test can already be run successfully.

The new version of the 3ru_3df_multirun_test uses DUNE-WIB emulated data instead of ProtoWIB data, always uses the ConnectivityService, and selects a specific DuneWIB frames.bin file using its checksum so that we can reliably know the number of expected TriggerRecords when SWTPG is enabled and the software_tpg_threshold is set to 150.  This test currently fails because of warning messages in the logfiles during the SWTPG part of the test.  The fix for those warnings is a one-line change in the fdreadoutlibs repo, so we hope that we can have this new integtest running successfully soon.