### PR TITLE
Added checks in do_start() methods to verify that data senders are ready to send data

### DIFF
--- a/plugins/DFOModule.hpp
+++ b/plugins/DFOModule.hpp
@@ -129,6 +129,7 @@ private:
   size_t m_td_send_retries;
   size_t m_busy_threshold;
   size_t m_free_threshold;
+  std::vector<std::string> m_trb_conn_ids;
 
   // Coordination
   std::atomic<bool> m_running_status{ false };

--- a/plugins/FragmentAggregatorModule.cpp
+++ b/plugins/FragmentAggregatorModule.cpp
@@ -54,6 +54,9 @@ FragmentAggregatorModule::init(std::shared_ptr<appfwk::ModuleConfiguration> mcfg
 	auto qid = cr->cast<confmodel::QueueWithSourceId>();
       	    m_producer_conn_ids[qid->get_source_id()] = cr->UID();
     }
+    if (cr->get_data_type() == datatype_to_string<daqdataformats::Fragment>()) {
+      m_trb_conn_ids.push_back(cr->UID());
+    }
   }
 
   // this is just to get the data request receiver registered early (before Start)
@@ -74,7 +77,14 @@ void
 FragmentAggregatorModule::do_start(const data_t& /* args */)
 {
   m_packets_processed = 0;
+
   auto iom = iomanager::IOManager::get();
+  for (auto trb_conn : m_trb_conn_ids) {
+    auto sender = iom->get_sender<std::unique_ptr<daqdataformats::Fragment>>(trb_conn);
+    if (sender != nullptr) {
+      sender->is_ready_for_sending(std::chrono::milliseconds(100));
+    }
+  }
   iom->add_callback<dfmessages::DataRequest>(
     m_data_req_input, std::bind(&FragmentAggregatorModule::process_data_request, this, std::placeholders::_1));
   iom->add_callback<std::unique_ptr<daqdataformats::Fragment>>(

--- a/plugins/FragmentAggregatorModule.cpp
+++ b/plugins/FragmentAggregatorModule.cpp
@@ -54,7 +54,7 @@ FragmentAggregatorModule::init(std::shared_ptr<appfwk::ModuleConfiguration> mcfg
 	auto qid = cr->cast<confmodel::QueueWithSourceId>();
       	    m_producer_conn_ids[qid->get_source_id()] = cr->UID();
     }
-    if (cr->get_data_type() == datatype_to_string<daqdataformats::Fragment>()) {
+    if (cr->get_data_type() == datatype_to_string<std::unique_ptr<daqdataformats::Fragment>>()) {
       m_trb_conn_ids.push_back(cr->UID());
     }
   }
@@ -82,7 +82,8 @@ FragmentAggregatorModule::do_start(const data_t& /* args */)
   for (auto trb_conn : m_trb_conn_ids) {
     auto sender = iom->get_sender<std::unique_ptr<daqdataformats::Fragment>>(trb_conn);
     if (sender != nullptr) {
-      sender->is_ready_for_sending(std::chrono::milliseconds(100));
+      bool is_ready = sender->is_ready_for_sending(std::chrono::milliseconds(100));
+      TLOG_DEBUG(0) << "The sender for " << trb_conn << " " << (is_ready ? "is" : "is not") << " ready.";
     }
   }
   iom->add_callback<dfmessages::DataRequest>(

--- a/plugins/FragmentAggregatorModule.hpp
+++ b/plugins/FragmentAggregatorModule.hpp
@@ -61,10 +61,11 @@ private:
   void process_data_request(dfmessages::DataRequest&);
   void process_fragment(std::unique_ptr<daqdataformats::Fragment>&);
 
-  // Input Connection namess
+  // Input and Output Connection namess
   std::string m_data_req_input;
   std::string m_fragment_input;
   std::map<int, std::string> m_producer_conn_ids;
+  std::vector<std::string> m_trb_conn_ids;
 
   // Stats
   std::atomic<int> m_packets_processed{ 0 };

--- a/plugins/TRBModule.cpp
+++ b/plugins/TRBModule.cpp
@@ -206,6 +206,17 @@ TRBModule::do_start(const data_t& args)
 {
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_start() method";
 
+  {
+    std::unique_lock<std::mutex> lk(m_map_sourceid_connections_mutex);
+    for (const auto& sid_sender : m_map_sourceid_connections) {
+      std::shared_ptr<data_req_sender_t> sender = sid_sender.second;
+      if (sender != nullptr) {
+        bool is_ready = sender->is_ready_for_sending(std::chrono::milliseconds(100));
+        TLOG_DEBUG(0) << "The sender for " << sid_sender.first << " " << (is_ready ? "is" : "is not") << " ready.";
+      }
+    }
+  }
+
   m_run_number.reset(new const daqdataformats::run_number_t(args.at("run").get<daqdataformats::run_number_t>()));
 
   // Register the callback to receive monitoring requests


### PR DESCRIPTION
...in DFModule, TRBModule, and FragmentAggregatorModule.

The background for these changes is that we noticed that the automated regression tests that include TPG (trigger primitive generation)  in the `daqsystemtest` package would sometimes have Warning messages in the DFO and/or MLT log files saying that triggers were inhibited or had been assigned to TRBuilders that were already fully busy.  These warning messages would only happen at the start of the first run in a DAQ session.

Debugging this by looking at TRACE messages from various Dataflow software modules, it became clear that there were slight delays in sending the first several messages between Dataflow and Readout DAQ modules at the start of the first run.  Another clue to the cause of this problem was the observation that the Connectivity Service was running somewhat slower than normal when the "inhibit" warning messages appeared.

The proposed solution is to cause the various IOManager Sender objects In the relevant DAQModules to pre-fetch the needed destination information from the ConnectivityService.  This is done by calling the "is_ready_for_sending()" method of the Sender objects in the DAQModule do_start() method.

To reproduce the problem and validate the changes in this PR, we can use the following steps:

- create a software area based on a recent nightly build, such as described [here](https://github.com/DUNE-DAQ/daqconf/wiki/Setting-up-a-fddaq%E2%80%90v5.3.0-development-area).
- check out and install a temporary version of the connectivityserver software in this software area.  This temporary version of the ConnectivityService includes an artificial delay in its get_connection operation to make it appear as if it is running slowly.  Here are suggested steps to do this:
    - `cd $DBT_AREA_ROOT`
    - `git clone https://github.com/DUNE-DAQ/connectivityserver.git -b develop`
    - `cd connectivityserver`
    - `git checkout kbiery/artificial_get_connection_delay`
    - `pip install -U .`
- run the TPG part of the 3ru_3df_multirun_test
    - `cd $DBT_AREA_ROOT/sourcecode/daqsystemtest/integtest`
    - `pytest -k TPG -s 3ru_3df_multirun_test.py`
- note the warning messages in logfiles that cause the integtest to fail
- update the dfmodules software to include the changes in this PR
    - `cd $DBT_AREA_ROOT/sourcecode/dfmodules`
    - `git checkout kbiery/check_senders_ready`
    - `cd $DBT_AREA_ROOT`
    - `dbt-build -j 12 ; dbt-workarea-env`
- re-run the TPG part of the 3ru_3df_multirun_test
    - `cd $DBT_AREA_ROOT/sourcecode/daqsystemtest/integtest`
    - `pytest -k TPG -s 3ru_3df_multirun_test.py`
- note that the integtest now runs cleanly/successfully
- restore the ConnectivityService code to its default version
    - `cd $DBT_AREA_ROOT/connectivityserver`
    - `git checkout develop`
    - `pip install -U .`
    - `cd $DBT_AREA_ROOT`
