### PR TITLE
Set completion time in metadata function passed to complete_assignment, to minimize measurement error

### DIFF
--- a/src/TriggerRecordBuilderData.cpp
+++ b/src/TriggerRecordBuilderData.cpp
@@ -105,7 +105,7 @@ TriggerRecordBuilderData::complete_assignment(daqdataformats::trigger_number_t t
 
   ++m_complete_counter;
   auto completion_time =
-    std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - dec_ptr->assigned_time);
+    std::chrono::duration_cast<std::chrono::microseconds>(now - dec_ptr->assigned_time);
   if (completion_time.count() < m_min_complete_time.load())
     m_min_complete_time.store(completion_time.count());
   if (completion_time.count() > m_max_complete_time.load())

--- a/unittest/TriggerRecordBuilderData_test.cxx
+++ b/unittest/TriggerRecordBuilderData_test.cxx
@@ -104,11 +104,13 @@ BOOST_AUTO_TEST_CASE(Assignments)
 
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
-  trbd_p->complete_assignment(1, [](nlohmann::json&) {});
+  std::chrono::steady_clock::time_point complete_time;
+  trbd_p->complete_assignment(1,
+                              [&complete_time](nlohmann::json&) { complete_time = std::chrono::steady_clock::now(); });
   BOOST_REQUIRE_EQUAL(trbd_p->used_slots(), 0);
 
   auto latency =
-    std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - assignment->assigned_time)
+    std::chrono::duration_cast<std::chrono::microseconds>(complete_time - assignment->assigned_time)
       .count();
 
   BOOST_REQUIRE_CLOSE(static_cast<double>(trbd_p->average_latency(start_time).count()), static_cast<double>(latency), 5);


### PR DESCRIPTION
In TriggerRecordBuilderData_test, there is a sleep_for on L105, which provides some amount of latency to be measured. Commenting this line causes the latency check to fail in the old code, whereas with this update, even with no time delay the comparison check succeeds.

Resolves #401 