### PR TITLE
Integtest changes for new wib pattern generation

### DIFF
--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -98,7 +98,7 @@ conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
 
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["generate_periodic_adc_pattern"] = True
-swtpg_conf["readout"]["emulated_TP_rate_per_ch"] = 0.25
+swtpg_conf["readout"]["emulated_TP_rate_per_ch"] = 1
 swtpg_conf["readout"]["enable_tpg"] = True
 swtpg_conf["readout"]["tpg_threshold"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -97,7 +97,8 @@ conf_dict["trigger"]["trigger_window_before_ticks"] = readout_window_time_before
 conf_dict["trigger"]["trigger_window_after_ticks"] = readout_window_time_after
 
 swtpg_conf = copy.deepcopy(conf_dict)
-swtpg_conf["readout"]["emulator_mode"] = True
+swtpg_conf["readout"]["generate_periodic_adc_pattern"] = True
+swtpg_conf["readout"]["emulated_TP_rate_per_ch"] = 0.25
 swtpg_conf["readout"]["enable_tpg"] = True
 swtpg_conf["readout"]["tpg_threshold"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -94,7 +94,8 @@ conf_dict["trigger"]["trigger_window_after_ticks"] = 1000
 conf_dict["dataflow"]["apps"][0]["max_file_size"] = 1074000000
 
 swtpg_conf = copy.deepcopy(conf_dict)
-swtpg_conf["readout"]["emulator_mode"] = True
+swtpg_conf["readout"]["generate_periodic_adc_pattern"] = True
+swtpg_conf["readout"]["emulated_TP_rate_per_ch"] = 0.25
 swtpg_conf["readout"]["enable_tpg"] = True
 swtpg_conf["readout"]["tpg_threshold"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
@@ -108,7 +109,8 @@ multiout_conf["dataflow"]["apps"][0]["output_paths"] = [".", "."]
 multiout_conf["dataflow"]["apps"][0]["max_file_size"] = 4*1024*1024*1024
 
 multiout_tpg_conf = copy.deepcopy(multiout_conf)
-multiout_tpg_conf["readout"]["emulator_mode"] = True
+multiout_tpg_conf["readout"]["generate_periodic_adc_pattern"] = True
+multiout_tpg_conf["readout"]["emulated_TP_rate_per_ch"] = 0.25
 multiout_tpg_conf["readout"]["enable_tpg"] = True
 multiout_tpg_conf["readout"]["tpg_threshold"] = 500
 multiout_tpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -95,7 +95,7 @@ conf_dict["dataflow"]["apps"][0]["max_file_size"] = 1074000000
 
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf["readout"]["generate_periodic_adc_pattern"] = True
-swtpg_conf["readout"]["emulated_TP_rate_per_ch"] = 0.25
+swtpg_conf["readout"]["emulated_TP_rate_per_ch"] = 1
 swtpg_conf["readout"]["enable_tpg"] = True
 swtpg_conf["readout"]["tpg_threshold"] = 500
 swtpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"
@@ -110,7 +110,7 @@ multiout_conf["dataflow"]["apps"][0]["max_file_size"] = 4*1024*1024*1024
 
 multiout_tpg_conf = copy.deepcopy(multiout_conf)
 multiout_tpg_conf["readout"]["generate_periodic_adc_pattern"] = True
-multiout_tpg_conf["readout"]["emulated_TP_rate_per_ch"] = 0.25
+multiout_tpg_conf["readout"]["emulated_TP_rate_per_ch"] = 1
 multiout_tpg_conf["readout"]["enable_tpg"] = True
 multiout_tpg_conf["readout"]["tpg_threshold"] = 500
 multiout_tpg_conf["readout"]["tpg_algorithm"] = "SimpleThreshold"


### PR DESCRIPTION
These changes are needed to keep the TPG parts of the integtests working after the latest changes to the WIB pattern generation.