### PR TITLE
Monitoring for FragmentAggregatorModule

### DIFF
--- a/plugins/FragmentAggregatorModule.cpp
+++ b/plugins/FragmentAggregatorModule.cpp
@@ -72,14 +72,16 @@ FragmentAggregatorModule::generate_opmon_data()
   opmon::FragmentAggregatorTimeInfo dr_times;
   uint64_t avg = (m_data_requests_processed != 0) ? (m_data_requests_time_average_us / m_data_requests_processed) : 0;
   dr_times.set_average_us(avg); m_data_requests_time_average_us.exchange(0);
-  dr_times.set_min_us(m_data_requests_time_min_us.exchange(0));
+  uint64_t old_min = m_data_requests_time_min_us.exchange(std::numeric_limits<uint64_t>::max());
+  dr_times.set_min_us((old_min < std::numeric_limits<uint64_t>::max()) ? old_min : 0);
   dr_times.set_max_us(m_data_requests_time_max_us.exchange(0));
   this->publish(std::move(dr_times), { { "data", "DataRequest" } });
 
   opmon::FragmentAggregatorTimeInfo frag_times;
   uint64_t avg2 = (m_fragments_processed != 0) ? (m_fragments_time_average_us / m_fragments_processed) : 0;
   frag_times.set_average_us(avg2); m_fragments_time_average_us.exchange(0);
-  frag_times.set_min_us(m_fragments_time_min_us.exchange(0));
+  uint64_t old_min2 = m_fragments_time_min_us.exchange(std::numeric_limits<uint64_t>::max());
+  frag_times.set_min_us((old_min2 < std::numeric_limits<uint64_t>::max()) ? old_min2 : 0);
   frag_times.set_max_us(m_fragments_time_max_us.exchange(0));
   this->publish(std::move(frag_times), { { "data", "Fragment" } });
 
@@ -154,7 +156,10 @@ FragmentAggregatorModule::process_data_request(dfmessages::DataRequest& data_req
 
   {
     std::scoped_lock lock(m_mutex);
+    
+    m_timestamp_before_dr = get_current_time_us();
     m_data_requests_received++;
+
     std::tuple<dfmessages::trigger_number_t, dfmessages::sequence_number_t, daqdataformats::SourceID> triplet = {
       data_request.trigger_number, data_request.sequence_number, data_request.request_information.component
     };
@@ -175,7 +180,12 @@ FragmentAggregatorModule::process_data_request(dfmessages::DataRequest& data_req
       auto sender = get_iom_sender<dfmessages::DataRequest>(uid_elem->second);
       data_request.data_destination = m_fragment_input;
       sender->send(std::move(data_request), iomanager::Sender::s_no_block);
+
       m_data_requests_processed++;
+      auto timestamp_total = get_current_time_us() - m_timestamp_before_dr;
+      if (timestamp_total < m_data_requests_time_min_us) { m_data_requests_time_min_us = timestamp_total; }
+      if (timestamp_total > m_data_requests_time_max_us) { m_data_requests_time_max_us = timestamp_total; }
+      m_data_requests_time_average_us += timestamp_total;
     }
   } catch (const ers::Issue& excpt) {
     ers::warning(excpt);
@@ -191,7 +201,9 @@ FragmentAggregatorModule::process_fragment(std::unique_ptr<daqdataformats::Fragm
   {
     std::scoped_lock lock(m_mutex);
     
+    m_timestamp_before_frag = get_current_time_us();
     m_fragments_received++;
+
     std::bitset<32> error_bits = fragment->get_error_bits();
     if (error_bits[static_cast<size_t>(dunedaq::daqdataformats::FragmentErrorBits::kDataNotFound)])
       m_fragments_empty++;
@@ -220,7 +232,13 @@ FragmentAggregatorModule::process_fragment(std::unique_ptr<daqdataformats::Fragm
                    << trb_identifier;
     auto sender = get_iom_sender<std::unique_ptr<daqdataformats::Fragment>>(trb_identifier);
     sender->send(std::move(fragment), iomanager::Sender::s_no_block);
+    
     m_fragments_processed++;
+    auto timestamp_total = get_current_time_us() - m_timestamp_before_frag;
+    if (timestamp_total < m_fragments_time_min_us) { m_fragments_time_min_us = timestamp_total; }
+    if (timestamp_total > m_fragments_time_max_us) { m_fragments_time_max_us = timestamp_total; }
+    m_fragments_time_average_us += timestamp_total;
+
   } catch (const ers::Issue& excpt) {
     ers::error(AbandonedFragment(ERS_HERE,
 				 fragment->get_run_number(),
@@ -230,6 +248,13 @@ FragmentAggregatorModule::process_fragment(std::unique_ptr<daqdataformats::Fragm
 				 excpt));
     m_fragments_failed++;
   }
+}
+
+uint64_t 
+FragmentAggregatorModule::get_current_time_us()
+{
+  return std::chrono::duration_cast<std::chrono::microseconds>(
+    std::chrono::steady_clock::now().time_since_epoch()).count();
 }
 
 } // namespace dfmodules

--- a/plugins/FragmentAggregatorModule.cpp
+++ b/plugins/FragmentAggregatorModule.cpp
@@ -8,10 +8,12 @@
 
 #include "FragmentAggregatorModule.hpp"
 #include "dfmodules/CommonIssues.hpp"
+#include "dfmodules/opmon/FragmentAggregatorModule.pb.h"
 
 #include "appmodel/FragmentAggregatorModule.hpp"
 #include "confmodel/Connection.hpp"
 #include "confmodel/QueueWithSourceId.hpp"
+#include "daqdataformats/FragmentHeader.hpp"
 #include "dfmessages/Fragment_serialization.hpp"
 #include "logging/Logging.hpp"
 
@@ -64,19 +66,37 @@ FragmentAggregatorModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcf
   iom->get_receiver<dfmessages::DataRequest>(m_data_req_input);
 }
 
-// void
-// FragmentAggregatorModule::get_info(opmonlib::InfoCollector& /*ci*/, int /* level */)
-// {
-//   // dummyconsumerinfo::Info info;
-//   // info.packets_processed = m_packets_processed;
+void
+FragmentAggregatorModule::generate_opmon_data()
+{
+  opmon::FragmentAggregatorModuleInfo info;
 
-//   // ci.add(info);
-// }
+  info.set_data_requests_received(m_data_requests_received.exchange(0));
+  info.set_data_requests_processed(m_data_requests_processed.exchange(0));
+  info.set_data_requests_failed(m_data_requests_failed.load());  //the failed counters are meant NOT to reset
+  info.set_fragments_received(m_fragments_received.exchange(0));
+  info.set_fragments_processed(m_fragments_processed.exchange(0));
+  info.set_fragments_failed(m_fragments_failed.load());
+  info.set_fragments_empty(m_fragments_empty.exchange(0));
+  info.set_fragments_incomplete(m_fragments_incomplete.exchange(0));
+  info.set_fragments_invalid(m_fragments_invalid.exchange(0));
+
+  this->publish(std::move(info));
+}
 
 void
 FragmentAggregatorModule::do_start(const data_t& /* args */)
 {
-  m_packets_processed = 0;
+
+  m_data_requests_received.store(0);
+  m_data_requests_processed.store(0);
+  m_data_requests_failed.store(0);
+  m_fragments_received.store(0);
+  m_fragments_processed.store(0);
+  m_fragments_failed.store(0);
+  m_fragments_empty.store(0);
+  m_fragments_incomplete.store(0);
+  m_fragments_invalid.store(0);
 
   // 19-Dec-2024, KAB: check that Fragment senders are ready to send. This is done so
   // that the IOManager infrastructure fetches the necessary connection details from
@@ -113,6 +133,7 @@ FragmentAggregatorModule::process_data_request(dfmessages::DataRequest& data_req
 
   {
     std::scoped_lock lock(m_mutex);
+    m_data_requests_received++;
     std::tuple<dfmessages::trigger_number_t, dfmessages::sequence_number_t, daqdataformats::SourceID> triplet = {
       data_request.trigger_number, data_request.sequence_number, data_request.request_information.component
     };
@@ -133,9 +154,11 @@ FragmentAggregatorModule::process_data_request(dfmessages::DataRequest& data_req
       auto sender = get_iom_sender<dfmessages::DataRequest>(uid_elem->second);
       data_request.data_destination = m_fragment_input;
       sender->send(std::move(data_request), iomanager::Sender::s_no_block);
+      m_data_requests_processed++;
     }
   } catch (const ers::Issue& excpt) {
     ers::warning(excpt);
+    m_data_requests_failed++;
   }
 }
 
@@ -146,6 +169,16 @@ FragmentAggregatorModule::process_fragment(std::unique_ptr<daqdataformats::Fragm
   std::string trb_identifier;
   {
     std::scoped_lock lock(m_mutex);
+    
+    m_fragments_received++;
+    std::bitset<32> error_bits = fragment->get_error_bits();
+    if (error_bits[static_cast<size_t>(dunedaq::daqdataformats::FragmentErrorBits::kDataNotFound)])
+      m_fragments_empty++;
+    if (error_bits[static_cast<size_t>(dunedaq::daqdataformats::FragmentErrorBits::kIncomplete)])
+      m_fragments_incomplete++;
+    if (error_bits[static_cast<size_t>(dunedaq::daqdataformats::FragmentErrorBits::kInvalidWindow)])
+      m_fragments_invalid++;
+
     auto dr_iter = m_data_req_map.find(
       std::make_tuple<dfmessages::trigger_number_t, dfmessages::sequence_number_t, daqdataformats::SourceID>(
         fragment->get_trigger_number(), fragment->get_sequence_number(), fragment->get_element_id()));
@@ -166,6 +199,7 @@ FragmentAggregatorModule::process_fragment(std::unique_ptr<daqdataformats::Fragm
                    << trb_identifier;
     auto sender = get_iom_sender<std::unique_ptr<daqdataformats::Fragment>>(trb_identifier);
     sender->send(std::move(fragment), iomanager::Sender::s_no_block);
+    m_fragments_processed++;
   } catch (const ers::Issue& excpt) {
     ers::error(AbandonedFragment(ERS_HERE,
 				 fragment->get_run_number(),
@@ -173,6 +207,7 @@ FragmentAggregatorModule::process_fragment(std::unique_ptr<daqdataformats::Fragm
 				 fragment->get_sequence_number(),
 				 fragment->get_element_id(),
 				 excpt));
+    m_fragments_failed++;
   }
 }
 

--- a/plugins/FragmentAggregatorModule.cpp
+++ b/plugins/FragmentAggregatorModule.cpp
@@ -69,19 +69,34 @@ FragmentAggregatorModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcf
 void
 FragmentAggregatorModule::generate_opmon_data()
 {
-  opmon::FragmentAggregatorModuleInfo info;
+  opmon::FragmentAggregatorTimeInfo dr_times;
+  uint64_t avg = (m_data_requests_processed != 0) ? (m_data_requests_time_average_us / m_data_requests_processed) : 0;
+  dr_times.set_average_us(avg); m_data_requests_time_average_us.exchange(0);
+  dr_times.set_min_us(m_data_requests_time_min_us.exchange(0));
+  dr_times.set_max_us(m_data_requests_time_max_us.exchange(0));
+  this->publish(std::move(dr_times), { { "data", "DataRequest" } });
 
-  info.set_data_requests_received(m_data_requests_received.exchange(0));
-  info.set_data_requests_processed(m_data_requests_processed.exchange(0));
-  info.set_data_requests_failed(m_data_requests_failed.load());  //the failed counters are meant NOT to reset
-  info.set_fragments_received(m_fragments_received.exchange(0));
-  info.set_fragments_processed(m_fragments_processed.exchange(0));
-  info.set_fragments_failed(m_fragments_failed.load());
-  info.set_fragments_empty(m_fragments_empty.exchange(0));
-  info.set_fragments_incomplete(m_fragments_incomplete.exchange(0));
-  info.set_fragments_invalid(m_fragments_invalid.exchange(0));
+  opmon::FragmentAggregatorTimeInfo frag_times;
+  uint64_t avg2 = (m_fragments_processed != 0) ? (m_fragments_time_average_us / m_fragments_processed) : 0;
+  frag_times.set_average_us(avg2); m_fragments_time_average_us.exchange(0);
+  frag_times.set_min_us(m_fragments_time_min_us.exchange(0));
+  frag_times.set_max_us(m_fragments_time_max_us.exchange(0));
+  this->publish(std::move(frag_times), { { "data", "Fragment" } });
 
-  this->publish(std::move(info));
+  opmon::FADataRequestsCounterInfo dr_info;
+  dr_info.set_data_requests_received(m_data_requests_received.exchange(0));
+  dr_info.set_data_requests_processed(m_data_requests_processed.exchange(0));
+  dr_info.set_data_requests_failed(m_data_requests_failed.load());  //the failed counters are meant NOT to reset
+  this->publish(std::move(dr_info));
+
+  opmon::FAFragmentsCounterInfo frag_info;
+  frag_info.set_fragments_received(m_fragments_received.exchange(0));
+  frag_info.set_fragments_processed(m_fragments_processed.exchange(0));
+  frag_info.set_fragments_failed(m_fragments_failed.load());
+  frag_info.set_fragments_empty(m_fragments_empty.exchange(0));
+  frag_info.set_fragments_incomplete(m_fragments_incomplete.exchange(0));
+  frag_info.set_fragments_invalid(m_fragments_invalid.exchange(0));
+  this->publish(std::move(frag_info));
 }
 
 void
@@ -97,6 +112,12 @@ FragmentAggregatorModule::do_start(const data_t& /* args */)
   m_fragments_empty.store(0);
   m_fragments_incomplete.store(0);
   m_fragments_invalid.store(0);
+  m_fragments_time_average_us.store(0);
+  m_fragments_time_min_us.store(std::numeric_limits<uint64_t>::max());
+  m_fragments_time_max_us.store(0);
+  m_data_requests_time_average_us.store(0);
+  m_data_requests_time_min_us.store(std::numeric_limits<uint64_t>::max());
+  m_data_requests_time_max_us.store(0);
 
   // 19-Dec-2024, KAB: check that Fragment senders are ready to send. This is done so
   // that the IOManager infrastructure fetches the necessary connection details from

--- a/plugins/FragmentAggregatorModule.cpp
+++ b/plugins/FragmentAggregatorModule.cpp
@@ -69,21 +69,21 @@ FragmentAggregatorModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcf
 void
 FragmentAggregatorModule::generate_opmon_data()
 {
-  opmon::FragmentAggregatorTimeInfo dr_times;
-  uint64_t avg = (m_data_requests_processed != 0) ? (m_data_requests_time_average_us / m_data_requests_processed) : 0;
-  dr_times.set_average_us(avg); m_data_requests_time_average_us.exchange(0);
-  uint64_t old_min = m_data_requests_time_min_us.exchange(std::numeric_limits<uint64_t>::max());
-  dr_times.set_min_us((old_min < std::numeric_limits<uint64_t>::max()) ? old_min : 0);
-  dr_times.set_max_us(m_data_requests_time_max_us.exchange(0));
-  this->publish(std::move(dr_times), { { "data", "DataRequest" } });
+  if (m_data_requests_processed > 0) {
+    opmon::FragmentAggregatorTimeInfo dr_times;
+    dr_times.set_min_us(m_data_requests_time_min_us.exchange(std::numeric_limits<uint64_t>::max()));	  
+    dr_times.set_max_us(m_data_requests_time_max_us.exchange(0));
+    dr_times.set_average_us(m_data_requests_time_average_us.exchange(0) / m_data_requests_processed);
+    this->publish(std::move(dr_times), { { "data", "DataRequest" } });
+  }
 
-  opmon::FragmentAggregatorTimeInfo frag_times;
-  uint64_t avg2 = (m_fragments_processed != 0) ? (m_fragments_time_average_us / m_fragments_processed) : 0;
-  frag_times.set_average_us(avg2); m_fragments_time_average_us.exchange(0);
-  uint64_t old_min2 = m_fragments_time_min_us.exchange(std::numeric_limits<uint64_t>::max());
-  frag_times.set_min_us((old_min2 < std::numeric_limits<uint64_t>::max()) ? old_min2 : 0);
-  frag_times.set_max_us(m_fragments_time_max_us.exchange(0));
-  this->publish(std::move(frag_times), { { "data", "Fragment" } });
+  if (m_fragments_processed > 0) {
+    opmon::FragmentAggregatorTimeInfo frag_times;
+    frag_times.set_min_us(m_fragments_time_min_us.exchange(std::numeric_limits<uint64_t>::max()));
+    frag_times.set_max_us(m_fragments_time_max_us.exchange(0));
+    frag_times.set_average_us(m_fragments_time_average_us.exchange(0) / m_fragments_processed);
+    this->publish(std::move(frag_times), { { "data", "Fragment" } });
+  }
 
   opmon::FADataRequestsCounterInfo dr_info;
   dr_info.set_data_requests_received(m_data_requests_received.exchange(0));

--- a/plugins/FragmentAggregatorModule.hpp
+++ b/plugins/FragmentAggregatorModule.hpp
@@ -72,13 +72,16 @@ private:
   void process_data_request(dfmessages::DataRequest&);
   void process_fragment(std::unique_ptr<daqdataformats::Fragment>&);
 
-  // Input and Output Connection namess
+  // Input and Output Connection names
   std::string m_data_req_input;
   std::string m_fragment_input;
   std::map<int, std::string> m_producer_conn_ids;
   std::vector<std::string> m_trb_conn_ids;
 
   // Opmon
+  uint64_t get_current_time_us();
+  uint64_t m_timestamp_before_dr;
+  uint64_t m_timestamp_before_frag;
   using metric_counter_type = uint64_t;
   std::atomic<metric_counter_type> m_data_requests_received{ 0 };
   std::atomic<metric_counter_type> m_data_requests_processed{ 0 };

--- a/plugins/FragmentAggregatorModule.hpp
+++ b/plugins/FragmentAggregatorModule.hpp
@@ -89,6 +89,12 @@ private:
   std::atomic<metric_counter_type> m_fragments_empty{ 0 };
   std::atomic<metric_counter_type> m_fragments_incomplete{ 0 };
   std::atomic<metric_counter_type> m_fragments_invalid{ 0 };
+  std::atomic<metric_counter_type> m_fragments_time_average_us{ 0 };
+  std::atomic<metric_counter_type> m_fragments_time_min_us{ 0 };
+  std::atomic<metric_counter_type> m_fragments_time_max_us{ 0 };
+  std::atomic<metric_counter_type> m_data_requests_time_average_us{ 0 };
+  std::atomic<metric_counter_type> m_data_requests_time_min_us{ 0 };
+  std::atomic<metric_counter_type> m_data_requests_time_max_us{ 0 };
 
   // TRB tracking
   std::map<std::tuple<dfmessages::trigger_number_t, dfmessages::sequence_number_t, daqdataformats::SourceID>,

--- a/plugins/FragmentAggregatorModule.hpp
+++ b/plugins/FragmentAggregatorModule.hpp
@@ -62,7 +62,7 @@ public:
   FragmentAggregatorModule& operator=(FragmentAggregatorModule&&) = delete;
 
   void init(std::shared_ptr<appfwk::ConfigurationManager> mcfg) override;
-  //  void get_info(opmonlib::InfoCollector& ci, int level) override;
+  void generate_opmon_data() override;
 
 private:
   // Commands
@@ -78,8 +78,17 @@ private:
   std::map<int, std::string> m_producer_conn_ids;
   std::vector<std::string> m_trb_conn_ids;
 
-  // Stats
-  std::atomic<int> m_packets_processed{ 0 };
+  // Opmon
+  using metric_counter_type = uint64_t;
+  std::atomic<metric_counter_type> m_data_requests_received{ 0 };
+  std::atomic<metric_counter_type> m_data_requests_processed{ 0 };
+  std::atomic<metric_counter_type> m_data_requests_failed{ 0 };
+  std::atomic<metric_counter_type> m_fragments_received{ 0 };
+  std::atomic<metric_counter_type> m_fragments_processed{ 0 };
+  std::atomic<metric_counter_type> m_fragments_failed{ 0 };
+  std::atomic<metric_counter_type> m_fragments_empty{ 0 };
+  std::atomic<metric_counter_type> m_fragments_incomplete{ 0 };
+  std::atomic<metric_counter_type> m_fragments_invalid{ 0 };
 
   // TRB tracking
   std::map<std::tuple<dfmessages::trigger_number_t, dfmessages::sequence_number_t, daqdataformats::SourceID>,

--- a/schema/dfmodules/opmon/FragmentAggregatorModule.proto
+++ b/schema/dfmodules/opmon/FragmentAggregatorModule.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package dunedaq.dfmodules.opmon;
+
+message FragmentAggregatorModuleInfo {
+
+  uint64 data_requests_received = 1;
+  uint64 data_requests_processed = 2;
+  uint64 data_requests_failed = 3;
+  uint64 fragments_received = 4;
+  uint64 fragments_processed = 5;
+  uint64 fragments_failed = 6;
+  uint64 fragments_empty = 7;
+  uint64 fragments_incomplete = 8;
+  uint64 fragments_invalid = 9;
+}

--- a/schema/dfmodules/opmon/FragmentAggregatorModule.proto
+++ b/schema/dfmodules/opmon/FragmentAggregatorModule.proto
@@ -2,15 +2,29 @@ syntax = "proto3";
 
 package dunedaq.dfmodules.opmon;
 
-message FragmentAggregatorModuleInfo {
+message FADataRequestsCounterInfo {
 
   uint64 data_requests_received = 1;
   uint64 data_requests_processed = 2;
   uint64 data_requests_failed = 3;
-  uint64 fragments_received = 4;
-  uint64 fragments_processed = 5;
-  uint64 fragments_failed = 6;
-  uint64 fragments_empty = 7;
-  uint64 fragments_incomplete = 8;
-  uint64 fragments_invalid = 9;
+
+}
+
+message FAFragmentsCounterInfo {
+
+  uint64 fragments_received = 1;
+  uint64 fragments_processed = 2;
+  uint64 fragments_failed = 3;
+  uint64 fragments_empty = 4;
+  uint64 fragments_incomplete = 5;
+  uint64 fragments_invalid = 6;
+
+}
+
+message FragmentAggregatorTimeInfo {
+
+  uint64 average_us = 1;
+  uint64 min_us = 2;
+  uint64 max_us = 3;
+
 }


### PR DESCRIPTION
Upon request from @mroda88, here is an initial version of opmon monitoring for FragmentAggregatorModule.

This includes:
- removing old / obsolete portions of opmon vars
- adding opmon metrics for data requests (received, sent, failed)
- adding opmon metrics for fragments (received, sent, failed)
- additional error checking for the fragment error bits (empty, incomplete, invalid window)
- adding opmon metrics for processing time (avg, min, max) for both data requests and fragments
- associated protobuf messages

The counters for `failed` are set-up to be cumulative (no resets). 

Testing:
- passes unit tests
- passes daqsystemtest_integtest_bundle
- local:
  - Able to see the relevant metrics being published and the counters to change in time:
- local:
  - Able to see the relevant metrics being published and the counters to change in time:
    - Data Requests processing times:

        ```
        {
         "time": "2025-06-11T09:48:20.972742681Z",
         "origin": {
          "session": "mrigan-local-test",
          "application": "ru-01",
          "substructure": [
           "fragmentaggregator-ru-01"
          ]
         },
         "custom_origin": {
          "data": "DataRequest"
         },
         "measurement": "dunedaq.dfmodules.opmon.FragmentAggregatorTimeInfo",
         "data": {
          "average_us": {
           "uint8_value": "10"
          },
          "min_us": {
           "uint8_value": "3"
          },
          "max_us": {
           "uint8_value": "218"
          }
         }
        }
        ```

    - Fragments processing times:

        ```
        {
         "time": "2025-06-11T09:48:20.972992235Z",
         "origin": {
          "session": "mrigan-local-test",
          "application": "ru-01",
          "substructure": [
           "fragmentaggregator-ru-01"
          ]
         },
         "custom_origin": {
          "data": "Fragment"
         },
         "measurement": "dunedaq.dfmodules.opmon.FragmentAggregatorTimeInfo",
         "data": {
          "average_us": {
           "uint8_value": "29"
          },
          "max_us": {
           "uint8_value": "169"
          },
          "min_us": {
           "uint8_value": "2"
          }
         }
        }
        ```

    - Fragments counters:

        ```
        {
         "time": "2025-06-11T09:48:20.973457987Z",
         "origin": {
          "session": "mrigan-local-test",
          "application": "ru-01",
          "substructure": [
           "fragmentaggregator-ru-01"
          ]
         },
         "measurement": "dunedaq.dfmodules.opmon.FAFragmentsCounterInfo",
         "data": {
          "fragments_empty": {
           "uint8_value": "4"
          },
          "fragments_failed": {
           "uint8_value": "0"
          },
          "fragments_processed": {
           "uint8_value": "231"
          },
          "fragments_invalid": {
           "uint8_value": "0"
          },
          "fragments_received": {
           "uint8_value": "231"
          },
          "fragments_incomplete": {
           "uint8_value": "0"
          }
         }
        }
        ```

    - Data requests counters:

        ```
        {
         "time": "2025-06-11T09:48:51.078466196Z",
         "origin": {
          "session": "mrigan-local-test",
          "application": "ru-01",
          "substructure": [
           "fragmentaggregator-ru-01"
          ]
         },
         "measurement": "dunedaq.dfmodules.opmon.FADataRequestsCounterInfo",
         "data": {
          "data_requests_failed": {
           "uint8_value": "0"
          },
          "data_requests_processed": {
           "uint8_value": "301"
          },
          "data_requests_received": {
           "uint8_value": "301"
          }
         }
        }
        ```