### PR TITLE
Integration test updates for DRO maps and other recent changes

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -99,17 +99,15 @@ confgen_name="daqconf_multiru_gen"
 
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-hardware_map_contents = integtest_file_gen.generate_hwmap_file(number_of_data_producers, number_of_readout_apps)
+dro_map_contents = integtest_file_gen.generate_dromap_file(number_of_data_producers, number_of_readout_apps)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["latency_buffer_size"] = 200000
-#conf_dict["readout"]["default_data_file"] = "asset://?label=ProtoWIB&subsystem=readout" # ProtoWIB
 #conf_dict["readout"]["default_data_file"] = "asset://?label=DuneWIB&subsystem=readout" # DuneWIB
 conf_dict["readout"]["default_data_file"] = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e" # WIBEth
-#conf_dict["readout"]["clock_speed_hz"] = 50000000 # ProtoWIB
 conf_dict["readout"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
-conf_dict["readout"]["eth_mode"] = True # WIBEth
+conf_dict["readout"]["use_fake_cards"] = True
 
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["enable_software_tpg"] = True

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -99,7 +99,7 @@ confgen_name="daqconf_multiru_gen"
 
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-dro_map_contents = integtest_file_gen.generate_dromap_file(number_of_data_producers, number_of_readout_apps)
+dro_map_contents = integtest_file_gen.generate_dromap_contents(number_of_data_producers, number_of_readout_apps)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -73,7 +73,7 @@ ignored_logfile_problems={"dqm": ["client will not be able to connect to Kafka c
 confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-hardware_map_contents = integtest_file_gen.generate_hwmap_file(number_of_data_producers, number_of_readout_apps)
+dro_map_contents = integtest_file_gen.generate_dromap_file(number_of_data_producers, number_of_readout_apps)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
@@ -81,7 +81,7 @@ conf_dict["readout"]["latency_buffer_size"] = 200000
 #conf_dict["readout"]["default_data_file"] = "asset://?label=DuneWIB&subsystem=readout" # DuneWIB
 conf_dict["readout"]["default_data_file"] = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e" # WIBEth
 conf_dict["readout"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
-conf_dict["readout"]["eth_mode"] = True # WIBEth
+conf_dict["readout"]["use_fake_cards"] = True
 conf_dict["trigger"]["trigger_rate_hz"] = trigger_rate
 conf_dict["trigger"]["trigger_window_before_ticks"] = 1000
 conf_dict["trigger"]["trigger_window_after_ticks"] = 1000

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -73,7 +73,7 @@ ignored_logfile_problems={"dqm": ["client will not be able to connect to Kafka c
 confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-dro_map_contents = integtest_file_gen.generate_dromap_file(number_of_data_producers, number_of_readout_apps)
+dro_map_contents = integtest_file_gen.generate_dromap_contents(number_of_data_producers, number_of_readout_apps)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -81,17 +81,15 @@ ignored_logfile_problems={}
 confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-hardware_map_contents = integtest_file_gen.generate_hwmap_file(number_of_data_producers)
+dro_map_contents = integtest_file_gen.generate_dromap_file(number_of_data_producers)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["latency_buffer_size"] = 200000
-#conf_dict["readout"]["default_data_file"] = "asset://?label=ProtoWIB&subsystem=readout" # ProtoWIB
 #conf_dict["readout"]["default_data_file"] = "asset://?label=DuneWIB&subsystem=readout" # DuneWIB
 conf_dict["readout"]["default_data_file"] = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e" # WIBEth
-#conf_dict["readout"]["clock_speed_hz"] = 50000000 # ProtoWIB
 conf_dict["readout"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
-conf_dict["readout"]["eth_mode"] = True # WIBEth
+conf_dict["readout"]["use_fake_cards"] = True
 conf_dict["trigger"]["trigger_rate_hz"] = 1.0
 conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before
 conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -81,7 +81,7 @@ ignored_logfile_problems={}
 confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-dro_map_contents = integtest_file_gen.generate_dromap_file(number_of_data_producers)
+dro_map_contents = integtest_file_gen.generate_dromap_contents(number_of_data_producers)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -54,7 +54,7 @@ ignored_logfile_problems={}
 confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-dro_map_contents = integtest_file_gen.generate_dromap_file(number_of_data_producers)
+dro_map_contents = integtest_file_gen.generate_dromap_contents(number_of_data_producers)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -54,14 +54,14 @@ ignored_logfile_problems={}
 confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-hardware_map_contents = integtest_file_gen.generate_hwmap_file(number_of_data_producers)
+dro_map_contents = integtest_file_gen.generate_dromap_file(number_of_data_producers)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["use_fake_data_producers"] = True
 #conf_dict["readout"]["clock_speed_hz"] = 50000000 # ProtoWIB
 conf_dict["readout"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
-conf_dict["readout"]["eth_mode"] = True # WIBEth
+conf_dict["readout"]["use_fake_cards"] = True
 conf_dict["trigger"]["trigger_window_before_ticks"] = 1000
 conf_dict["trigger"]["trigger_window_after_ticks"] = 1001
 

--- a/integtest/large_trigger_record_test.py
+++ b/integtest/large_trigger_record_test.py
@@ -25,6 +25,8 @@ token_count=1
 readout_window_time_before=10000000
 readout_window_time_after=1000000
 data_rate_slowdown_factor=1
+minimum_total_disk_space_gb=32  # double what we need
+minimum_free_disk_space_gb=24   # 50% more than what we need
 
 # Default values for validation parameters
 expected_number_of_data_files=4
@@ -53,6 +55,18 @@ hsi_frag_params ={"fragment_type_description": "HSI",
                              "min_size_bytes": 72, "max_size_bytes": 100}
 ignored_logfile_problems={}
 
+# Determine if the conditions are right for these tests
+sufficient_disk_space=True
+actual_output_path=output_path_parameter
+if output_path_parameter == ".":
+    actual_output_path="/tmp"
+disk_space=shutil.disk_usage(actual_output_path)
+total_disk_space_gb=(disk_space.total/(1024*1024*1024))
+free_disk_space_gb=(disk_space.free/(1024*1024*1024))
+print(f"DEBUG: Space on disk for output path {actual_output_path}: total = {total_disk_space_gb} GB and free = {free_disk_space_gb} GB.")
+if total_disk_space_gb < minimum_total_disk_space_gb or free_disk_space_gb < minimum_free_disk_space_gb:
+    sufficient_disk_space=False
+
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
 # to run the config generation and nanorc
@@ -61,13 +75,13 @@ ignored_logfile_problems={}
 confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-hardware_map_contents = integtest_file_gen.generate_hwmap_file(number_of_data_producers, number_of_readout_apps)
+dro_map_contents = integtest_file_gen.generate_dromap_contents(number_of_data_producers, number_of_readout_apps)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["use_fake_data_producers"] = True
 conf_dict["readout"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
-conf_dict["readout"]["eth_mode"] = True # WIBEth
+conf_dict["readout"]["use_fake_cards"] = True
 conf_dict["trigger"]["trigger_rate_hz"] = trigger_rate
 conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before
 conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
@@ -87,14 +101,20 @@ confgen_arguments={"TRSize_55PercentOfMaxFileSize": conf_dict,
                    "TRSize_125PercentOfMaxFileSize": oversize_conf,
                   }
 # The commands to run in nanorc, as a list
-nanorc_command_list="integtest-partition boot conf".split()
-nanorc_command_list+="start_run --wait 10 101 wait ".split() + [str(run_duration)] + "stop_run --wait 2 wait 2".split()
-nanorc_command_list+="start 102 wait 10 enable_triggers wait ".split() + [str(run_duration)] + "stop_run wait 2".split()
-nanorc_command_list+="scrap terminate".split()
+if sufficient_disk_space and sufficient_resources_on_this_computer:
+    nanorc_command_list="integtest-partition boot conf".split()
+    nanorc_command_list+="start_run --wait 10 101 wait ".split() + [str(run_duration)] + "stop_run --wait 2 wait 2".split()
+    nanorc_command_list+="start 102 wait 10 enable_triggers wait ".split() + [str(run_duration)] + "stop_run wait 2".split()
+    nanorc_command_list+="scrap terminate".split()
+else:
+    nanorc_command_list=["integtest-partition", "boot", "terminate"]
 
 # The tests themselves
 
 def test_nanorc_success(run_nanorc):
+    if not sufficient_disk_space:
+        pytest.skip(f"The raw data output path ({actual_output_path}) does not have enough space to run this test.")
+
     current_test=os.environ.get('PYTEST_CURRENT_TEST')
     match_obj = re.search(r".*\[(.+)\].*", current_test)
     if match_obj:
@@ -107,11 +127,20 @@ def test_nanorc_success(run_nanorc):
     assert run_nanorc.completed_process.returncode==0
 
 def test_log_files(run_nanorc):
+    if not sufficient_disk_space:
+        pytest.skip(f"The raw data output path ({actual_output_path}) does not have enough space to run this test.")
+
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(run_nanorc.log_files, True, True, ignored_logfile_problems)
 
 def test_data_files(run_nanorc):
+    if not sufficient_disk_space:
+        print(f"The raw data output path ({actual_output_path}) does not have enough space to run this test.")
+        print(f"    (Free and total space are {free_disk_space_gb} GB and {total_disk_space_gb} GB.)")
+        print(f"    (Minimums are {minimum_free_disk_space_gb} GB and {minimum_total_disk_space_gb} GB.)")
+        pytest.skip(f"The raw data output path ({actual_output_path}) does not have enough space to run this test.")
+
     local_expected_event_count=expected_event_count
     local_event_count_tolerance=expected_event_count_tolerance
     fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
@@ -133,6 +162,9 @@ def test_data_files(run_nanorc):
             assert data_file_checks.check_fragment_sizes(data_file, fragment_check_list[jdx])
 
 def test_cleanup(run_nanorc):
+    if not sufficient_disk_space:
+        pytest.skip(f"The raw data output path ({actual_output_path}) does not have enough space to run this test.")
+
     pathlist_string=""
     filelist_string=""
     for data_file in run_nanorc.data_files:

--- a/integtest/large_trigger_record_test.py
+++ b/integtest/large_trigger_record_test.py
@@ -9,6 +9,7 @@ import os
 import re
 import urllib.request
 import copy
+import shutil
 
 import dfmodules.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
@@ -16,6 +17,7 @@ import integrationtest.config_file_gen as config_file_gen
 import dfmodules.integtest_file_gen as integtest_file_gen
 
 # Values that help determine the running conditions
+output_path_parameter="."
 number_of_data_producers=10
 run_duration=32  # seconds
 number_of_readout_apps=3
@@ -25,8 +27,8 @@ token_count=1
 readout_window_time_before=10000000
 readout_window_time_after=1000000
 data_rate_slowdown_factor=1
-minimum_total_disk_space_gb=32  # double what we need
-minimum_free_disk_space_gb=24   # 50% more than what we need
+minimum_total_disk_space_gb=33  # 50% more than what we need
+minimum_free_disk_space_gb=28   # 25% more than what we need
 
 # Default values for validation parameters
 expected_number_of_data_files=4
@@ -92,6 +94,7 @@ for df_app in range(number_of_dataflow_apps):
     dfapp_conf = {}
     dfapp_conf["app_name"] = f"dataflow{df_app}"
     dfapp_conf["max_file_size"] = 2*1024*1024*1024
+    dfapp_conf["output_paths"] = [ output_path_parameter ]
     conf_dict["dataflow"]["apps"].append(dfapp_conf)
 
 oversize_conf = copy.deepcopy(conf_dict)
@@ -101,7 +104,7 @@ confgen_arguments={"TRSize_55PercentOfMaxFileSize": conf_dict,
                    "TRSize_125PercentOfMaxFileSize": oversize_conf,
                   }
 # The commands to run in nanorc, as a list
-if sufficient_disk_space and sufficient_resources_on_this_computer:
+if sufficient_disk_space:
     nanorc_command_list="integtest-partition boot conf".split()
     nanorc_command_list+="start_run --wait 10 101 wait ".split() + [str(run_duration)] + "stop_run --wait 2 wait 2".split()
     nanorc_command_list+="start 102 wait 10 enable_triggers wait ".split() + [str(run_duration)] + "stop_run wait 2".split()

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -90,7 +90,7 @@ if cpu_count < minimum_cpu_count or free_mem < minimum_free_memory_gb:
 confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-dro_map_contents = integtest_file_gen.generate_dromap_file(number_of_data_producers, number_of_readout_apps)
+dro_map_contents = integtest_file_gen.generate_dromap_contents(number_of_data_producers, number_of_readout_apps)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -90,17 +90,15 @@ if cpu_count < minimum_cpu_count or free_mem < minimum_free_memory_gb:
 confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-hardware_map_contents = integtest_file_gen.generate_hwmap_file(number_of_data_producers, number_of_readout_apps)
+dro_map_contents = integtest_file_gen.generate_dromap_file(number_of_data_producers, number_of_readout_apps)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["latency_buffer_size"] = latency_buffer_size
-#conf_dict["readout"]["default_data_file"] = "asset://?label=ProtoWIB&subsystem=readout" # ProtoWIB
 #conf_dict["readout"]["default_data_file"] = "asset://?label=DuneWIB&subsystem=readout" # DuneWIB
 conf_dict["readout"]["default_data_file"] = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e" # WIBEth
-#conf_dict["readout"]["clock_speed_hz"] = 50000000 # ProtoWIB
 conf_dict["readout"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
-conf_dict["readout"]["eth_mode"] = True # WIBEth
+conf_dict["readout"]["use_fake_cards"] = True
 conf_dict["readout"]["emulated_data_times_start_with_now"] = True
 conf_dict["trigger"]["trigger_rate_hz"] = trigger_rate
 conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -195,9 +195,6 @@ def test_cleanup(run_nanorc):
     if not sufficient_disk_space:
         pytest.skip(f"The raw data output path ({actual_output_path}) does not have enough space to run this test.")
 
-    print("============================================")
-    print("Listing the hdf5 files before deleting them:")
-    print("============================================")
     pathlist_string=""
     filelist_string=""
     for data_file in run_nanorc.data_files:
@@ -205,13 +202,18 @@ def test_cleanup(run_nanorc):
         if str(data_file.parent) not in pathlist_string:
             pathlist_string += " " + str(data_file.parent)
 
-    os.system(f"df -h {pathlist_string}")
-    print("--------------------")
-    os.system(f"ls -alF {filelist_string}");
+    if pathlist_string and filelist_string:
+        print("============================================")
+        print("Listing the hdf5 files before deleting them:")
+        print("============================================")
 
-    for data_file in run_nanorc.data_files:
-        data_file.unlink()
+        os.system(f"df -h {pathlist_string}")
+        print("--------------------")
+        os.system(f"ls -alF {filelist_string}");
 
-    print("--------------------")
-    os.system(f"df -h {pathlist_string}")
-    print("============================================")
+        for data_file in run_nanorc.data_files:
+            data_file.unlink()
+
+        print("--------------------")
+        os.system(f"df -h {pathlist_string}")
+        print("============================================")

--- a/integtest/long_window_readout_test.py
+++ b/integtest/long_window_readout_test.py
@@ -26,14 +26,14 @@ latency_buffer_size=600000
 data_rate_slowdown_factor=1
 minimum_cpu_count=24
 minimum_free_memory_gb=52
+minimum_total_disk_space_gb=32  # double what we need
+minimum_free_disk_space_gb=24   # 50% more than what we need
 
 # Default values for validation parameters
 expected_number_of_data_files=4*number_of_dataflow_apps
 check_for_logfile_errors=True
 expected_event_count=202
 expected_event_count_tolerance= 9
-minimum_total_disk_space_gb=32  # double what we need
-minimum_free_disk_space_gb=24   # 50% more than what we need
 wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", 
                            "fragment_type": "ProtoWIB",
                            "hdf5_source_subsystem": "Detector_Readout",

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -54,17 +54,15 @@ confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 
-hardware_map_contents = integtest_file_gen.generate_hwmap_file( number_of_data_producers)
+dro_map_contents = integtest_file_gen.generate_dromap_file(number_of_data_producers)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["boot"]["op_env"] = "integtest"
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
-#conf_dict["readout"]["default_data_file"] = "asset://?label=ProtoWIB&subsystem=readout" # ProtoWIB
 #conf_dict["readout"]["default_data_file"] = "asset://?label=DuneWIB&subsystem=readout" # DuneWIB
 conf_dict["readout"]["default_data_file"] = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e" # WIBEth
-#conf_dict["readout"]["clock_speed_hz"] = 50000000 # ProtoWIB
 conf_dict["readout"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
-conf_dict["readout"]["eth_mode"] = True # WIBEth
+conf_dict["readout"]["use_fake_cards"] = True
 conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before
 conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
 

--- a/integtest/minimal_system_quick_test.py
+++ b/integtest/minimal_system_quick_test.py
@@ -54,7 +54,7 @@ confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 
-dro_map_contents = integtest_file_gen.generate_dromap_file(number_of_data_producers)
+dro_map_contents = integtest_file_gen.generate_dromap_contents(number_of_data_producers)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["boot"]["op_env"] = "integtest"

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -77,7 +77,7 @@ ignored_logfile_problems={"trigger": ["zipped_tpset_q: Unable to push within tim
 confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-dro_map_contents = integtest_file_gen.generate_dromap_file(number_of_data_producers, number_of_readout_apps)
+dro_map_contents = integtest_file_gen.generate_dromap_contents(number_of_data_producers, number_of_readout_apps)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -77,17 +77,15 @@ ignored_logfile_problems={"trigger": ["zipped_tpset_q: Unable to push within tim
 confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-hardware_map_contents = integtest_file_gen.generate_hwmap_file(number_of_data_producers, number_of_readout_apps)
+dro_map_contents = integtest_file_gen.generate_dromap_file(number_of_data_producers, number_of_readout_apps)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["latency_buffer_size"] = 200000
-#conf_dict["readout"]["default_data_file"] = "asset://?label=ProtoWIB&subsystem=readout" # ProtoWIB
 #conf_dict["readout"]["default_data_file"] = "asset://?label=DuneWIB&subsystem=readout" # DuneWIB
 conf_dict["readout"]["default_data_file"] = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e" # WIBEth
-#conf_dict["readout"]["clock_speed_hz"] = 50000000 # ProtoWIB
 conf_dict["readout"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
-conf_dict["readout"]["eth_mode"] = True # WIBEth
+conf_dict["readout"]["use_fake_cards"] = True
 conf_dict["readout"]["emulated_data_times_start_with_now"] = True
 conf_dict["trigger"]["trigger_rate_hz"] = 10
 conf_dict["trigger"]["trigger_window_before_ticks"] = 52000

--- a/python/dfmodules/integtest_file_gen.py
+++ b/python/dfmodules/integtest_file_gen.py
@@ -1,3 +1,4 @@
+import os
 
 def generate_hwmap_file(n_links, n_apps = 1, det_id = 3):
     conf="# DRO_SourceID DetLink DetSlot DetCrate DetID DRO_Host DRO_Card DRO_SLR DRO_Link\n"
@@ -16,3 +17,14 @@ def generate_hwmap_file(n_links, n_apps = 1, det_id = 3):
             conf+=f"{sid} {sid % 2} {sid // 2} {crate} {det_id} localhost {card} {slr} {link_num}\n"
             sid += 1
     return conf
+
+def generate_dromap_file():
+    #json_file=tmp_path_factory.getbasetemp() / "temp_dromap.json"
+    #json_file="/tmp/temp_dromap.json"
+    json_file="temp_dromap.json"
+    os.system(f"dromap_editor add-eth --src-id 0 --geo-stream-id 0 --geo-det-id 3 add-eth --src-id 1 --geo-stream-id 1 --geo-det-id 3 save {json_file} >> /dev/null")
+    #os.system("pwd")
+    map_text=""
+    for line in open(json_file).readlines():
+        map_text+=line
+    return map_text

--- a/python/dfmodules/integtest_file_gen.py
+++ b/python/dfmodules/integtest_file_gen.py
@@ -29,8 +29,12 @@ def generate_dromap_file(n_streams, n_apps = 1, det_id = 3, app_type = "eth"):
         for stream in range(n_streams):
             dromap_editor_cmd += " add-eth"
             dromap_editor_cmd += f" --src-id {source_id}"
+            dromap_editor_cmd += f" --geo-crate-id {app}"
             dromap_editor_cmd += f" --geo-stream-id {stream}"
             dromap_editor_cmd += f" --geo-det-id {det_id}"
+            dromap_editor_cmd += f" --eth-rx-mac 00:00:00:00:00:0{app}"
+            dromap_editor_cmd += f" --eth-rx-ip 0.0.0.{app}"
+            dromap_editor_cmd += f" --eth-rx-iface {app}"
             source_id += 1
     dromap_editor_cmd += f" save {json_file} >> /dev/null"
 

--- a/python/dfmodules/integtest_file_gen.py
+++ b/python/dfmodules/integtest_file_gen.py
@@ -18,11 +18,24 @@ def generate_hwmap_file(n_links, n_apps = 1, det_id = 3):
             sid += 1
     return conf
 
-def generate_dromap_file():
+def generate_dromap_file(n_streams, n_apps = 1, det_id = 3, app_type = "eth"):
     #json_file=tmp_path_factory.getbasetemp() / "temp_dromap.json"
     #json_file="/tmp/temp_dromap.json"
-    json_file="temp_dromap.json"
-    os.system(f"dromap_editor add-eth --src-id 0 --geo-stream-id 0 --geo-det-id 3 add-eth --src-id 1 --geo-stream-id 1 --geo-det-id 3 save {json_file} >> /dev/null")
+    json_file = "temp_dromap.json"
+
+    dromap_editor_cmd = "dromap_editor"
+    source_id = 0
+    for app in range(n_apps):
+        for stream in range(n_streams):
+            dromap_editor_cmd += " add-eth"
+            dromap_editor_cmd += f" --src-id {source_id}"
+            dromap_editor_cmd += f" --geo-stream-id {stream}"
+            dromap_editor_cmd += f" --geo-det-id {det_id}"
+            source_id += 1
+    dromap_editor_cmd += f" save {json_file} >> /dev/null"
+
+    os.system(dromap_editor_cmd)
+    #os.system(f"dromap_editor add-eth --src-id 0 --geo-stream-id 0 --geo-det-id 3 add-eth --src-id 1 --geo-stream-id 1 --geo-det-id 3 save {json_file} >> /dev/null")
     #os.system("pwd")
     map_text=""
     for line in open(json_file).readlines():

--- a/python/dfmodules/integtest_file_gen.py
+++ b/python/dfmodules/integtest_file_gen.py
@@ -19,7 +19,7 @@ def generate_hwmap_file(n_links, n_apps = 1, det_id = 3):
             sid += 1
     return conf
 
-def generate_dromap_contents(n_streams, n_apps = 1, det_id = 3, app_type = "eth"):
+def generate_dromap_contents(n_streams, n_apps = 1, det_id = 3, app_type = "eth", eth_protocol = "udp"):
     the_map = dromap.DetReadoutMapService()
     source_id = 0
     for app in range(n_apps):
@@ -30,7 +30,7 @@ def generate_dromap_contents(n_streams, n_apps = 1, det_id = 3, app_type = "eth"
                 the_map.add_srcid(source_id, geo_id, app_type,
                                   card=app, slr=(stream // 5), link=(stream % 5))
             else:
-                the_map.add_srcid(source_id, geo_id, app_type,
+                the_map.add_srcid(source_id, geo_id, app_type, protocol=eth_protocol,
                                   rx_iface=app, rx_mac=f"00:00:00:00:00:0{app}", rx_ip=f"0.0.0.{app}")
             source_id += 1
     return json.dumps(the_map.as_json(), indent=4)

--- a/python/dfmodules/integtest_file_gen.py
+++ b/python/dfmodules/integtest_file_gen.py
@@ -19,7 +19,8 @@ def generate_hwmap_file(n_links, n_apps = 1, det_id = 3):
             sid += 1
     return conf
 
-def generate_dromap_contents(n_streams, n_apps = 1, det_id = 3, app_type = "eth", eth_protocol = "udp"):
+def generate_dromap_contents(n_streams, n_apps = 1, det_id = 3, app_type = "eth", app_host = "localhost",
+                             eth_protocol = "udp", flx_mode = "fix_rate", flx_protocol = "full"):
     the_map = dromap.DetReadoutMapService()
     source_id = 0
     for app in range(n_apps):
@@ -27,10 +28,11 @@ def generate_dromap_contents(n_streams, n_apps = 1, det_id = 3, app_type = "eth"
             geo_id = dromap.GeoID(det_id, app, 0, stream)
             if app_type == 'flx':
                 # untested!
-                the_map.add_srcid(source_id, geo_id, app_type,
+                the_map.add_srcid(source_id, geo_id, app_type, host=app_host,
+                                  protocol=flx_protocol, mode=flx_mode,
                                   card=app, slr=(stream // 5), link=(stream % 5))
             else:
-                the_map.add_srcid(source_id, geo_id, app_type, protocol=eth_protocol,
+                the_map.add_srcid(source_id, geo_id, app_type, protocol=eth_protocol, rx_host=app_host,
                                   rx_iface=app, rx_mac=f"00:00:00:00:00:0{app}", rx_ip=f"0.0.0.{app}")
             source_id += 1
     return json.dumps(the_map.as_json(), indent=4)

--- a/python/dfmodules/integtest_file_gen.py
+++ b/python/dfmodules/integtest_file_gen.py
@@ -25,7 +25,12 @@ def generate_dromap_contents(n_streams, n_apps = 1, det_id = 3, app_type = "eth"
     for app in range(n_apps):
         for stream in range(n_streams):
             geo_id = dromap.GeoID(det_id, app, 0, stream)
-            the_map.add_srcid(source_id, geo_id, app_type,
-                              rx_iface=app, rx_mac=f"00:00:00:00:00:0{app}", rx_ip=f"0.0.0.{app}")
+            if app_type == 'flx':
+                # untested!
+                the_map.add_srcid(source_id, geo_id, app_type,
+                                  card=app, slr=(stream // 5), link=(stream % 5))
+            else:
+                the_map.add_srcid(source_id, geo_id, app_type,
+                                  rx_iface=app, rx_mac=f"00:00:00:00:00:0{app}", rx_ip=f"0.0.0.{app}")
             source_id += 1
     return json.dumps(the_map.as_json(), indent=4)


### PR DESCRIPTION
The switch from the use of HardwareMaps to DetectorReadoutMaps in our configurations needed to be propagated to the automated integration tests, and this PR is part of the integtest changes.

The full set of repositories that are part of this block of changes is the following:  `daqconf, daq-systemtest, dfmodules, lbrulibs, listrev, `and` integrationtest`.

In order to set up a software area to test these changes, I recommend the following steps:

1. create a software area based on the instructions here:  [https://github.com/DUNE-DAQ/daqconf/wiki/Instructions-for-setting-up-a-development-software-area](https://github.com/DUNE-DAQ/daqconf/wiki/Instructions-for-setting-up-a-development-software-area)
2. run these additional commands (in a shell that has had `dbt-workarea-env` sourced, etc):

```
cd $DBT_AREA_ROOT
cd integrationtest
git fetch ; git checkout kbiery/HardwareMap_to_DROMap ; git pull
pip install -U .
cd ../sourcecode
cd daqconf
git fetch ; git checkout kbiery/HardwareMap_to_DROMap ; git pull
cd ../dfmodules
git fetch ; git checkout kbiery/HardwareMap_to_DROMap ; git pull
cd ../daq-systemtest
git fetch ; git checkout kbiery/HardwareMap_to_DROMap ; git pull
cd ..
git clone https://github.com/DUNE-DAQ/lbrulibs.git -b kbiery/HardwareMap_to_DROMap
git clone https://github.com/DUNE-DAQ/listrev.git -b kbiery/HardwareMap_to_DROMap
cd ..
dbt-build -j 20
```

In the resulting software area, the following integtests should work**:
```
# dfmodules/integtest/minimal_system_quick_test.py
# dfmodules/integtest/3ru_3df_multirun_test.py
# dfmodules/integtest/fake_data_producer_test.py
# dfmodules/integtest/long_window_readout_test.py
# dfmodules/integtest/large_trigger_record_test.py
# dfmodules/integtest/3ru_1df_multirun_test.py
# dfmodules/integtest/disabled_output_test.py
# dfmodules/integtest/multi_output_file_test.py
# dfmodules/integtest/insufficient_disk_space_test.py
#
# daq-systemtest/integtest/readout_type_scan.py
#
# lbrulibs/integtest/test_pacman-raw.py
# lbrulibs/integtest/test_mpd-raw.py
#
# listrev/integtest/listrev_test.py
```

There are still changes that we will need to make, for example to add back TP generation to the integtests, but the changes contained in this PR, and the accompanying ones in other repos, are a useful chunk of work to be reviewed.

** actually, a couple of the integtests don't fully work yet.  The insufficient_disk_space one needs a pending change in `integrationtest`, and the lbrulibs ones occasionally have empty fragment warnings.