### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/include/dfmodules/DataStore.hpp
+++ b/include/dfmodules/DataStore.hpp
@@ -22,7 +22,7 @@
 #include "daqdataformats/TimeSlice.hpp"
 #include "daqdataformats/TriggerRecord.hpp"
 #include "daqdataformats/Types.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include "utilities/NamedObject.hpp"
 
 #include "nlohmann/json.hpp"

--- a/include/dfmodules/DataStore.hpp
+++ b/include/dfmodules/DataStore.hpp
@@ -22,7 +22,7 @@
 #include "daqdataformats/TimeSlice.hpp"
 #include "daqdataformats/TriggerRecord.hpp"
 #include "daqdataformats/Types.hpp"
-#include "logging/Logging.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include "utilities/NamedObject.hpp"
 
 #include "nlohmann/json.hpp"

--- a/plugins/DFOModule.hpp
+++ b/plugins/DFOModule.hpp
@@ -23,7 +23,7 @@
 #include "iomanager/Sender.hpp"
 
 #include "appfwk/DAQModule.hpp"
-#include "logging/Logging.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <map>
 #include <memory>

--- a/plugins/DFOModule.hpp
+++ b/plugins/DFOModule.hpp
@@ -23,7 +23,7 @@
 #include "iomanager/Sender.hpp"
 
 #include "appfwk/DAQModule.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <map>
 #include <memory>

--- a/plugins/DataWriterModule.hpp
+++ b/plugins/DataWriterModule.hpp
@@ -18,6 +18,7 @@
 #include "iomanager/Receiver.hpp"
 #include "iomanager/Sender.hpp"
 #include "utilities/WorkerThread.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <chrono>
 #include <map>

--- a/plugins/DataWriterModule.hpp
+++ b/plugins/DataWriterModule.hpp
@@ -18,7 +18,7 @@
 #include "iomanager/Receiver.hpp"
 #include "iomanager/Sender.hpp"
 #include "utilities/WorkerThread.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <chrono>
 #include <map>

--- a/plugins/FakeDataProdModule.hpp
+++ b/plugins/FakeDataProdModule.hpp
@@ -15,6 +15,7 @@
 #include "appmodel/FakeDataProdConf.hpp"
 #include "appfwk/DAQModule.hpp"
 #include "utilities/WorkerThread.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <memory>
 #include <string>

--- a/plugins/FakeDataProdModule.hpp
+++ b/plugins/FakeDataProdModule.hpp
@@ -15,7 +15,7 @@
 #include "appmodel/FakeDataProdConf.hpp"
 #include "appfwk/DAQModule.hpp"
 #include "utilities/WorkerThread.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <memory>
 #include <string>

--- a/plugins/FragmentAggregatorModule.hpp
+++ b/plugins/FragmentAggregatorModule.hpp
@@ -15,6 +15,7 @@
 #include "dfmessages/DataRequest.hpp"
 
 #include "appfwk/DAQModule.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include "iomanager/Receiver.hpp"
 #include "iomanager/Sender.hpp"

--- a/plugins/FragmentAggregatorModule.hpp
+++ b/plugins/FragmentAggregatorModule.hpp
@@ -15,7 +15,7 @@
 #include "dfmessages/DataRequest.hpp"
 
 #include "appfwk/DAQModule.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include "iomanager/Receiver.hpp"
 #include "iomanager/Sender.hpp"

--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -24,7 +24,7 @@
 #include "confmodel/Session.hpp"
 
 #include "appfwk/DAQModule.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include "boost/date_time/posix_time/posix_time.hpp"
 #include "boost/lexical_cast.hpp"

--- a/plugins/HDF5DataStore.hpp
+++ b/plugins/HDF5DataStore.hpp
@@ -24,7 +24,7 @@
 #include "confmodel/Session.hpp"
 
 #include "appfwk/DAQModule.hpp"
-#include "logging/Logging.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include "boost/date_time/posix_time/posix_time.hpp"
 #include "boost/lexical_cast.hpp"

--- a/plugins/TPStreamWriterModule.hpp
+++ b/plugins/TPStreamWriterModule.hpp
@@ -19,6 +19,7 @@
 #include "daqdataformats/TimeSlice.hpp"
 #include "trigger/TPSet.hpp"
 #include "utilities/WorkerThread.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <memory>
 #include <string>

--- a/plugins/TPStreamWriterModule.hpp
+++ b/plugins/TPStreamWriterModule.hpp
@@ -19,7 +19,7 @@
 #include "daqdataformats/TimeSlice.hpp"
 #include "trigger/TPSet.hpp"
 #include "utilities/WorkerThread.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <memory>
 #include <string>

--- a/plugins/TRBModule.hpp
+++ b/plugins/TRBModule.hpp
@@ -25,7 +25,7 @@
 #include "utilities/WorkerThread.hpp"
 #include "iomanager/Sender.hpp"
 #include "iomanager/Receiver.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include "dfmodules/opmon/TRBModule.pb.h"
 

--- a/plugins/TRBModule.hpp
+++ b/plugins/TRBModule.hpp
@@ -25,6 +25,7 @@
 #include "utilities/WorkerThread.hpp"
 #include "iomanager/Sender.hpp"
 #include "iomanager/Receiver.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include "dfmodules/opmon/TRBModule.pb.h"
 

--- a/src/dfmodules/CommonIssues.hpp
+++ b/src/dfmodules/CommonIssues.hpp
@@ -15,6 +15,7 @@
 #include "appfwk/DAQModule.hpp"
 #include "daqdataformats/SourceID.hpp"
 #include "daqdataformats/Types.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 

--- a/src/dfmodules/CommonIssues.hpp
+++ b/src/dfmodules/CommonIssues.hpp
@@ -15,7 +15,7 @@
 #include "appfwk/DAQModule.hpp"
 #include "daqdataformats/SourceID.hpp"
 #include "daqdataformats/Types.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 

--- a/src/dfmodules/TPBundleHandler.hpp
+++ b/src/dfmodules/TPBundleHandler.hpp
@@ -17,6 +17,7 @@
 #include "trgdataformats/TriggerPrimitive.hpp"
 #include "ers/Issue.hpp"
 #include "trigger/TPSet.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <chrono>
 #include <map>

--- a/src/dfmodules/TPBundleHandler.hpp
+++ b/src/dfmodules/TPBundleHandler.hpp
@@ -17,7 +17,7 @@
 #include "trgdataformats/TriggerPrimitive.hpp"
 #include "ers/Issue.hpp"
 #include "trigger/TPSet.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <chrono>
 #include <map>

--- a/src/dfmodules/TriggerRecordBuilderData.hpp
+++ b/src/dfmodules/TriggerRecordBuilderData.hpp
@@ -19,7 +19,7 @@
 #include "ers/Issue.hpp"
 #include "nlohmann/json.hpp"
 #include "opmonlib/MonitorableObject.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <atomic>
 #include <chrono>

--- a/src/dfmodules/TriggerRecordBuilderData.hpp
+++ b/src/dfmodules/TriggerRecordBuilderData.hpp
@@ -19,6 +19,7 @@
 #include "ers/Issue.hpp"
 #include "nlohmann/json.hpp"
 #include "opmonlib/MonitorableObject.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <atomic>
 #include <chrono>


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)