### PR TITLE
Changes to avoid warning messages when tardy TPs arrive at the TPStreamWriter

### DIFF
--- a/include/dfmodules/DataStore.hpp
+++ b/include/dfmodules/DataStore.hpp
@@ -77,6 +77,17 @@ ERS_DECLARE_ISSUE(dfmodules,
 
 /**
  * @brief An ERS Issue for DataStore problems in which it is
+ * reasonable to skip any warning or error message.
+ * @cond Doxygen doesn't like ERS macros LCOV_EXCL_START
+ */
+ERS_DECLARE_ISSUE(dfmodules,
+                  IgnorableDataStoreProblem,
+                  "Module " << mod_name << ": A problem was encountered when " << description,
+                  ((std::string)mod_name)((std::string)description))
+/// @endcond LCOV_EXCL_STOP
+
+/**
+ * @brief An ERS Issue for DataStore problems in which it is
  * not clear whether retrying the operation might succeed or not.
  * @cond Doxygen doesn't like ERS macros LCOV_EXCL_START
  */

--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -241,8 +241,13 @@ public:
     }
 
     // write the data block
-    m_file_handle->write(ts);
-    m_recorded_size = m_file_handle->get_recorded_size();
+    try {
+      m_file_handle->write(ts);
+      m_recorded_size = m_file_handle->get_recorded_size();
+    } catch (hdf5libs::TimeSliceAlreadyExists const& excpt) {
+      std::string msg = "writing a time slice to file " + m_file_handle->get_file_name();
+      throw IgnorableDataStoreProblem(ERS_HERE, get_name(), msg, excpt);
+    }
   }
 
   /**

--- a/plugins/TPStreamWriter.cpp
+++ b/plugins/TPStreamWriter.cpp
@@ -215,7 +215,7 @@ TPStreamWriter::do_work(std::atomic<bool>& running_flag)
           m_data_writer->write(*timeslice_ptr);
 	  ++m_timeslice_written;
 	  m_bytes_output += timeslice_ptr->get_total_size_bytes();
-          m_tp_written += (timeslice_ptr->get_total_payload_data_size_bytes() / sizeof(trgdataformats::TriggerPrimitive));
+          m_tp_written += (timeslice_ptr->get_sum_of_fragment_payload_sizes() / sizeof(trgdataformats::TriggerPrimitive));
         } catch (const RetryableDataStoreProblem& excpt) {
           should_retry = true;
           ers::error(DataWritingProblem(ERS_HERE,

--- a/plugins/TPStreamWriter.hpp
+++ b/plugins/TPStreamWriter.hpp
@@ -82,6 +82,8 @@ private:
   std::atomic<uint64_t> m_timeslices_written = { 0 }; // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_bytes_output = { 0 };       // NOLINT(build/unsigned)
   std::atomic<double>   m_tardy_timeslice_max_seconds = { 0.0 }; // NOLINT(build/unsigned)
+  std::atomic<uint64_t> m_total_tps_received = { 0 }; // NOLINT(build/unsigned)
+  std::atomic<uint64_t> m_total_tps_written = { 0 };  // NOLINT(build/unsigned)
 };
 } // namespace dfmodules
 

--- a/schema/dfmodules/info/tpstreamwriterinfo.jsonnet
+++ b/schema/dfmodules/info/tpstreamwriterinfo.jsonnet
@@ -18,6 +18,8 @@ local info = {
        s.field("timeslices_written", self.uint8, 0, doc="incremental count of TimeSlices that have been written out"),
        s.field("bytes_output", self.uint8, 0, doc="incremental number of bytes that have been written out"),
        s.field("tardy_timeslice_max_seconds", self.float4, 0, doc="incremental max amount of time that a TimeSlice was tardy"),
+       s.field("total_tps_received", self.uint8, 0, doc="count of TPs that have been received in the current run"),
+       s.field("total_tps_written", self.uint8, 0, doc="count of TPs that have been written out in the current run"),
    ], doc="TPSet writer information")
 };
 

--- a/schema/dfmodules/info/tpstreamwriterinfo.jsonnet
+++ b/schema/dfmodules/info/tpstreamwriterinfo.jsonnet
@@ -9,9 +9,12 @@ local info = {
    uint8  : s.number("uint8", "u8", doc="An unsigned of 8 bytes"),
 
    info: s.record("Info", [
-       s.field("tpset_received", self.uint8, 0, doc="incremental received tpset counter"), 
-       s.field("tpset_written", self.uint8, 0, doc="incremental written tpset counter"), 
-       s.field("bytes_output", self.uint8, 0, doc="incremental number of bytes that have been written out"), 
+       s.field("tpset_received", self.uint8, 0, doc="incremental received tpset counter"),
+       s.field("tpset_accumulated", self.uint8, 0, doc="incremental accumulated tpset counter"),
+       s.field("tp_accumulated", self.uint8, 0, doc="incremental accumulated tp counter"),
+       s.field("tp_written", self.uint8, 0, doc="incremental written tp counter"),
+       s.field("timeslice_written", self.uint8, 0, doc="incremental written timeslice counter"),
+       s.field("bytes_output", self.uint8, 0, doc="incremental number of bytes that have been written out"),
    ], doc="TPSet writer information")
 };
 

--- a/schema/dfmodules/tpstreamwriter.jsonnet
+++ b/schema/dfmodules/tpstreamwriter.jsonnet
@@ -11,6 +11,8 @@ local types = {
 
     float : s.number("Float", "f4", doc="A floating point number of 4 bytes"),
 
+    flag: s.boolean("Flag", doc="Parameter that can be used to enable or disable functionality"),
+
     conf: s.record("ConfParams", [
         s.field("tp_accumulation_interval_ticks", self.size, 62500000,
                 doc="Size of the TP accumulation window, measured in clock ticks"),
@@ -19,6 +21,8 @@ local types = {
         s.field("data_store_parameters", self.dsparams,
                 doc="Parameters that configure the DataStore associated with this TPStreamWriter"),
         s.field("source_id", self.sourceid_number, 999, doc="Source ID of TPSW instance, added to time slice header"),
+        s.field("warn_user_when_late_tps_are_discarded", self.flag, false,
+                doc="Whether to warn users when TimeSlices that contain late TPs are discarded"),
     ], doc="TPStreamWriter configuration parameters"),
 
 };


### PR DESCRIPTION
This PR depends on ones in [daqdataformats](https://github.com/DUNE-DAQ/daqdataformats/pull/55) and [hdf5libs](https://github.com/DUNE-DAQ/hdf5libs/pull/96).

These changes include a flag to control whether warning messages are produced when tardy TPs arrive at the TPStreamWriter.  They also include additional metrics to provide insight into lost TPs when the warning messages are disabled.
