### PR TITLE
removed the find_dependency calls for detchannelmaps and trgchannelma…

### DIFF
--- a/cmake/dfmodulesConfig.cmake.in
+++ b/cmake/dfmodulesConfig.cmake.in
@@ -19,8 +19,6 @@ find_dependency(trigger)
 find_dependency(serialization)
 find_dependency(readoutlibs)
 find_dependency(hdf5libs)
-find_dependency(detchannelmaps)
-find_dependency(trgchannelmaps)
 find_dependency(Boost COMPONENTS iostreams)
 
 


### PR DESCRIPTION
…ps from cmake/dfmodulesConfig.cmake.in since those packages aren't used by dfmodules code