### PR TITLE
DAQ conf split

### DIFF
--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -80,7 +80,7 @@ ignored_logfile_problems={}
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="daqconf_multiru_gen"
+confgen_name="fddaqconf_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 dro_map_contents = dro_map_gen.generate_dromap_contents(number_of_data_producers)

--- a/integtest/insufficient_disk_space_test.py
+++ b/integtest/insufficient_disk_space_test.py
@@ -95,7 +95,7 @@ required_logfile_problems={"dataflow": ["A problem was encountered when writing 
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="daqconf_multiru_gen"
+confgen_name="fddaqconf_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 dro_map_contents = dro_map_gen.generate_dromap_contents(number_of_data_producers, number_of_readout_apps)

--- a/integtest/large_trigger_record_test.py
+++ b/integtest/large_trigger_record_test.py
@@ -74,7 +74,7 @@ if total_disk_space_gb < minimum_total_disk_space_gb or free_disk_space_gb < min
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="daqconf_multiru_gen"
+confgen_name="fddaqconf_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 dro_map_contents = dro_map_gen.generate_dromap_contents(number_of_data_producers, number_of_readout_apps)

--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -74,7 +74,7 @@ ignored_logfile_problems={"trigger": ["zipped_tpset_q: Unable to push within tim
 # to run the config generation and nanorc
 
 # The name of the python module for the config generation
-confgen_name="daqconf_multiru_gen"
+confgen_name="fddaqconf_gen"
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 dro_map_contents = dro_map_gen.generate_dromap_contents(number_of_data_producers, number_of_readout_apps)


### PR DESCRIPTION
This pull request addresses the need to have a daqconf for fd and nd separately. This pull request is associated to a number of pull requests: 
- daqconf: https://github.com/DUNE-DAQ/daqconf/pull/386
- nddaqconf: https://github.com/DUNE-DAQ/nddaqconf/pull/3
- fddaqconf: https://github.com/DUNE-DAQ/fddaqconf/pull/1
- lbrulibs: https://github.com/DUNE-DAQ/lbrulibs/pull/62
- daq-systemtest: https://github.com/DUNE-DAQ/daq-systemtest/pull/64
- dfmodules: https://github.com/DUNE-DAQ/dfmodules/pull/313
- ndreadoutmodules: https://github.com/DUNE-DAQ/ndreadoutmodules/pull/5

You can find the associated issue in https://github.com/DUNE-DAQ/daq-deliverables/issues/119
and the deliverable documentation https://github.com/DUNE-DAQ/daq-deliverables/blob/feature/fddaq_v4.2.0_dev/docs/fddaq-v4.2.0/daqconfSplitForNDFD.md