### PR TITLE
Moved, renamed, and updated the script to run multiple dfmodules integtests

### DIFF
--- a/integtest/multi_output_file_test.py
+++ b/integtest/multi_output_file_test.py
@@ -66,7 +66,7 @@ hsi_frag_params ={"fragment_type_description": "HSI",
                              "fragment_type": "Hardware_Signal",
                              "hdf5_source_subsystem": "HW_Signals_Interface",
                              "expected_fragment_count": 1,
-                             "min_size_bytes": 72, "max_size_bytes": 100}
+                             "min_size_bytes": 72, "max_size_bytes": 128}
 ignored_logfile_problems={"trigger": ["zipped_tpset_q: Unable to push within timeout period"]}
 
 # The next three variable declarations *must* be present as globals in the test

--- a/scripts/dfmodules_integtest_bundle.sh
+++ b/scripts/dfmodules_integtest_bundle.sh
@@ -84,7 +84,13 @@ while [[ ${overall_loop_count} -lt ${overall_run_count} ]]; do
       let individual_loop_count=0
       while [[ ${individual_loop_count} -lt ${individual_run_count} ]]; do
         echo "===== Running ${TEST_NAME}" >> ${ITGRUNNER_LOG_FILE}
-        pytest -s ${TEST_NAME} --nanorc-option partition-number ${session_number} | tee -a ${ITGRUNNER_LOG_FILE}
+        if [[ -e "./${TEST_NAME}" ]]; then
+          pytest -s ./${TEST_NAME} --nanorc-option partition-number ${session_number} | tee -a ${ITGRUNNER_LOG_FILE}
+        elif [[ -e "${DBT_AREA_ROOT}/sourcecode/dfmodules/integtest/${TEST_NAME}" ]]; then
+          pytest -s ${DBT_AREA_ROOT}/sourcecode/dfmodules/integtest/${TEST_NAME} --nanorc-option partition-number ${session_number} | tee -a ${ITGRUNNER_LOG_FILE}
+        else
+          pytest -s ${DFMODULES_SHARE}/integtest/${TEST_NAME} --nanorc-option partition-number ${session_number} | tee -a ${ITGRUNNER_LOG_FILE}
+        fi
 
         let individual_loop_count=${individual_loop_count}+1
       done
@@ -97,13 +103,13 @@ while [[ ${overall_loop_count} -lt ${overall_run_count} ]]; do
 done
 
 # print out summary information
-echo ""
-echo ""
-echo "+++++++++++++++++++++++++++++++++++++++++++++++++"
-echo "++++++++++++++++++++ SUMMARY ++++++++++++++++++++"
-echo "+++++++++++++++++++++++++++++++++++++++++++++++++"
-echo ""
-date
-echo "Log file is: ${ITGRUNNER_LOG_FILE}"
-echo ""
-grep '=====' ${ITGRUNNER_LOG_FILE} | egrep ' in |Running'
+echo ""                                                   | tee -a ${ITGRUNNER_LOG_FILE}
+echo ""                                                   | tee -a ${ITGRUNNER_LOG_FILE}
+echo "+++++++++++++++++++++++++++++++++++++++++++++++++"  | tee -a ${ITGRUNNER_LOG_FILE}
+echo "++++++++++++++++++++ SUMMARY ++++++++++++++++++++"  | tee -a ${ITGRUNNER_LOG_FILE}
+echo "+++++++++++++++++++++++++++++++++++++++++++++++++"  | tee -a ${ITGRUNNER_LOG_FILE}
+echo ""                                                   | tee -a ${ITGRUNNER_LOG_FILE}
+date                                                      | tee -a ${ITGRUNNER_LOG_FILE}
+echo "Log file is: ${ITGRUNNER_LOG_FILE}"                 | tee -a ${ITGRUNNER_LOG_FILE}
+echo ""                                                   | tee -a ${ITGRUNNER_LOG_FILE}
+grep '=====' ${ITGRUNNER_LOG_FILE} | egrep ' in |Running' | tee -a ${ITGRUNNER_LOG_FILE}


### PR DESCRIPTION
For this, I copied the pattern that we used in the daqsystemtest repo.
The idea is to make the dfmodules_bundle run-able from any directory without needing to specify the full path to the script.
To test it, one will need to switch to this branch, re-build the software area, and probably re-run dbt-workarea-env.