### PR TITLE
Fix and re-enable TPG integration tests

### DIFF
--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -15,8 +15,8 @@ import dfmodules.integtest_file_gen as integtest_file_gen
 number_of_data_producers=3
 number_of_readout_apps=3
 run_duration=20  # seconds
-trigger_rate=0.1 # Hz
-data_rate_slowdown_factor=1
+trigger_rate=1 # Hz
+data_rate_slowdown_factor=10
 
 # Default values for validation parameters
 expected_number_of_data_files=3
@@ -113,6 +113,8 @@ conf_dict["readout"]["use_fake_cards"] = True
 conf_dict["hsi"]["random_trigger_rate_hz"] = trigger_rate
 
 swtpg_conf = copy.deepcopy(conf_dict)
+swtpg_conf["daq_common"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor / 10
+swtpg_conf["hsi"]["random_trigger_rate_hz"] = trigger_rate / 10 # Scaling to avoid issues in the Trigger app
 swtpg_conf["readout"]["emulator_mode"] = True
 swtpg_conf["readout"]["enable_tpg"] = True
 swtpg_conf["readout"]["tpg_threshold"] = 500
@@ -177,6 +179,8 @@ def test_data_files(run_nanorc):
     local_event_count_tolerance=expected_event_count_tolerance
     fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
     if "enable_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_tpg"]:
+        local_expected_event_count = expected_event_count / 10 # Scaling to avoid issues in the Trigger app
+        local_event_count_tolerance = local_expected_event_count / 10
         local_expected_event_count+=(number_of_data_producers * run_duration / 2)  #(270*number_of_data_producers*run_duration/(100))
         local_event_count_tolerance+=(number_of_data_producers * run_duration / 4)  #(10*number_of_data_producers*run_duration/(100))
         #fragment_check_list.append(wib1_frag_multi_trig_params) # ProtoWIB

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -176,7 +176,7 @@ def test_data_files(run_nanorc):
     local_expected_event_count=expected_event_count
     local_event_count_tolerance=expected_event_count_tolerance
     fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
-    if "enable_software_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_software_tpg"]:
+    if "enable_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_tpg"]:
         local_expected_event_count+=(270*number_of_data_producers*number_of_readout_apps*run_duration/100)
         local_event_count_tolerance+=(10*number_of_data_producers*number_of_readout_apps*run_duration/100)
         #fragment_check_list.append(wib1_frag_multi_trig_params) # ProtoWIB

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -110,14 +110,21 @@ conf_dict["readout"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
 conf_dict["readout"]["use_fake_cards"] = True
 
 swtpg_conf = copy.deepcopy(conf_dict)
-swtpg_conf["readout"]["enable_software_tpg"] = True
+swtpg_conf["readout"]["emulator_mode"] = True
+swtpg_conf["readout"]["enable_tpg"] = True
+swtpg_conf["readout"]["tpg_threshold"] = 500
+swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
+swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
+swtpg_conf["trigger"]["mlt_send_timed_out_tds"] = False
+swtpg_conf["trigger"]["tpg_channel_map"] = "PD2HDChannelMap"
+swtpg_conf["trigger"]["trigger_activity_config"] = {"prescale": 300}
 swtpg_conf["dataflow"]["token_count"] = max(10, 3*number_of_data_producers*number_of_readout_apps)
 
 dqm_conf = copy.deepcopy(conf_dict)
 dqm_conf["dqm"]["enable_dqm"] = True
 
 confgen_arguments={"WIBEth_System": conf_dict,
-#                   "Software_TPG_System": swtpg_conf,
+                   "Software_TPG_System": swtpg_conf,
                    "DQM_System": dqm_conf,
                   }
 

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -177,8 +177,8 @@ def test_data_files(run_nanorc):
     local_event_count_tolerance=expected_event_count_tolerance
     fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
     if "enable_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_tpg"]:
-        local_expected_event_count+=(number_of_data_producers * run_duration / 5)  #(270*number_of_data_producers*run_duration/(100))
-        local_event_count_tolerance+=(number_of_data_producers * run_duration / 10)  #(10*number_of_data_producers*run_duration/(100))
+        local_expected_event_count+=(number_of_data_producers * run_duration / 2)  #(270*number_of_data_producers*run_duration/(100))
+        local_event_count_tolerance+=(number_of_data_producers * run_duration / 4)  #(10*number_of_data_producers*run_duration/(100))
         #fragment_check_list.append(wib1_frag_multi_trig_params) # ProtoWIB
         #fragment_check_list.append(wib2_frag_multi_trig_params) # DuneWIB
         fragment_check_list.append(wibeth_frag_multi_trig_params) # WIBEth

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -110,7 +110,7 @@ conf_dict["readout"]["latency_buffer_size"] = 200000
 conf_dict["readout"]["default_data_file"] = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e" # WIBEth
 conf_dict["detector"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
 conf_dict["readout"]["use_fake_cards"] = True
-conf_dict["trigger"]["trigger_rate_hz"] = trigger_rate
+conf_dict["hsi"]["random_trigger_rate_hz"] = trigger_rate
 
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["emulator_mode"] = True

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -177,8 +177,8 @@ def test_data_files(run_nanorc):
     local_event_count_tolerance=expected_event_count_tolerance
     fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
     if "enable_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_tpg"]:
-        local_expected_event_count+=(270*number_of_data_producers*number_of_readout_apps*run_duration/100)
-        local_event_count_tolerance+=(10*number_of_data_producers*number_of_readout_apps*run_duration/100)
+        local_expected_event_count+=(number_of_data_producers * run_duration / 5)  #(270*number_of_data_producers*run_duration/(100))
+        local_event_count_tolerance+=(number_of_data_producers * run_duration / 10)  #(10*number_of_data_producers*run_duration/(100))
         #fragment_check_list.append(wib1_frag_multi_trig_params) # ProtoWIB
         #fragment_check_list.append(wib2_frag_multi_trig_params) # DuneWIB
         fragment_check_list.append(wibeth_frag_multi_trig_params) # WIBEth

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -3,6 +3,7 @@ import os
 import re
 import copy
 import psutil
+import math
 import urllib.request
 
 import dfmodules.data_file_checks as data_file_checks
@@ -14,13 +15,14 @@ import dfmodules.integtest_file_gen as integtest_file_gen
 number_of_data_producers=3
 number_of_readout_apps=3
 run_duration=20  # seconds
-data_rate_slowdown_factor=10
+trigger_rate=0.1 # Hz
+data_rate_slowdown_factor=1
 
 # Default values for validation parameters
 expected_number_of_data_files=3
 check_for_logfile_errors=True
-expected_event_count=run_duration
-expected_event_count_tolerance=2
+expected_event_count=trigger_rate * run_duration
+expected_event_count_tolerance=math.ceil(expected_event_count / 10)
 minimum_cpu_count=18
 minimum_free_memory_gb=24
 wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", 
@@ -108,6 +110,7 @@ conf_dict["readout"]["latency_buffer_size"] = 200000
 conf_dict["readout"]["default_data_file"] = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e" # WIBEth
 conf_dict["readout"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
 conf_dict["readout"]["use_fake_cards"] = True
+conf_dict["trigger"]["trigger_rate_hz"] = trigger_rate
 
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["emulator_mode"] = True

--- a/integtest/3ru_1df_multirun_test.py
+++ b/integtest/3ru_1df_multirun_test.py
@@ -119,7 +119,7 @@ swtpg_conf["readout"]["tpg_threshold"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 swtpg_conf["trigger"]["mlt_send_timed_out_tds"] = False
-swtpg_conf["trigger"]["tpg_channel_map"] = "PD2HDChannelMap"
+swtpg_conf["detector"]["tpc_channel_map"] = "PD2HDChannelMap"
 swtpg_conf["trigger"]["trigger_activity_config"] = {"prescale": 300}
 swtpg_conf["dataflow"]["token_count"] = max(10, 3*number_of_data_producers*number_of_readout_apps)
 

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -95,16 +95,19 @@ for df_app in range(number_of_dataflow_apps):
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["emulator_mode"] = True
 swtpg_conf["readout"]["enable_tpg"] = True
-swtpg_conf["readout"]["tpg_threshold"] = 150
-swtpg_conf["readout"]["tpg_algorithm"] = "Simplethreshold"
+swtpg_conf["readout"]["tpg_threshold"] = 500
+swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
+swtpg_conf["trigger"]["mlt_send_timed_out_tds"] = False
+swtpg_conf["trigger"]["tpg_channel_map"] = "PD2HDChannelMap"
+swtpg_conf["trigger"]["trigger_activity_config"] = {"prescale": 300}
 swtpg_conf["dataflow"]["token_count"] = int(math.ceil(max(10, 3*number_of_data_producers*number_of_readout_apps)/number_of_dataflow_apps))
 
 dqm_conf = copy.deepcopy(conf_dict)
 dqm_conf["dqm"]["enable_dqm"] = True
 
 confgen_arguments={"WIBEth_System": conf_dict,
-#                   "Software_TPG_System": swtpg_conf,
+                   "Software_TPG_System": swtpg_conf,
                    "DQM_System": dqm_conf,
                   }
 # The commands to run in nanorc, as a list

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -143,8 +143,8 @@ def test_data_files(run_nanorc):
     high_number_of_files=expected_number_of_data_files
     fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
     if "enable_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_tpg"]:
-        local_expected_event_count+=(265*number_of_data_producers*number_of_readout_apps*run_duration/(100*number_of_dataflow_apps))
-        local_event_count_tolerance+=(10*number_of_data_producers*number_of_readout_apps*run_duration/(100*number_of_dataflow_apps))
+        local_expected_event_count+=(number_of_data_producers * run_duration / 5)  #(270*number_of_data_producers*run_duration/(100))
+        local_event_count_tolerance+=(number_of_data_producers * run_duration / 10)  #(10*number_of_data_producers*run_duration/(100))
         #fragment_check_list.append(wib2_frag_multi_trig_params) # DuneWIB
         fragment_check_list.append(wibeth_frag_multi_trig_params) # WIBEth
         fragment_check_list.append(triggertp_frag_params)

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -14,9 +14,9 @@ import dfmodules.integtest_file_gen as integtest_file_gen
 number_of_data_producers=2
 number_of_readout_apps=3
 number_of_dataflow_apps=3
-trigger_rate=3.0 # Hz
+trigger_rate=0.3 # Hz
 run_duration=20  # seconds
-data_rate_slowdown_factor=10
+data_rate_slowdown_factor=1
 
 # Default values for validation parameters
 expected_number_of_data_files=3*number_of_dataflow_apps

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -142,7 +142,7 @@ def test_data_files(run_nanorc):
     low_number_of_files=expected_number_of_data_files
     high_number_of_files=expected_number_of_data_files
     fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
-    if "enable_software_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_software_tpg"]:
+    if "enable_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_tpg"]:
         local_expected_event_count+=(265*number_of_data_producers*number_of_readout_apps*run_duration/(100*number_of_dataflow_apps))
         local_event_count_tolerance+=(10*number_of_data_producers*number_of_readout_apps*run_duration/(100*number_of_dataflow_apps))
         #fragment_check_list.append(wib2_frag_multi_trig_params) # DuneWIB

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -14,9 +14,9 @@ import dfmodules.integtest_file_gen as integtest_file_gen
 number_of_data_producers=2
 number_of_readout_apps=3
 number_of_dataflow_apps=3
-trigger_rate=0.3 # Hz
+trigger_rate=3 # Hz
 run_duration=20  # seconds
-data_rate_slowdown_factor=1
+data_rate_slowdown_factor=10
 
 # Default values for validation parameters
 expected_number_of_data_files=3*number_of_dataflow_apps
@@ -93,6 +93,8 @@ for df_app in range(number_of_dataflow_apps):
     conf_dict["dataflow"]["apps"].append(dfapp_conf)
 
 swtpg_conf = copy.deepcopy(conf_dict)
+swtpg_conf["daq_common"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor / 10
+swtpg_conf["hsi"]["random_trigger_rate_hz"] = trigger_rate / 10 # Scaling to avoid issues in Trigger app
 swtpg_conf["readout"]["emulator_mode"] = True
 swtpg_conf["readout"]["enable_tpg"] = True
 swtpg_conf["readout"]["tpg_threshold"] = 500
@@ -143,6 +145,8 @@ def test_data_files(run_nanorc):
     high_number_of_files=expected_number_of_data_files
     fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
     if "enable_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_tpg"]:
+        local_expected_event_count = expected_event_count / 10 # Scaling to avoid issues with Trigger app
+        local_event_count_tolerance = local_expected_event_count / 10
         local_expected_event_count+=(number_of_data_producers * run_duration / 5)  #(270*number_of_data_producers*run_duration/(100))
         local_event_count_tolerance+=(number_of_data_producers * run_duration / 10)  #(10*number_of_data_producers*run_duration/(100))
         #fragment_check_list.append(wib2_frag_multi_trig_params) # DuneWIB

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -99,7 +99,7 @@ swtpg_conf["readout"]["tpg_threshold"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 swtpg_conf["trigger"]["mlt_send_timed_out_tds"] = False
-swtpg_conf["trigger"]["tpg_channel_map"] = "PD2HDChannelMap"
+swtpg_conf["detector"]["tpc_channel_map"] = "PD2HDChannelMap"
 swtpg_conf["trigger"]["trigger_activity_config"] = {"prescale": 300}
 swtpg_conf["dataflow"]["token_count"] = int(math.ceil(max(10, 3*number_of_data_producers*number_of_readout_apps)/number_of_dataflow_apps))
 

--- a/integtest/3ru_3df_multirun_test.py
+++ b/integtest/3ru_3df_multirun_test.py
@@ -93,8 +93,11 @@ for df_app in range(number_of_dataflow_apps):
     conf_dict["dataflow"]["apps"].append(dfapp_conf)
 
 swtpg_conf = copy.deepcopy(conf_dict)
-swtpg_conf["readout"]["enable_software_tpg"] = True
-swtpg_conf["readout"]["software_tpg_threshold"] = 150
+swtpg_conf["readout"]["emulator_mode"] = True
+swtpg_conf["readout"]["enable_tpg"] = True
+swtpg_conf["readout"]["tpg_threshold"] = 150
+swtpg_conf["readout"]["tpg_algorithm"] = "Simplethreshold"
+swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 swtpg_conf["dataflow"]["token_count"] = int(math.ceil(max(10, 3*number_of_data_producers*number_of_readout_apps)/number_of_dataflow_apps))
 
 dqm_conf = copy.deepcopy(conf_dict)

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -97,9 +97,12 @@ conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["emulator_mode"] = True
 swtpg_conf["readout"]["enable_tpg"] = True
-swtpg_conf["readout"]["tpg_threshold"] = 150
+swtpg_conf["readout"]["tpg_threshold"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
+swtpg_conf["trigger"]["mlt_send_timed_out_tds"] = False
+swtpg_conf["trigger"]["tpg_channel_map"] = "PD2HDChannelMap"
+swtpg_conf["trigger"]["trigger_activity_config"] = {"prescale": 300}
 
 confgen_arguments={"WIBEth_System": conf_dict,
                    "Software_TPG_System": swtpg_conf,

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -95,10 +95,14 @@ conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before
 conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
 
 swtpg_conf = copy.deepcopy(conf_dict)
-swtpg_conf["readout"]["enable_software_tpg"] = True
+swtpg_conf["readout"]["emulator_mode"] = True
+swtpg_conf["readout"]["enable_tpg"] = True
+swtpg_conf["readout"]["tpg_threshold"] = 150
+swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
+swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 
 confgen_arguments={"WIBEth_System": conf_dict,
-#                   "Software_TPG_System": swtpg_conf,
+                   "Software_TPG_System": swtpg_conf,
                   }
 
 # The commands to run in nanorc, as a list
@@ -132,9 +136,9 @@ def test_data_files(run_nanorc):
     local_expected_event_count=expected_event_count
     local_event_count_tolerance=expected_event_count_tolerance
     fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
-    if "enable_software_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_software_tpg"]:
-        local_expected_event_count+=(270*number_of_data_producers*run_duration/100)
-        local_event_count_tolerance+=(10*number_of_data_producers*run_duration/100)
+    if "enable_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_tpg"]:
+        local_expected_event_count+=(number_of_data_producers*run_duration/10)
+        local_event_count_tolerance+=(number_of_data_producers*run_duration/10)
         #fragment_check_list.append(wib1_frag_multi_trig_params) # ProtoWIB
         #fragment_check_list.append(wib2_frag_multi_trig_params) # DuneWIB
         fragment_check_list.append(wibeth_frag_multi_trig_params) # WIBEth

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -103,7 +103,7 @@ swtpg_conf["readout"]["tpg_threshold"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 swtpg_conf["trigger"]["mlt_send_timed_out_tds"] = False
-swtpg_conf["trigger"]["tpg_channel_map"] = "PD2HDChannelMap"
+swtpg_conf["detector"]["tpc_channel_map"] = "PD2HDChannelMap"
 swtpg_conf["trigger"]["trigger_activity_config"] = {"prescale": 300}
 
 confgen_arguments={"WIBEth_System": conf_dict,

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -13,8 +13,8 @@ import dfmodules.integtest_file_gen as integtest_file_gen
 # Values that help determine the running conditions
 number_of_data_producers=2
 run_duration=20  # seconds
-trigger_rate = 0.1 # Hz
-data_rate_slowdown_factor=1
+trigger_rate = 1.0 # Hz
+data_rate_slowdown_factor=10
 readout_window_time_before=1000
 readout_window_time_after=1001
 
@@ -97,6 +97,8 @@ conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before
 conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
 
 swtpg_conf = copy.deepcopy(conf_dict)
+swtpg_conf["daq_common"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor / 10
+swtpg_conf["hsi"]["random_trigger_rate_hz"] = trigger_rate / 10 # Scaling to avoid issues in the trigger app
 swtpg_conf["readout"]["emulator_mode"] = True
 swtpg_conf["readout"]["enable_tpg"] = True
 swtpg_conf["readout"]["tpg_threshold"] = 500
@@ -142,6 +144,8 @@ def test_data_files(run_nanorc):
     local_event_count_tolerance=expected_event_count_tolerance
     fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
     if "enable_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_tpg"]:
+        local_expected_event_count = expected_event_count / 10 # Scaling to avoid issues in the trigger app
+        local_event_count_tolerance = expected_event_count_tolerance / 10 
         local_expected_event_count+=(number_of_data_producers * run_duration / 5)  #(270*number_of_data_producers*run_duration/(100))
         local_event_count_tolerance+=(number_of_data_producers * run_duration / 10)  #(10*number_of_data_producers*run_duration/(100))
         #fragment_check_list.append(wib1_frag_multi_trig_params) # ProtoWIB

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -142,8 +142,8 @@ def test_data_files(run_nanorc):
     local_event_count_tolerance=expected_event_count_tolerance
     fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
     if "enable_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_tpg"]:
-        local_expected_event_count+=(number_of_data_producers*run_duration/10)
-        local_event_count_tolerance+=(number_of_data_producers*run_duration/10)
+        local_expected_event_count+=(number_of_data_producers * run_duration / 5)  #(270*number_of_data_producers*run_duration/(100))
+        local_event_count_tolerance+=(number_of_data_producers * run_duration / 10)  #(10*number_of_data_producers*run_duration/(100))
         #fragment_check_list.append(wib1_frag_multi_trig_params) # ProtoWIB
         #fragment_check_list.append(wib2_frag_multi_trig_params) # DuneWIB
         fragment_check_list.append(wibeth_frag_multi_trig_params) # WIBEth

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -1,3 +1,4 @@
+import math
 import pytest
 import os
 import re
@@ -12,15 +13,16 @@ import dfmodules.integtest_file_gen as integtest_file_gen
 # Values that help determine the running conditions
 number_of_data_producers=2
 run_duration=20  # seconds
-data_rate_slowdown_factor=10
+trigger_rate = 0.1 # Hz
+data_rate_slowdown_factor=1
 readout_window_time_before=1000
 readout_window_time_after=1001
 
 # Default values for validation parameters
 expected_number_of_data_files=2
 check_for_logfile_errors=True
-expected_event_count=run_duration
-expected_event_count_tolerance=2
+expected_event_count=trigger_rate * run_duration
+expected_event_count_tolerance=math.ceil(expected_event_count / 10)
 wib1_frag_hsi_trig_params={"fragment_type_description": "WIB", 
                            "fragment_type": "ProtoWIB",
                            "hdf5_source_subsystem": "Detector_Readout",
@@ -90,7 +92,7 @@ conf_dict["readout"]["latency_buffer_size"] = 200000
 conf_dict["readout"]["default_data_file"] = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e" # WIBEth
 conf_dict["readout"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
 conf_dict["readout"]["use_fake_cards"] = True
-conf_dict["trigger"]["trigger_rate_hz"] = 1.0
+conf_dict["trigger"]["trigger_rate_hz"] = trigger_rate
 conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before
 conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
 

--- a/integtest/fake_data_producer_test.py
+++ b/integtest/fake_data_producer_test.py
@@ -61,7 +61,6 @@ conf_dict["daq_common"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["use_fake_data_producers"] = True
 #conf_dict["readout"]["clock_speed_hz"] = 50000000 # ProtoWIB
 conf_dict["detector"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
-conf_dict["readout"]["use_fake_cards"] = True
 conf_dict["trigger"]["trigger_window_before_ticks"] = 1000
 conf_dict["trigger"]["trigger_window_after_ticks"] = 1001
 

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -150,7 +150,7 @@ def test_data_files(run_nanorc):
     local_file_count=expected_number_of_data_files
     fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
     if "enable_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_tpg"]:
-        local_file_count=5
+        local_file_count=4
         #fragment_check_list.append(wib1_frag_multi_trig_params) # ProtoWIB
         #fragment_check_list.append(wib2_frag_multi_trig_params) # DuneWIB
         fragment_check_list.append(wibeth_frag_multi_trig_params) # WIBEth

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -100,7 +100,7 @@ swtpg_conf["readout"]["tpg_threshold"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 swtpg_conf["trigger"]["mlt_send_timed_out_tds"] = False
-swtpg_conf["trigger"]["tpg_channel_map"] = "PD2HDChannelMap"
+swtpg_conf["detector"]["tpc_channel_map"] = "PD2HDChannelMap"
 swtpg_conf["trigger"]["trigger_activity_config"] = {"prescale": 300}
 swtpg_conf["dataflow"]["token_count"] = max(10, 3*number_of_data_producers*number_of_readout_apps)
 
@@ -115,7 +115,7 @@ multiout_tpg_conf["readout"]["tpg_threshold"] = 500
 multiout_tpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
 multiout_tpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 multiout_tpg_conf["trigger"]["mlt_send_timed_out_tds"] = False
-multiout_tpg_conf["trigger"]["tpg_channel_map"] = "PD2HDChannelMap"
+multiout_tpg_conf["detector"]["tpc_channel_map"] = "PD2HDChannelMap"
 multiout_tpg_conf["trigger"]["trigger_activity_config"] = {"prescale": 300}
 multiout_tpg_conf["dataflow"]["token_count"] = max(10, 3*number_of_data_producers*number_of_readout_apps)
 

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -93,7 +93,14 @@ conf_dict["trigger"]["trigger_window_after_ticks"] = 1000
 conf_dict["dataflow"]["apps"][0]["max_file_size"] = 1074000000
 
 swtpg_conf = copy.deepcopy(conf_dict)
-swtpg_conf["readout"]["enable_software_tpg"] = True
+swtpg_conf["readout"]["emulator_mode"] = True
+swtpg_conf["readout"]["enable_tpg"] = True
+swtpg_conf["readout"]["tpg_threshold"] = 500
+swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
+swtpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
+swtpg_conf["trigger"]["mlt_send_timed_out_tds"] = False
+swtpg_conf["trigger"]["tpg_channel_map"] = "PD2HDChannelMap"
+swtpg_conf["trigger"]["trigger_activity_config"] = {"prescale": 300}
 swtpg_conf["dataflow"]["token_count"] = max(10, 3*number_of_data_producers*number_of_readout_apps)
 
 multiout_conf = copy.deepcopy(conf_dict)
@@ -101,13 +108,20 @@ multiout_conf["dataflow"]["apps"][0]["output_paths"] = [".", "."]
 multiout_conf["dataflow"]["apps"][0]["max_file_size"] = 4*1024*1024*1024
 
 multiout_tpg_conf = copy.deepcopy(multiout_conf)
-multiout_tpg_conf["readout"]["enable_software_tpg"] = True
+multiout_tpg_conf["readout"]["emulator_mode"] = True
+multiout_tpg_conf["readout"]["enable_tpg"] = True
+multiout_tpg_conf["readout"]["tpg_threshold"] = 500
+multiout_tpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
+multiout_tpg_conf["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
+multiout_tpg_conf["trigger"]["mlt_send_timed_out_tds"] = False
+multiout_tpg_conf["trigger"]["tpg_channel_map"] = "PD2HDChannelMap"
+multiout_tpg_conf["trigger"]["trigger_activity_config"] = {"prescale": 300}
 multiout_tpg_conf["dataflow"]["token_count"] = max(10, 3*number_of_data_producers*number_of_readout_apps)
 
 confgen_arguments={"WIBEth_System (Rollover files)": conf_dict,
-                   #"Software_TPG_System (Rollover files)": swtpg_conf,
+                   "Software_TPG_System (Rollover files)": swtpg_conf,
                    "WIBEth_System (Multiple outputs)": multiout_conf,
-                   #"Software_TPG_System (Multiple outputs)": multiout_tpg_conf
+                   "Software_TPG_System (Multiple outputs)": multiout_tpg_conf
                   }
 
 # The commands to run in nanorc, as a list

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -149,7 +149,7 @@ def test_log_files(run_nanorc):
 def test_data_files(run_nanorc):
     local_file_count=expected_number_of_data_files
     fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
-    if "enable_software_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_software_tpg"]:
+    if "enable_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_tpg"]:
         local_file_count=5
         #fragment_check_list.append(wib1_frag_multi_trig_params) # ProtoWIB
         #fragment_check_list.append(wib2_frag_multi_trig_params) # DuneWIB

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -46,7 +46,7 @@ wibeth_frag_multi_trig_params={"fragment_type_description": "WIBEth",
                   "fragment_type": "WIBEth",
                   "hdf5_source_subsystem": "Detector_Readout",
                   "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
-                  "min_size_bytes": 72, "max_size_bytes": 14472}
+                  "min_size_bytes": 72, "max_size_bytes": 194472}
 triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate",
                               "fragment_type": "Trigger_Candidate",
                               "hdf5_source_subsystem": "Trigger",

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -116,7 +116,7 @@ conf_dict["readout"]["tpg_threshold"] = 500
 conf_dict["readout"]["tpg_algorithm"] = "SimpleThreshold"
 conf_dict["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
 conf_dict["trigger"]["mlt_send_timed_out_tds"] = False
-conf_dict["trigger"]["tpg_channel_map"] = "PD2HDChannelMap"
+conf_dict["detector"]["tpc_channel_map"] = "PD2HDChannelMap"
 conf_dict["trigger"]["trigger_activity_config"] = {"prescale": 300}
 
 conf_dict["dataflow"]["token_count"] = int(math.ceil(max(10, 3*number_of_data_producers*number_of_readout_apps)/number_of_dataflow_apps))

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -101,14 +101,13 @@ confgen_name="daqconf_multiru_gen"
 dro_map_contents = integtest_file_gen.generate_dromap_contents(number_of_data_producers, number_of_readout_apps)
 
 conf_dict = config_file_gen.get_default_config_dict()
-conf_dict["readout"]["clock_speed_hz"] = 50000000
-conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
+conf_dict["daq_common"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["latency_buffer_size"] = 200000
-conf_dict["readout"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
+conf_dict["detector"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
 conf_dict["readout"]["use_fake_cards"] = True # WIBEth
 conf_dict["hsi"]["random_trigger_rate_hz"] = pulser_trigger_rate
-conf_dict["trigger"]["enable_tpset_writing"] = True
-conf_dict["trigger"]["tpset_output_path"] = output_dir
+conf_dict["dataflow"]["enable_tpset_writing"] = True
+conf_dict["dataflow"]["tpset_output_path"] = output_dir
 
 conf_dict["readout"]["emulator_mode"] = True
 conf_dict["readout"]["enable_tpg"] = True

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -161,8 +161,8 @@ def test_data_files(run_nanorc):
     high_number_of_files=expected_number_of_data_files
     fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
     if "enable_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_tpg"]:
-        local_expected_event_count+=(270*number_of_data_producers*number_of_readout_apps*run_duration/(100*number_of_dataflow_apps))
-        local_event_count_tolerance+=(10*number_of_data_producers*number_of_readout_apps*run_duration/(100*number_of_dataflow_apps))
+        local_expected_event_count+=(number_of_data_producers * run_duration / 5)  #(270*number_of_data_producers*run_duration/(100))
+        local_event_count_tolerance+=(number_of_data_producers * run_duration / 10)  #(10*number_of_data_producers*run_duration/(100))
         #fragment_check_list.append(wib1_frag_multi_trig_params) # ProtoWIB
         #fragment_check_list.append(wib2_frag_multi_trig_params) # DuneWIB
         fragment_check_list.append(wibeth_frag_multi_trig_params) # WIBEth

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -160,7 +160,7 @@ def test_data_files(run_nanorc):
     low_number_of_files=expected_number_of_data_files
     high_number_of_files=expected_number_of_data_files
     fragment_check_list=[triggercandidate_frag_params, hsi_frag_params]
-    if "enable_software_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_software_tpg"]:
+    if "enable_tpg" in run_nanorc.confgen_config["readout"].keys() and run_nanorc.confgen_config["readout"]["enable_tpg"]:
         local_expected_event_count+=(270*number_of_data_producers*number_of_readout_apps*run_duration/(100*number_of_dataflow_apps))
         local_event_count_tolerance+=(10*number_of_data_producers*number_of_readout_apps*run_duration/(100*number_of_dataflow_apps))
         #fragment_check_list.append(wib1_frag_multi_trig_params) # ProtoWIB

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -66,7 +66,7 @@ wibeth_frag_multi_trig_params={"fragment_type_description": "WIBEth",
 wibeth_tpset_params={"fragment_type_description": "TP Stream", 
                    "fragment_type": "Trigger_Primitive",
                    "hdf5_source_subsystem": "Trigger",
-                   "expected_fragment_count": (number_of_data_producers*number_of_readout_apps),
+                   "expected_fragment_count": number_of_readout_apps,
                    "min_size_bytes": 72, "max_size_bytes": 3291080}
 triggercandidate_frag_params={"fragment_type_description": "Trigger Candidate", 
                               "fragment_type": "Trigger_Candidate",

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -13,9 +13,9 @@ import dfmodules.integtest_file_gen as integtest_file_gen
 number_of_data_producers=2
 number_of_readout_apps=2
 number_of_dataflow_apps=2
-pulser_trigger_rate=1.0 # Hz
+pulser_trigger_rate=0.1 # Hz
 run_duration=30  # seconds
-data_rate_slowdown_factor=10
+data_rate_slowdown_factor=1
 output_dir = "."
 
 # Default values for validation parameters

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -106,7 +106,7 @@ conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["latency_buffer_size"] = 200000
 conf_dict["readout"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
 conf_dict["readout"]["use_fake_cards"] = True # WIBEth
-conf_dict["trigger"]["trigger_rate_hz"] = pulser_trigger_rate
+conf_dict["hsi"]["random_trigger_rate_hz"] = pulser_trigger_rate
 conf_dict["trigger"]["enable_tpset_writing"] = True
 conf_dict["trigger"]["tpset_output_path"] = output_dir
 

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -98,14 +98,14 @@ ignored_logfile_problems={}
 confgen_name="daqconf_multiru_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
-hardware_map_contents = integtest_file_gen.generate_hwmap_file(number_of_data_producers, number_of_readout_apps)
+dro_map_contents = integtest_file_gen.generate_dromap_contents(number_of_data_producers, number_of_readout_apps)
 
 conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["readout"]["clock_speed_hz"] = 50000000
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["latency_buffer_size"] = 200000
 conf_dict["readout"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
-conf_dict["readout"]["eth_mode"] = True # WIBEth
+conf_dict["readout"]["use_fake_cards"] = True # WIBEth
 conf_dict["trigger"]["trigger_rate_hz"] = pulser_trigger_rate
 conf_dict["trigger"]["enable_tpset_writing"] = True
 conf_dict["trigger"]["tpset_output_path"] = output_dir

--- a/integtest/tpstream_writing_test.py
+++ b/integtest/tpstream_writing_test.py
@@ -104,16 +104,20 @@ conf_dict = config_file_gen.get_default_config_dict()
 conf_dict["readout"]["clock_speed_hz"] = 50000000
 conf_dict["readout"]["data_rate_slowdown_factor"] = data_rate_slowdown_factor
 conf_dict["readout"]["latency_buffer_size"] = 200000
-#conf_dict["readout"]["default_data_file"] = "asset://?label=ProtoWIB&subsystem=readout" # ProtoWIB
-#conf_dict["readout"]["default_data_file"] = "asset://?label=DuneWIB&subsystem=readout" # DuneWIB
-conf_dict["readout"]["default_data_file"] = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e" # WIBEth
-#conf_dict["readout"]["clock_speed_hz"] = 50000000 # ProtoWIB
 conf_dict["readout"]["clock_speed_hz"] = 62500000 # DuneWIB/WIBEth
 conf_dict["readout"]["eth_mode"] = True # WIBEth
 conf_dict["trigger"]["trigger_rate_hz"] = pulser_trigger_rate
 conf_dict["trigger"]["enable_tpset_writing"] = True
 conf_dict["trigger"]["tpset_output_path"] = output_dir
-conf_dict["readout"]["enable_software_tpg"] = True
+
+conf_dict["readout"]["emulator_mode"] = True
+conf_dict["readout"]["enable_tpg"] = True
+conf_dict["readout"]["tpg_threshold"] = 500
+conf_dict["readout"]["tpg_algorithm"] = "SimpleThreshold"
+conf_dict["readout"]["default_data_file"] = "asset://?checksum=dd156b4895f1b06a06b6ff38e37bd798" # WIBEth All Zeros
+conf_dict["trigger"]["mlt_send_timed_out_tds"] = False
+conf_dict["trigger"]["tpg_channel_map"] = "PD2HDChannelMap"
+conf_dict["trigger"]["trigger_activity_config"] = {"prescale": 300}
 
 conf_dict["dataflow"]["token_count"] = int(math.ceil(max(10, 3*number_of_data_producers*number_of_readout_apps)/number_of_dataflow_apps))
 conf_dict["dataflow"]["apps"] = [] # Remove preconfigured dataflow0 app


### PR DESCRIPTION
Now that WIBEth TPG is supported, re-enable the TPG portions of the integration tests, with appropriate updates.