### PR TITLE
Changed clock frequency defaults to 62.5 MHz

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -87,6 +87,7 @@ try:
   conf_dict["boot"]["use_connectivity_service"] = True
 except:
   conf_dict["boot"]["use_connectivity_service"] = False
+conf_dict["readout"]["clock_speed_hz"] = 50000000
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["latency_buffer_size"] = 200000
 conf_dict["readout"]["default_data_file"] = "asset://?label=ProtoWIB&subsystem=readout"

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -71,6 +71,7 @@ try:
   conf_dict["boot"]["use_connectivity_service"] = True
 except:
   conf_dict["boot"]["use_connectivity_service"] = False
+conf_dict["readout"]["clock_speed_hz"] = 50000000
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["latency_buffer_size"] = 200000
 conf_dict["readout"]["default_data_file"] = "asset://?label=ProtoWIB&subsystem=readout"

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -49,6 +49,7 @@ try:
   conf_dict["boot"]["use_connectivity_service"] = True
 except:
   conf_dict["boot"]["use_connectivity_service"] = False
+conf_dict["readout"]["clock_speed_hz"] = 50000000
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["use_fake_data_producers"] = True
 conf_dict["readout"]["default_data_file"] = "asset://?label=ProtoWIB&subsystem=readout"

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -65,6 +65,7 @@ try:
   conf_dict["boot"]["use_connectivity_service"] = True
 except:
   conf_dict["boot"]["use_connectivity_service"] = False
+conf_dict["readout"]["clock_speed_hz"] = 50000000
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["latency_buffer_size"] = 200000
 conf_dict["readout"]["default_data_file"] = "asset://?label=ProtoWIB&subsystem=readout"

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -76,6 +76,7 @@ try:
   conf_dict["boot"]["use_connectivity_service"] = True
 except:
   conf_dict["boot"]["use_connectivity_service"] = False
+conf_dict["readout"]["clock_speed_hz"] = 50000000
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["latency_buffer_size"] = 200000
 conf_dict["readout"]["default_data_file"] = "asset://?label=ProtoWIB&subsystem=readout"

--- a/python/dfmodules/testapp_noreadout_confgen.py
+++ b/python/dfmodules/testapp_noreadout_confgen.py
@@ -38,7 +38,7 @@ import math
 # Time to waait on pop()
 QUEUE_POP_WAIT_MS=100;
 # local clock speed Hz
-CLOCK_SPEED_HZ = 50000000;
+CLOCK_SPEED_HZ = 62500000;
 
 def generate(
         NUMBER_OF_DATA_PRODUCERS=2,          

--- a/python/dfmodules/testapp_noreadout_networkqueue_confgen.py
+++ b/python/dfmodules/testapp_noreadout_networkqueue_confgen.py
@@ -57,7 +57,7 @@ from pprint import pprint
 # Time to waait on pop()
 QUEUE_POP_WAIT_MS=100;
 # local clock speed Hz
-CLOCK_SPEED_HZ = 50000000;
+CLOCK_SPEED_HZ = 62500000;
 
 # Checklist for replacing a queue with a qton/ntoq pair:
 

--- a/python/dfmodules/testapp_noreadout_two_process.py
+++ b/python/dfmodules/testapp_noreadout_two_process.py
@@ -60,7 +60,7 @@ from pprint import pprint
 # Time to wait on pop()
 QUEUE_POP_WAIT_MS=100;
 # local clock speed Hz
-CLOCK_SPEED_HZ = 50000000;
+CLOCK_SPEED_HZ = 62500000;
 
 
 def generate_df(

--- a/python/dfmodules/tpset_demo/tpset_producer_gen.py
+++ b/python/dfmodules/tpset_demo/tpset_producer_gen.py
@@ -41,7 +41,7 @@ def generate(
     cmd_data = {}
 
     # Derived parameters
-    CLOCK_FREQUENCY_HZ = 50000000 / SLOWDOWN_FACTOR
+    CLOCK_FREQUENCY_HZ = 62500000 / SLOWDOWN_FACTOR
 
     # Define modules and queues
     queue_specs = [

--- a/schema/dfmodules/tpstreamwriter.jsonnet
+++ b/schema/dfmodules/tpstreamwriter.jsonnet
@@ -10,7 +10,7 @@ local types = {
     sourceid_number : s.number("sourceid_number", "u4", doc="Source identifier"),
 
     conf: s.record("ConfParams", [
-        s.field("tp_accumulation_interval_ticks", self.size, 50000000,
+        s.field("tp_accumulation_interval_ticks", self.size, 62500000,
                 doc="Size of the TP accumulation window, measured in clock ticks"),
         s.field("data_store_parameters", self.dsparams,
                 doc="Parameters that configure the DataStore associated with this TPStreamWriter"),


### PR DESCRIPTION
and explicitly specified 50 MHz in various integtests, as appropriate.

The full set of repositories that are affected by this change is contained in the following list

```
git clone https://github.com/DUNE-DAQ/daqconf.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/dfmodules.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/dqm.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/flxlibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/hdf5libs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/hsilibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/listrev.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/readoutmodules.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/timinglibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/trigger.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/triggeralgs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/wibmod.git -b kbiery/62.5MHz_defaults
```

Recall that this first step in the deprecation of legacy hardware is simply switching to a default clock frequency of 62.5 MHz in our scripts, etc.  More changes will come later.