### PR TITLE
Changes to support additional file transfer metadata

### DIFF
--- a/include/dfmodules/DataStore.hpp
+++ b/include/dfmodules/DataStore.hpp
@@ -120,7 +120,8 @@ public:
    * This allows DataStore instances to make any preparations that will be
    * beneficial in advance of the first data blocks being written or read.
    */
-  virtual void prepare_for_run(daqdataformats::run_number_t run_number) = 0;
+  virtual void prepare_for_run(daqdataformats::run_number_t run_number,
+                               bool run_is_for_test_purposes) = 0;
 
   /**
    * @brief Informs the DataStore that writes or reads of data blocks associated

--- a/plugins/DataWriter.cpp
+++ b/plugins/DataWriter.cpp
@@ -144,7 +144,6 @@ DataWriter::do_start(const data_t& payload)
   m_data_storage_is_enabled = (!start_params.disable_data_storage);
   m_run_number = start_params.run;
 
- 
   // 04-Feb-2021, KAB: added this call to allow DataStore to prepare for the run.
   // I've put this call fairly early in this method because it could throw an
   // exception and abort the run start.  And, it seems sensible to avoid starting
@@ -159,7 +158,7 @@ DataWriter::do_start(const data_t& payload)
     }
     
     try {
-      m_data_writer->prepare_for_run(m_run_number);
+      m_data_writer->prepare_for_run(m_run_number, (start_params.production_vs_test == "TEST"));
     } catch (const ers::Issue& excpt) {
       throw UnableToStart(ERS_HERE, get_name(), m_run_number, excpt);
     }

--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -254,9 +254,11 @@ public:
    *
    * This method may throw an exception if it finds a problem.
    */
-  void prepare_for_run(daqdataformats::run_number_t run_number)
+  void prepare_for_run(daqdataformats::run_number_t run_number,
+                       bool run_is_for_test_purposes)
   {
     m_run_number = run_number;
+    m_run_is_for_test_purposes = run_is_for_test_purposes;
 
     struct statvfs vfs_results;
     TLOG_DEBUG(TLVL_BASIC) << get_name() << ": Preparing to get the statvfs results for path: \"" << m_path << "\"";
@@ -316,6 +318,7 @@ private:
   std::string m_basic_name_of_open_file;
   unsigned m_open_flags_of_open_file;
   daqdataformats::run_number_t m_run_number;
+  bool m_run_is_for_test_purposes;
   hdf5libs::hdf5rawdatafile::SrcIDGeoIDMap m_hardware_map;
 
   // Total number of generated files
@@ -439,6 +442,8 @@ private:
         // write attributes that aren't being handled by the HDF5RawDataFile right now
         // m_file_handle->write_attribute("data_format_version",(int)m_key_translator_ptr->get_current_version());
         m_file_handle->write_attribute("operational_environment", (std::string)m_config_params.operational_environment);
+        m_file_handle->write_attribute("offline_data_stream", (std::string)m_config_params.offline_data_stream);
+        m_file_handle->write_attribute("run_is_for_test_purposes", (bool)m_run_is_for_test_purposes);
       }
     } else {
       TLOG_DEBUG(TLVL_BASIC) << get_name() << ": Pointer file to  " << m_basic_name_of_open_file

--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -443,7 +443,7 @@ private:
         // m_file_handle->write_attribute("data_format_version",(int)m_key_translator_ptr->get_current_version());
         m_file_handle->write_attribute("operational_environment", (std::string)m_config_params.operational_environment);
         m_file_handle->write_attribute("offline_data_stream", (std::string)m_config_params.offline_data_stream);
-        m_file_handle->write_attribute("run_is_for_test_purposes", (bool)m_run_is_for_test_purposes);
+        m_file_handle->write_attribute("run_is_for_test_purposes", (std::string)(m_run_is_for_test_purposes ? "true" : "false"));
       }
     } else {
       TLOG_DEBUG(TLVL_BASIC) << get_name() << ": Pointer file to  " << m_basic_name_of_open_file

--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -443,7 +443,7 @@ private:
         // m_file_handle->write_attribute("data_format_version",(int)m_key_translator_ptr->get_current_version());
         m_file_handle->write_attribute("operational_environment", (std::string)m_config_params.operational_environment);
         m_file_handle->write_attribute("offline_data_stream", (std::string)m_config_params.offline_data_stream);
-        m_file_handle->write_attribute("run_is_for_test_purposes", (std::string)(m_run_is_for_test_purposes ? "true" : "false"));
+        m_file_handle->write_attribute("run_was_for_test_purposes", (std::string)(m_run_is_for_test_purposes ? "true" : "false"));
       }
     } else {
       TLOG_DEBUG(TLVL_BASIC) << get_name() << ": Pointer file to  " << m_basic_name_of_open_file

--- a/plugins/TPStreamWriter.cpp
+++ b/plugins/TPStreamWriter.cpp
@@ -103,7 +103,7 @@ TPStreamWriter::do_start(const nlohmann::json& payload)
   // exception and abort the run start.  And, it seems sensible to avoid starting
   // threads, etc. if we throw an exception.
   try {
-    m_data_writer->prepare_for_run(m_run_number);
+    m_data_writer->prepare_for_run(m_run_number, (start_params.production_vs_test == "TEST"));
   } catch (const ers::Issue& excpt) {
     throw UnableToStart(ERS_HERE, get_name(), m_run_number, excpt);
   }

--- a/schema/dfmodules/hdf5datastore.jsonnet
+++ b/schema/dfmodules/hdf5datastore.jsonnet
@@ -59,7 +59,8 @@ local types = {
         s.field("free_space_safety_factor_for_write", self.factor, 5.0,
                 doc="The safety factor that should be used when determining if there is sufficient free disk space during write operations"),
         s.field("srcid_geoid_map", hdf5rdf.SrcIDGeoIDMap, doc="The Source-Geo Id map"),
-        
+	s.field("offline_data_stream", self.ds_string, "cosmics")
+
     ], doc="HDF5DataStore configuration"),
 
 };


### PR DESCRIPTION
These changes are part of the work to provide an additional file-transfer metadata field to offline (`DUNE.daq_test`) and to provide more descriptive values in the existing `data_stream` file-transfer metadata field.

The changes in this repo mainly consist of receiving the appropriate configuration or start-run parameters and storing them in each HDF5 data file as file-level Attributes.

This PR is part of a Deliverable for fddaq-v4.4.0, DUNE-DAQ/daq-deliverables#126, and it is coupled with corresponding PRs in other repos, such as DUNE-DAQ/daqconf#431 and DUNE-DAQ/hdf5libs#75.