### PR TITLE
Copied the improvements in tardy TP handling from v4 to v5.

### DIFF
--- a/plugins/TPStreamWriterModule.cpp
+++ b/plugins/TPStreamWriterModule.cpp
@@ -71,9 +71,15 @@ void
 TPStreamWriterModule::generate_opmon_data() {
   opmon::TPStreamWriterInfo info;
 
-  info.set_tpset_received(m_tpset_received.exchange(0));
-  info.set_tp_received( m_tp_received.exchange(0) );
-  info.set_tp_written(m_tp_written.exchange(0));
+  info.set_heartbeat_tpsets_received(m_heartbeat_tpsets.exchange(0));
+  info.set_tpsets_with_tps_received(m_tpsets_with_tps.exchange(0));
+  info.set_tps_received(m_tps_received.exchange(0));
+  info.set_tps_written(m_tps_written.exchange(0));
+  info.set_total_tps_received(m_total_tps_received.load());
+  info.set_total_tps_written(m_total_tps_written.load());
+  info.set_tardy_timeslice_max_seconds(m_tardy_timeslice_max_seconds.exchange(0.0));
+  info.set_timeslices_written(m_timeslices_written.exchange(0));
+  info.set_bytes_output(m_bytes_output.exchange(0));
 
   publish(std::move(info));
 }
@@ -83,6 +89,10 @@ TPStreamWriterModule::do_conf(const data_t& )
 {
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_conf() method";
   m_accumulation_interval_ticks = m_tp_writer_conf->get_tp_accumulation_interval();
+  m_accumulation_inactivity_time_before_write =
+    std::chrono::milliseconds(static_cast<int>(1000*m_tp_writer_conf->get_tp_accumulation_inactivity_time_before_write_sec()));
+  m_warn_user_when_tardy_tps_are_discarded = m_tp_writer_conf->get_warn_user_when_tardy_tps_are_discarded();
+  m_accumulation_interval_seconds = ((double) m_accumulation_interval_ticks) / 62500000.0;
 
   // create the DataStore instance here
   try {
@@ -108,6 +118,8 @@ TPStreamWriterModule::do_start(const nlohmann::json& payload)
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_start() method";
   rcif::cmd::StartParams start_params = payload.get<rcif::cmd::StartParams>();
   m_run_number = start_params.run;
+  m_total_tps_received.store(0);
+  m_total_tps_written.store(0);
 
   // 06-Mar-2022, KAB: added this call to allow DataStore to prepare for the run.
   // I've put this call fairly early in this method because it could throw an
@@ -166,39 +178,57 @@ TPStreamWriterModule::do_work(std::atomic<bool>& running_flag)
   daqdataformats::timestamp_t first_timestamp = 0;
   daqdataformats::timestamp_t last_timestamp = 0;
 
-  TPBundleHandler tp_bundle_handler(m_accumulation_interval_ticks, m_run_number, std::chrono::seconds(1));
+  TPBundleHandler tp_bundle_handler(m_accumulation_interval_ticks, m_run_number, m_accumulation_inactivity_time_before_write);
 
-  while (running_flag.load()) {
+  bool possible_pending_data = true;
+  size_t largest_timeslice_number = 0;
+  while (running_flag.load() || possible_pending_data) {
     trigger::TPSet tpset;
     try {
       tpset = m_tpset_source->receive(m_queue_timeout);
       ++n_tpset_received;
-      ++m_tpset_received;
-      m_tp_received += tpset.objects.size();
+
+      if (tpset.type == trigger::TPSet::Type::kHeartbeat) {
+        ++m_heartbeat_tpsets;
+        continue;
+      }
+
+      TLOG_DEBUG(21) << "Number of TPs in TPSet is " << tpset.objects.size() << ", Source ID is " << tpset.origin
+                     << ", seqno is " << tpset.seqno << ", start timestamp is " << tpset.start_time << ", run number is "
+                     << tpset.run_number << ", slice id is " << (tpset.start_time / m_accumulation_interval_ticks);
+
+      // 30-Mar-2022, KAB: added test for matching run number.  This is to avoid getting
+      // confused by TPSets that happen to be leftover in transit from one run to the
+      // next (which we have observed in v2.10.x systems).
+      if (tpset.run_number != m_run_number) {
+        TLOG_DEBUG(22) << "Discarding TPSet with invalid run number " << tpset.run_number << " (current is "
+                       << m_run_number << "),  Source ID is " << tpset.origin << ", seqno is " << tpset.seqno;
+        continue;
+      }
+      ++m_tpsets_with_tps;
+
+      size_t num_tps_in_tpset = tpset.objects.size();
+      tp_bundle_handler.add_tpset(std::move(tpset));
+      m_tps_received += num_tps_in_tpset;
+      m_total_tps_received += num_tps_in_tpset;
     } catch (iomanager::TimeoutExpired&) {
-      continue;
+      if (running_flag.load()) {continue;}
     }
 
-    if (tpset.type == trigger::TPSet::Type::kHeartbeat)
-	    continue;
-
-    TLOG_DEBUG(21) << "Number of TPs in TPSet is " << tpset.objects.size() << ", Source ID is " << tpset.origin
-                   << ", seqno is " << tpset.seqno << ", start timestamp is " << tpset.start_time << ", run number is "
-                   << tpset.run_number << ", slice id is " << (tpset.start_time / m_accumulation_interval_ticks);
-
-    // 30-Mar-2022, KAB: added test for matching run number.  This is to avoid getting
-    // confused by TPSets that happen to be leftover in transit from one run to the
-    // next (which we have observed in v2.10.x systems).
-    if (tpset.run_number != m_run_number) {
-      TLOG_DEBUG(22) << "Discarding TPSet with invalid run number " << tpset.run_number << " (current is "
-                     << m_run_number << "),  Source ID is " << tpset.origin << ", seqno is " << tpset.seqno;
-      continue;
+    std::vector<std::unique_ptr<daqdataformats::TimeSlice>> list_of_timeslices;
+    if (running_flag.load()) {
+      list_of_timeslices = tp_bundle_handler.get_properly_aged_timeslices();
+    } else {
+      list_of_timeslices = tp_bundle_handler.get_all_remaining_timeslices();
+      possible_pending_data = false;
     }
 
-    tp_bundle_handler.add_tpset(std::move(tpset));
+    // keep track of the largest timeslice number (for reporting on tardy ones)
+    for (auto& timeslice_ptr : list_of_timeslices) {
+      largest_timeslice_number = std::max(timeslice_ptr->get_header().timeslice_number, largest_timeslice_number);
+    }
 
-    std::vector<std::unique_ptr<daqdataformats::TimeSlice>> list_of_timeslices =
-      tp_bundle_handler.get_properly_aged_timeslices();
+    // attempt to write out each TimeSlice
     for (auto& timeslice_ptr : list_of_timeslices) {
       daqdataformats::SourceID sid(daqdataformats::SourceID::Subsystem::kTRBuilder, m_source_id);
       timeslice_ptr->set_element_id(sid);
@@ -210,12 +240,11 @@ TPStreamWriterModule::do_work(std::atomic<bool>& running_flag)
         should_retry = false;
         try {
           m_data_writer->write(*timeslice_ptr);
-	  size_t n_tp = 0;
-	  const auto & frags = timeslice_ptr -> get_fragments_ref();
-	  for ( const auto & f_ptr :  frags ) {
-	    n_tp += f_ptr -> get_data_size()/sizeof(trgdataformats::TriggerPrimitive);
-	  }
-	  m_tp_written += n_tp;
+	  ++m_timeslices_written;
+	  m_bytes_output += timeslice_ptr->get_total_size_bytes();
+          size_t number_of_tps_written = (timeslice_ptr->get_sum_of_fragment_payload_sizes() / sizeof(trgdataformats::TriggerPrimitive));
+          m_tps_written += number_of_tps_written;
+          m_total_tps_written += number_of_tps_written;
         } catch (const RetryableDataStoreProblem& excpt) {
           should_retry = true;
           ers::error(DataWritingProblem(ERS_HERE,
@@ -228,6 +257,24 @@ TPStreamWriterModule::do_work(std::atomic<bool>& running_flag)
           }
           usleep(retry_wait_usec);
           retry_wait_usec *= 2;
+        } catch (const IgnorableDataStoreProblem& excpt) {
+          int timeslice_number_diff = largest_timeslice_number - timeslice_ptr->get_header().timeslice_number;
+          double seconds_too_late = m_accumulation_interval_seconds * timeslice_number_diff;
+          m_tardy_timeslice_max_seconds = std::max(m_tardy_timeslice_max_seconds.load(), seconds_too_late);
+          if (m_warn_user_when_tardy_tps_are_discarded) {
+            std::ostringstream sid_list;
+            bool first_frag = true;
+            for (auto const& frag_ptr : timeslice_ptr->get_fragments_ref()) {
+              if (first_frag) {first_frag = false;}
+              else {sid_list << ",";}
+              sid_list << frag_ptr->get_element_id().to_string();
+            }
+            ers::warning(TardyTPsDiscarded(ERS_HERE,
+                                           get_name(),
+                                           sid_list.str(),
+                                           timeslice_ptr->get_header().timeslice_number,
+                                           seconds_too_late));
+          }
         } catch (const std::exception& excpt) {
           ers::error(DataWritingProblem(ERS_HERE,
                                         get_name(),

--- a/schema/dfmodules/opmon/TPStreamWriter.proto
+++ b/schema/dfmodules/opmon/TPStreamWriter.proto
@@ -4,9 +4,17 @@ package dunedaq.dfmodules.opmon;
 
 message TPStreamWriterInfo {
 
-  uint64 tpset_received = 1;  // incremental
-  uint64 tp_received  = 10;   // incremental
-  uint64 tp_written   = 11;   // incremental
+  uint64 heartbeat_tpsets_received = 1; // incremental count of heartbeat TPSets received
+  uint64 tpsets_with_tps_received = 2;  // incremental count of TPSets received that contain TPs
+
+  uint64 tps_received = 11;       // incremental count of TPs that have been received
+  uint64 tps_written = 12;        // incremental count of TPs that have been written out
+  uint64 total_tps_received = 16; // count of TPs that have been received in the current run
+  uint64 total_tps_written = 17;  // count of TPs that have been written out in the current run
+
+uint64 tardy_timeslice_max_seconds = 21; //incremental max amount of time that a TimeSlice was tardy
+
+  uint64 timeslices_written = 31; // incremental count of TimeSlices that have been written out
+  uint64 bytes_output = 32;       // incremental number of bytes that have been written out
 
 }
-

--- a/src/dfmodules/TPBundleHandler.hpp
+++ b/src/dfmodules/TPBundleHandler.hpp
@@ -40,6 +40,12 @@ ERS_DECLARE_ISSUE(dfmodules,
                     << tpset_source_id << ", start_time=" << tpset_start_time
                     << " to bundle, because another TPSet with these values already exists",
                   ((size_t)tpset_source_id)((daqdataformats::timestamp_t)tpset_start_time))
+ERS_DECLARE_ISSUE(dfmodules,
+                  TardyTPSetReceived,
+                  "Received a TPSet with a timestamp that is too early compared to ones that have already "
+                  << "been processed, sourceid=" << tpset_source_id << ", start_time=" << tpset_start_time
+                  << ", the calculated timeslice_id is " << tsid,
+                  ((size_t)tpset_source_id)((daqdataformats::timestamp_t)tpset_start_time)((int64_t)tsid))
 // Re-enable coverage checking LCOV_EXCL_STOP
 
 namespace dfmodules {
@@ -87,6 +93,11 @@ public:
     return m_update_time;
   }
 
+  void update_slice_number(int delta)
+  {
+    m_slice_number += delta;
+  }
+
 private:
   daqdataformats::timestamp_t m_begin_time;
   daqdataformats::timestamp_t m_end_time;
@@ -109,6 +120,7 @@ public:
     , m_run_number(run_number)
     , m_cooling_off_time(cooling_off_time)
     , m_slice_index_offset(0)
+    , m_one_or_more_time_slices_have_aged_out(false)
   {
   }
 
@@ -121,6 +133,8 @@ public:
 
   std::vector<std::unique_ptr<daqdataformats::TimeSlice>> get_properly_aged_timeslices();
 
+  std::vector<std::unique_ptr<daqdataformats::TimeSlice>> get_all_remaining_timeslices();
+
 private:
   daqdataformats::timestamp_t m_slice_interval;
   daqdataformats::run_number_t m_run_number;
@@ -128,6 +142,7 @@ private:
   size_t m_slice_index_offset;
   std::map<daqdataformats::timestamp_t, TimeSliceAccumulator> m_timeslice_accumulators;
   mutable std::mutex m_accumulator_map_mutex;
+  bool m_one_or_more_time_slices_have_aged_out;
 };
 } // namespace dfmodules
 } // namespace dunedaq


### PR DESCRIPTION
These changes are dependent on ones in [appmodel](https://github.com/DUNE-DAQ/appmodel/pull/145).  And, there is [a change in daqsystemtest](https://github.com/DUNE-DAQ/daqsystemtest/pull/131) that depends on this one.

I have re-run the tests that are described in PR #358, and the majority of the integtest in the daqsystemtest repo continue to work with these changes.