### PR TITLE
Kbiery/tpswriter improvements

### DIFF
--- a/plugins/TPStreamWriter.cpp
+++ b/plugins/TPStreamWriter.cpp
@@ -158,36 +158,42 @@ TPStreamWriter::do_work(std::atomic<bool>& running_flag)
 
   TPBundleHandler tp_bundle_handler(m_accumulation_interval_ticks, m_run_number, m_accumulation_inactivity_time_before_write);
 
-  while (running_flag.load()) {
+  bool possible_pending_data = true;
+  while (running_flag.load() || possible_pending_data) {
     trigger::TPSet tpset;
     try {
       tpset = m_tpset_source->receive(m_queue_timeout);
       ++n_tpset_received;
       ++m_tpset_received;
+
+      if (tpset.type == trigger::TPSet::Type::kHeartbeat)
+        continue;
+
+      TLOG_DEBUG(21) << "Number of TPs in TPSet is " << tpset.objects.size() << ", Source ID is " << tpset.origin
+                     << ", seqno is " << tpset.seqno << ", start timestamp is " << tpset.start_time << ", run number is "
+                     << tpset.run_number << ", slice id is " << (tpset.start_time / m_accumulation_interval_ticks);
+
+      // 30-Mar-2022, KAB: added test for matching run number.  This is to avoid getting
+      // confused by TPSets that happen to be leftover in transit from one run to the
+      // next (which we have observed in v2.10.x systems).
+      if (tpset.run_number != m_run_number) {
+        TLOG_DEBUG(22) << "Discarding TPSet with invalid run number " << tpset.run_number << " (current is "
+                       << m_run_number << "),  Source ID is " << tpset.origin << ", seqno is " << tpset.seqno;
+        continue;
+      }
+
+      tp_bundle_handler.add_tpset(std::move(tpset));
     } catch (iomanager::TimeoutExpired&) {
-      continue;
+      if (running_flag.load()) {continue;}
     }
 
-    if (tpset.type == trigger::TPSet::Type::kHeartbeat)
-	    continue;
-
-    TLOG_DEBUG(21) << "Number of TPs in TPSet is " << tpset.objects.size() << ", Source ID is " << tpset.origin
-                   << ", seqno is " << tpset.seqno << ", start timestamp is " << tpset.start_time << ", run number is "
-                   << tpset.run_number << ", slice id is " << (tpset.start_time / m_accumulation_interval_ticks);
-
-    // 30-Mar-2022, KAB: added test for matching run number.  This is to avoid getting
-    // confused by TPSets that happen to be leftover in transit from one run to the
-    // next (which we have observed in v2.10.x systems).
-    if (tpset.run_number != m_run_number) {
-      TLOG_DEBUG(22) << "Discarding TPSet with invalid run number " << tpset.run_number << " (current is "
-                     << m_run_number << "),  Source ID is " << tpset.origin << ", seqno is " << tpset.seqno;
-      continue;
+    std::vector<std::unique_ptr<daqdataformats::TimeSlice>> list_of_timeslices;
+    if (running_flag.load()) {
+      list_of_timeslices = tp_bundle_handler.get_properly_aged_timeslices();
+    } else {
+      list_of_timeslices = tp_bundle_handler.get_all_remaining_timeslices();
+      possible_pending_data = false;
     }
-
-    tp_bundle_handler.add_tpset(std::move(tpset));
-
-    std::vector<std::unique_ptr<daqdataformats::TimeSlice>> list_of_timeslices =
-      tp_bundle_handler.get_properly_aged_timeslices();
     for (auto& timeslice_ptr : list_of_timeslices) {
       daqdataformats::SourceID sid(daqdataformats::SourceID::Subsystem::kTRBuilder, m_source_id);
       timeslice_ptr->set_element_id(sid);

--- a/plugins/TPStreamWriter.hpp
+++ b/plugins/TPStreamWriter.hpp
@@ -19,6 +19,7 @@
 #include "trigger/TPSet.hpp"
 #include "utilities/WorkerThread.hpp"
 
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -59,6 +60,7 @@ private:
   // Configuration
   std::chrono::milliseconds m_queue_timeout;
   size_t m_accumulation_interval_ticks;
+  std::chrono::steady_clock::duration m_accumulation_inactivity_time_before_write;
   daqdataformats::run_number_t m_run_number;
   uint32_t m_source_id; // NOLINT(build/unsigned)
 

--- a/schema/dfmodules/tpstreamwriter.jsonnet
+++ b/schema/dfmodules/tpstreamwriter.jsonnet
@@ -9,9 +9,13 @@ local types = {
 
     sourceid_number : s.number("sourceid_number", "u4", doc="Source identifier"),
 
+    float : s.number("Float", "f4", doc="A floating point number of 4 bytes"),
+
     conf: s.record("ConfParams", [
         s.field("tp_accumulation_interval_ticks", self.size, 62500000,
                 doc="Size of the TP accumulation window, measured in clock ticks"),
+        s.field("tp_accumulation_inactivity_time_before_write_sec", self.float, 1.0,
+                doc="Amount of time in which there must be no new data before a given time slice is written out (default is 1 sec)"),
         s.field("data_store_parameters", self.dsparams,
                 doc="Parameters that configure the DataStore associated with this TPStreamWriter"),
         s.field("source_id", self.sourceid_number, 999, doc="Source ID of TPSW instance, added to time slice header"),

--- a/src/TPBundleHandler.cpp
+++ b/src/TPBundleHandler.cpp
@@ -130,7 +130,9 @@ TPBundleHandler::add_tpset(trigger::TPSet&& tpset)
   }
 
   // 24-Mar-2024, KAB: added check for TimeSlice indexes that are earlier
-  // than the one that we started with. Discard them so that we don't get
+  // than the one that we started with. We try to gracefully handle them
+  // by adjusting the slice_ids of existing slices, but if we can't do that,
+  // we discard them so that we don't get
   // TimeSlices with large timeslice_ids (e.g. -1 converted to a uint64_t).
   if (tsidx_from_begin_time <= m_slice_index_offset) {
     auto lk = std::lock_guard<std::mutex>(m_accumulator_map_mutex);

--- a/src/TPBundleHandler.cpp
+++ b/src/TPBundleHandler.cpp
@@ -129,6 +129,10 @@ TPBundleHandler::add_tpset(trigger::TPSet&& tpset)
     m_slice_index_offset = tsidx_from_begin_time - 1;
   }
 
+  if (tsidx_from_begin_time <= m_slice_index_offset) {
+    return;
+  }
+
   // add the TPSet to any 'extra' accumulators
   for (size_t tsidx = (tsidx_from_begin_time + 1); tsidx <= tsidx_from_end_time; ++tsidx) {
     {

--- a/src/dfmodules/TPBundleHandler.hpp
+++ b/src/dfmodules/TPBundleHandler.hpp
@@ -93,6 +93,11 @@ public:
     return m_update_time;
   }
 
+  void update_slice_number(int delta)
+  {
+    m_slice_number += delta;
+  }
+
 private:
   daqdataformats::timestamp_t m_begin_time;
   daqdataformats::timestamp_t m_end_time;
@@ -115,6 +120,7 @@ public:
     , m_run_number(run_number)
     , m_cooling_off_time(cooling_off_time)
     , m_slice_index_offset(0)
+    , m_one_or_more_time_slices_have_aged_out(false)
   {
   }
 
@@ -136,6 +142,7 @@ private:
   size_t m_slice_index_offset;
   std::map<daqdataformats::timestamp_t, TimeSliceAccumulator> m_timeslice_accumulators;
   mutable std::mutex m_accumulator_map_mutex;
+  bool m_one_or_more_time_slices_have_aged_out;
 };
 } // namespace dfmodules
 } // namespace dunedaq

--- a/src/dfmodules/TPBundleHandler.hpp
+++ b/src/dfmodules/TPBundleHandler.hpp
@@ -40,6 +40,12 @@ ERS_DECLARE_ISSUE(dfmodules,
                     << tpset_source_id << ", start_time=" << tpset_start_time
                     << " to bundle, because another TPSet with these values already exists",
                   ((size_t)tpset_source_id)((daqdataformats::timestamp_t)tpset_start_time))
+ERS_DECLARE_ISSUE(dfmodules,
+                  TardyTPSetReceived,
+                  "Received a TPSet with a timestamp that is too early compared to ones that have already "
+                  << "been processed, sourceid=" << tpset_source_id << ", start_time=" << tpset_start_time
+                  << ", the calculated timeslice_id is " << tsid,
+                  ((size_t)tpset_source_id)((daqdataformats::timestamp_t)tpset_start_time)((int64_t)tsid))
 // Re-enable coverage checking LCOV_EXCL_STOP
 
 namespace dfmodules {
@@ -120,6 +126,8 @@ public:
   void add_tpset(trigger::TPSet&& tpset);
 
   std::vector<std::unique_ptr<daqdataformats::TimeSlice>> get_properly_aged_timeslices();
+
+  std::vector<std::unique_ptr<daqdataformats::TimeSlice>> get_all_remaining_timeslices();
 
 private:
   daqdataformats::timestamp_t m_slice_interval;


### PR DESCRIPTION
This PR is a response to [ehn1-operations-issues 30](https://github.com/DUNE-DAQ/ehn1-operations-issues/issues/30), "tpwriter errors on TimeSliceHeader dataset creation".  It has correlated changes in [daqconf](https://github.com/DUNE-DAQ/daqconf/pull/440) and [daqsystemtest](https://github.com/DUNE-DAQ/daqsystemtest/pull/85).

To help manage the error messages that are seen at EHN1, this PR adds support for a TPStreamWriter configuration parameter that can be used to lengthen the amount of time that the TPSW waits for a TimeSlice to be accumulated.  We believe that increasing this time will allow a wider variation of TPSet times to be accumulated in each TimeSlice in the TPStreamWriter, and this will avoid the error condition in which a TPSet arrives with a timestamp that is in a time interval (TimeSlice) that has already been written to the HDF5 file.

The new `daqconf` configuration input parameter is verbosely named `tp_accumulation_inactivity_time_before_write_sec`, and it has a default value of 1.0 seconds.  

The changes in this PR also

1. downgrade the annoying Error message to a Warning message
2. fix a bug in which a wide variation of TPSet timestamps at the beginning of a run can lead to nonsense slice numbers in the TimeSlices that are written to the HDF5 file
3. attempt to gracefully handle a moderate variation in TPSet timestamps at the beginning of a run.  If the variation cannot be gracefully handled, a warning message is printed out
5. fix a bug in which pending TimeSlices were not written out at the end of a run.
