### PR TITLE
FD/ND split of detdataformats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(dfmessages REQUIRED)
 find_package(opmonlib REQUIRED)
 find_package(iomanager REQUIRED)
 find_package(detdataformats REQUIRED)
+find_package(trgdataformats REQUIRED)
 find_package(detchannelmaps REQUIRED)
 
 # JCF, Dec-1-2021: removed timinglibs
@@ -27,7 +28,7 @@ daq_codegen( info/*.jsonnet DEP_PKGS opmonlib TEMPLATES opmonlib/InfoStructs.hpp
 ##############################################################################
 daq_add_library( TriggerInhibitAgent.cpp TriggerRecordBuilderData.cpp TPBundleHandler.cpp
                  LINK_LIBRARIES 
-                 opmonlib::opmonlib ers::ers HighFive appfwk::appfwk logging::logging stdc++fs dfmessages::dfmessages utilities::utilities trigger::trigger detdataformats::detdataformats)
+                 opmonlib::opmonlib ers::ers HighFive appfwk::appfwk logging::logging stdc++fs dfmessages::dfmessages utilities::utilities trigger::trigger detdataformats::detdataformats trgdataformats::trgdataformats)
 
 daq_add_plugin( HDF5DataStore      duneDataStore LINK_LIBRARIES logging::logging daqdataformats::daqdataformats hdf5libs::hdf5libs appfwk::appfwk stdc++fs)
 

--- a/cmake/dfmodulesConfig.cmake.in
+++ b/cmake/dfmodulesConfig.cmake.in
@@ -20,6 +20,7 @@ find_dependency(serialization)
 find_dependency(readoutlibs)
 find_dependency(hdf5libs)
 find_dependency(detchannelmaps)
+find_dependency(trgchannelmaps)
 find_dependency(Boost COMPONENTS iostreams)
 
 

--- a/src/TPBundleHandler.cpp
+++ b/src/TPBundleHandler.cpp
@@ -89,7 +89,7 @@ TimeSliceAccumulator::get_timeslice()
     std::vector<std::pair<void*, size_t>> list_of_pieces;
     for (auto& [start_time, tpset] : bundle_map) {
       list_of_pieces.push_back(std::make_pair<void*, size_t>(
-        &tpset.objects[0], tpset.objects.size() * sizeof(detdataformats::trigger::TriggerPrimitive)));
+        &tpset.objects[0], tpset.objects.size() * sizeof(trgdataformats::TriggerPrimitive)));
     }
     std::unique_ptr<daqdataformats::Fragment> frag(new daqdataformats::Fragment(list_of_pieces));
 
@@ -104,7 +104,7 @@ TimeSliceAccumulator::get_timeslice()
     size_t frag_payload_size = frag->get_size() - sizeof(dunedaq::daqdataformats::FragmentHeader);
     TLOG_DEBUG(21) << "In get_timeslice, Source ID is " << sourceid << ", number of pieces is " << list_of_pieces.size()
                    << ", size of Fragment payload is " << frag_payload_size << ", size of TP is "
-                   << sizeof(detdataformats::trigger::TriggerPrimitive);
+                   << sizeof(trgdataformats::TriggerPrimitive);
 
     list_of_fragments.push_back(std::move(frag));
   }

--- a/src/dfmodules/TPBundleHandler.hpp
+++ b/src/dfmodules/TPBundleHandler.hpp
@@ -14,7 +14,7 @@
 
 #include "daqdataformats/TimeSlice.hpp"
 #include "daqdataformats/Types.hpp"
-#include "detdataformats/trigger/TriggerPrimitive.hpp"
+#include "trgdataformats/TriggerPrimitive.hpp"
 #include "ers/Issue.hpp"
 #include "trigger/TPSet.hpp"
 


### PR DESCRIPTION
As the first step of the FD/ND release split, `detdataformats` is split into several new packages:
1. `fddetdataformats`
2. `nddetdataformats`
3. `trgdataformats`

The split involves relocation of headers, rename of namespaces, and updates to C
MakeLists.txt and config.cmake.in

This PR contains the necessary changes as a result of the split.

