### PR TITLE
Avoid a race condition in the DFO

### DIFF
--- a/plugins/DFOModule.cpp
+++ b/plugins/DFOModule.cpp
@@ -135,6 +135,10 @@ DFOModule::do_start(const data_t& payload)
   m_last_token_received = m_last_td_received = std::chrono::steady_clock::now();
 
   auto iom = iomanager::IOManager::get();
+  if (m_busy_sender != nullptr) {
+    bool is_ready = m_busy_sender->is_ready_for_sending(std::chrono::milliseconds(100));
+    TLOG_DEBUG(0) << "The sender for TriggerInhibit messages " << (is_ready ? "is" : "is not") << " ready.";
+  }
   for (auto trb_conn : m_trb_conn_ids) {
     auto sender = iom->get_sender<dfmessages::TriggerDecision>(trb_conn);
     if (sender != nullptr) {


### PR DESCRIPTION
To avoid a race condition in the DFO in which a busy state is determined but that state has changed by the time that the value is sent to the MLT, we have combined the `is_busy()` lookup and the sending of the result to the MLT into a single method and protected the contents of that method with a mutex.

This PR is loosely coupled with one in `datahandlinglibs` ([PR 37](https://github.com/DUNE-DAQ/datahandlinglibs/pull/37)).  Together, they noticeably reduce the chance for Trigger Inhibits to happen in various integration/regression tests in the `daqsystemtest` package.  

Here are sample instructions for demonstrating the effect of these changes on np04-srv-003.  Typically, the first set of `3ru_1df` runs does not complete 10 iterations without encountering a trigger inhibit warning.  And, typically, the second set of `3ru_1df` runs does not enounter a trigger inhibit warning in its 10 iterations.

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest_v5
dbt-create -n NFD_DEV_241231_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/datahandlinglibs.git -b develop
cd datahandlinglibs ; git checkout a904cac9d5f ; cd ..

git clone https://github.com/DUNE-DAQ/fdreadoutlibs.git -b develop
cd fdreadoutlibs ; git checkout 69a06db374 ; cd ..

git clone https://github.com/DUNE-DAQ/fdreadoutmodules.git -b develop
cd fdreadoutmodules ; git checkout 64884a05334 ; cd ..

git clone https://github.com/DUNE-DAQ/dfmodules.git -b develop
cd dfmodules ; git checkout 57951b26d24 ; cd ..

git clone https://github.com/DUNE-DAQ/trigger.git -b develop
cd trigger ; git checkout 3cbbc8ecae6 ; cd ..

cd ..

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

daqsystemtest_integtest_bundle.sh -f 6 -l 6 -N 10 --stop-on-fail

cd sourcecode/datahandlinglibs
git checkout kbiery/fragments_senders_ready_at_start
cd ../../

cd sourcecode/dfmodules
git checkout kbiery/dfo_notify_trigger_mutex
cd ../../

dbt-build -j 12
dbt-workarea-env

daqsystemtest_integtest_bundle.sh -f 6 -l 6 -N 10 --stop-on-fail
```

Full disclosure:  the second set of regression tests does not always complete fully successfully.  Occasionally, there are unrelated problems that cause an early stop.  And, at least once, I have observed a trigger inhibit message from run 103 (which is different than the ones that are often observed in run 101).  So, the success of the second set of integtests may be best described as a significant reduction in the occurrence of trigger inhibit messages.