### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(serialization REQUIRED) ## MR This can probably be removed? Unless 
 find_package(readoutlibs REQUIRED)
 find_package(Boost COMPONENTS iostreams unit_test_framework REQUIRED)
 
-daq_codegen( *.jsonnet DEP_PKGS detchannelmaps hdf5libs TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
+daq_codegen( *.jsonnet DEP_PKGS hdf5libs TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
 daq_codegen( info/*.jsonnet DEP_PKGS opmonlib TEMPLATES opmonlib/InfoStructs.hpp.j2 opmonlib/InfoNljs.hpp.j2 )
 
 ##############################################################################


### PR DESCRIPTION
Remove `detchannelmaps` dependency in `daq_codegen` call.

This is to avoid warning messages like: 

`path does not exist: /cvmfs/dunedaq-development.opensciencegrid.org/nightly/NAB23-09-14/spack-0.20.0-gcc-12.1.0/spack-0.20.0/opt/spack/linux-almalinux9-x86_64/gcc-12.1.0/detchannelmaps-NAB23-09-14-2picxyo3hpxfy4mtmzujgeayn75nlq7r/lib64/detchannelmaps/cmake/../../../share/schema`