### PR TITLE
Added a get_receiver() call for the DataRequest input in the FragmentAggregator init() method.

### DIFF
--- a/plugins/FragmentAggregatorModule.cpp
+++ b/plugins/FragmentAggregatorModule.cpp
@@ -55,6 +55,10 @@ FragmentAggregatorModule::init(std::shared_ptr<appfwk::ModuleConfiguration> mcfg
       	    m_producer_conn_ids[qid->get_source_id()] = cr->UID();
     }
   }
+
+  // this is just to get the data request receiver registered early (before Start)
+  auto iom = iomanager::IOManager::get();
+  iom->get_receiver<dfmessages::DataRequest>(m_data_req_input);
 }
 
 // void

--- a/plugins/FragmentAggregatorModule.cpp
+++ b/plugins/FragmentAggregatorModule.cpp
@@ -139,6 +139,11 @@ FragmentAggregatorModule::process_fragment(std::unique_ptr<daqdataformats::Fragm
     }
   }
   try {
+    TLOG_DEBUG(27) << get_name() << " Sending fragment for trigger/sequence_number "
+                   << fragment->get_trigger_number() << "."
+                   << fragment->get_sequence_number() << " and SourceID "
+                   << fragment->get_element_id() << " to "
+                   << trb_identifier;
     auto sender = get_iom_sender<std::unique_ptr<daqdataformats::Fragment>>(trb_identifier);
     sender->send(std::move(fragment), iomanager::Sender::s_no_block);
   } catch (const ers::Issue& excpt) {


### PR DESCRIPTION
This is to get the receiver registered early, before we install the callback at Start time, so that senders can find it when they look for it.

This helps avoid the warning messages that we have been seeing in the minimal_system_quick_test in which the TRB complains about not being able to send DataRequests at the start of the run.

I'm including the addition of a debug statement in this PR that I found useful several weeks ago when debugging a different problem.

To test this change, I locally modified a copy of the minimal_system_quick_test to have no wait between start and enable-triggers.  That modified test fails fairly often on daq.fnal.gov without the code change in the PR, and has not failed yet in my testing with this code change.