### PR TITLE
Add verbose error

### DIFF
--- a/plugins/FragmentAggregatorModule.cpp
+++ b/plugins/FragmentAggregatorModule.cpp
@@ -167,7 +167,12 @@ FragmentAggregatorModule::process_fragment(std::unique_ptr<daqdataformats::Fragm
     auto sender = get_iom_sender<std::unique_ptr<daqdataformats::Fragment>>(trb_identifier);
     sender->send(std::move(fragment), iomanager::Sender::s_no_block);
   } catch (const ers::Issue& excpt) {
-    ers::warning(excpt);
+    ers::error(AbandonedFragment(ERS_HERE,
+				 fragment->get_run_number(),
+				 fragment->get_trigger_number(),
+				 fragment->get_sequence_number(),
+				 fragment->get_element_id(),
+				 excpt));
   }
 }
 

--- a/plugins/FragmentAggregatorModule.hpp
+++ b/plugins/FragmentAggregatorModule.hpp
@@ -39,6 +39,16 @@ ERS_DECLARE_ISSUE(dfmodules,                  ///< Namespace
                   ((daqdataformats::SourceID)src)                                         ///< Message parameters
 )
 
+
+ERS_DECLARE_ISSUE(dfmodules,                ///< Namespace
+                  AbandonedFragment,        ///< Issue class name
+                  "Fragment from " <<  source << " for trigger " << trigger << '-' << sequence << " of run " << run << " was dropped",
+		  ((daqdataformats::run_number_t)run)
+                  ((daqdataformats::trigger_number_t)trigger)
+		  ((daqdataformats::sequence_number_t)sequence)              
+		  ((daqdataformats::SourceID)source)
+)
+
 namespace dfmodules {
 
 class FragmentAggregatorModule : public dunedaq::appfwk::DAQModule


### PR DESCRIPTION
When the fragment aggregator fails to send, the issue is reported as a warning which is not descriptive because we don't have any information about the what is lost. We only know what error was reported by the iomanager. This is the typical example of what is seen. 

![Screenshot From 2025-06-04 12-54-30](https://github.com/user-attachments/assets/40b09c76-7d12-45f4-a9de-5ea468044666)

This PRs turns the warning into an error, as there is data loss and it also adds a dedicated ERS message to specify what was lost. 
This is a screenshot of the message that we see after the PR. 

![image](https://github.com/user-attachments/assets/49166fe5-0294-4618-8682-57e76e1a473e)
