### PR TITLE
Adding discarded TPs metric

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(dfmodules VERSION 4.1.2)
+project(dfmodules VERSION 4.1.3)
 
 find_package(daq-cmake REQUIRED)
 daq_setup_environment()

--- a/plugins/TPStreamWriterModule.cpp
+++ b/plugins/TPStreamWriterModule.cpp
@@ -75,8 +75,10 @@ TPStreamWriterModule::generate_opmon_data() {
   info.set_tpsets_with_tps_received(m_tpsets_with_tps.exchange(0));
   info.set_tps_received(m_tps_received.exchange(0));
   info.set_tps_written(m_tps_written.exchange(0));
+  info.set_tps_discarded(m_tps_discarded.exchange(0));
   info.set_total_tps_received(m_total_tps_received.load());
   info.set_total_tps_written(m_total_tps_written.load());
+  info.set_total_tps_discarded(m_total_tps_discarded.load());
   info.set_tardy_timeslice_max_seconds(m_tardy_timeslice_max_seconds.exchange(0.0));
   info.set_timeslices_written(m_timeslices_written.exchange(0));
   info.set_bytes_output(m_bytes_output.exchange(0));
@@ -276,6 +278,9 @@ TPStreamWriterModule::do_work(std::atomic<bool>& running_flag)
               else {sid_list << ",";}
               sid_list << frag_ptr->get_element_id().to_string();
             }
+	    size_t number_of_tps_discarded = (timeslice_ptr->get_sum_of_fragment_payload_sizes() / sizeof(trgdataformats::TriggerPrimitive));
+	    m_tps_discarded += number_of_tps_discarded;
+	    m_total_tps_discarded += number_of_tps_discarded;
             ers::warning(TardyTPsDiscarded(ERS_HERE,
                                            get_name(),
                                            sid_list.str(),

--- a/plugins/TPStreamWriterModule.cpp
+++ b/plugins/TPStreamWriterModule.cpp
@@ -122,6 +122,7 @@ TPStreamWriterModule::do_start(const nlohmann::json& payload)
   m_run_number = start_params.run;
   m_total_tps_received.store(0);
   m_total_tps_written.store(0);
+  m_total_tps_discarded.store(0);
 
   // 06-Mar-2022, KAB: added this call to allow DataStore to prepare for the run.
   // I've put this call fairly early in this method because it could throw an

--- a/plugins/TPStreamWriterModule.cpp
+++ b/plugins/TPStreamWriterModule.cpp
@@ -248,8 +248,9 @@ TPStreamWriterModule::do_work(std::atomic<bool>& running_flag)
       size_t retry_wait_usec = 1000;
       do {
         should_retry = false;
+	size_t number_of_tps = 0;
         try {
-	  size_t number_of_tps = (timeslice_ptr->get_sum_of_fragment_payload_sizes() / sizeof(trgdataformats::TriggerPrimitive));
+	  number_of_tps = (timeslice_ptr->get_sum_of_fragment_payload_sizes() / sizeof(trgdataformats::TriggerPrimitive));
           m_data_writer->write(*timeslice_ptr);
 	  ++m_timeslices_written;
 	  m_bytes_output += timeslice_ptr->get_total_size_bytes();

--- a/plugins/TPStreamWriterModule.cpp
+++ b/plugins/TPStreamWriterModule.cpp
@@ -263,11 +263,8 @@ TPStreamWriterModule::do_work(std::atomic<bool>& running_flag)
                                         timeslice_ptr->get_header().timeslice_number,
                                         timeslice_ptr->get_header().run_number,
                                         excpt));
-          if (retry_wait_usec > 1000000) {
-            retry_wait_usec = 1000000;
-          }
-          usleep(retry_wait_usec);
-          retry_wait_usec *= 2;
+	  usleep(retry_wait_usec);
+	  retry_wait_usec = std::min(retry_wait_usec * 2, 1000000UL);
         } catch (const IgnorableDataStoreProblem& excpt) {
           int timeslice_number_diff = largest_timeslice_number - timeslice_ptr->get_header().timeslice_number;
           double seconds_too_late = m_accumulation_interval_seconds * timeslice_number_diff;

--- a/plugins/TPStreamWriterModule.cpp
+++ b/plugins/TPStreamWriterModule.cpp
@@ -249,12 +249,12 @@ TPStreamWriterModule::do_work(std::atomic<bool>& running_flag)
       do {
         should_retry = false;
         try {
+	  size_t number_of_tps = (timeslice_ptr->get_sum_of_fragment_payload_sizes() / sizeof(trgdataformats::TriggerPrimitive));
           m_data_writer->write(*timeslice_ptr);
 	  ++m_timeslices_written;
 	  m_bytes_output += timeslice_ptr->get_total_size_bytes();
-          size_t number_of_tps_written = (timeslice_ptr->get_sum_of_fragment_payload_sizes() / sizeof(trgdataformats::TriggerPrimitive));
-          m_tps_written += number_of_tps_written;
-          m_total_tps_written += number_of_tps_written;
+          m_tps_written += number_of_tps;
+          m_total_tps_written += number_of_tps;
         } catch (const RetryableDataStoreProblem& excpt) {
           should_retry = true;
           ers::error(DataWritingProblem(ERS_HERE,
@@ -271,6 +271,8 @@ TPStreamWriterModule::do_work(std::atomic<bool>& running_flag)
           int timeslice_number_diff = largest_timeslice_number - timeslice_ptr->get_header().timeslice_number;
           double seconds_too_late = m_accumulation_interval_seconds * timeslice_number_diff;
           m_tardy_timeslice_max_seconds = std::max(m_tardy_timeslice_max_seconds.load(), seconds_too_late);
+	  m_tps_discarded += number_of_tps;
+	  m_total_tps_discarded += number_of_tps;
           if (m_warn_user_when_tardy_tps_are_discarded) {
             std::ostringstream sid_list;
             bool first_frag = true;
@@ -279,9 +281,6 @@ TPStreamWriterModule::do_work(std::atomic<bool>& running_flag)
               else {sid_list << ",";}
               sid_list << frag_ptr->get_element_id().to_string();
             }
-	    size_t number_of_tps_discarded = (timeslice_ptr->get_sum_of_fragment_payload_sizes() / sizeof(trgdataformats::TriggerPrimitive));
-	    m_tps_discarded += number_of_tps_discarded;
-	    m_total_tps_discarded += number_of_tps_discarded;
             ers::warning(TardyTPsDiscarded(ERS_HERE,
                                            get_name(),
                                            sid_list.str(),

--- a/plugins/TPStreamWriterModule.cpp
+++ b/plugins/TPStreamWriterModule.cpp
@@ -285,6 +285,8 @@ TPStreamWriterModule::do_work(std::atomic<bool>& running_flag)
                                            seconds_too_late));
           }
         } catch (const std::exception& excpt) {
+	  m_tps_discarded += number_of_tps;
+	  m_total_tps_discarded += number_of_tps;
           ers::error(DataWritingProblem(ERS_HERE,
                                         get_name(),
                                         timeslice_ptr->get_header().timeslice_number,

--- a/plugins/TPStreamWriterModule.cpp
+++ b/plugins/TPStreamWriterModule.cpp
@@ -248,9 +248,8 @@ TPStreamWriterModule::do_work(std::atomic<bool>& running_flag)
       size_t retry_wait_usec = 1000;
       do {
         should_retry = false;
-	size_t number_of_tps = 0;
+	size_t number_of_tps = (timeslice_ptr->get_sum_of_fragment_payload_sizes() / sizeof(trgdataformats::TriggerPrimitive));
         try {
-	  number_of_tps = (timeslice_ptr->get_sum_of_fragment_payload_sizes() / sizeof(trgdataformats::TriggerPrimitive));
           m_data_writer->write(*timeslice_ptr);
 	  ++m_timeslices_written;
 	  m_bytes_output += timeslice_ptr->get_total_size_bytes();

--- a/plugins/TPStreamWriterModule.hpp
+++ b/plugins/TPStreamWriterModule.hpp
@@ -83,11 +83,13 @@ private:
   std::atomic<uint64_t> m_tpsets_with_tps = { 0 };    // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_tps_received = { 0 };       // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_tps_written = { 0 };        // NOLINT(build/unsigned)
+  std::atomic<uint64_t> m_tps_discarded = { 0 };      // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_timeslices_written = { 0 }; // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_bytes_output = { 0 };       // NOLINT(build/unsigned)
   std::atomic<double>   m_tardy_timeslice_max_seconds = { 0.0 }; // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_total_tps_received = { 0 }; // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_total_tps_written = { 0 };  // NOLINT(build/unsigned)
+  std::atomic<uint64_t> m_total_tps_discarded = { 0 };// NOLINT(build/unsigned)
 };
 } // namespace dfmodules
 

--- a/schema/dfmodules/opmon/TPStreamWriter.proto
+++ b/schema/dfmodules/opmon/TPStreamWriter.proto
@@ -9,8 +9,10 @@ message TPStreamWriterInfo {
 
   uint64 tps_received = 11;       // incremental count of TPs that have been received
   uint64 tps_written = 12;        // incremental count of TPs that have been written out
+  uint64 tps_discarded = 13;      // incremental count of TPs that have been discarded (not written out)
   uint64 total_tps_received = 16; // count of TPs that have been received in the current run
   uint64 total_tps_written = 17;  // count of TPs that have been written out in the current run
+  uint64 total_tps_discarded = 18;// count of TPs that have been discarded in the current run
 
 uint64 tardy_timeslice_max_seconds = 21; //incremental max amount of time that a TimeSlice was tardy
 


### PR DESCRIPTION
This pull request introduces new metric to track TPs that are discarded by the `TPStreamWriterModule`. This change adds two new fields to `opmon::TPStreamWriter`.

### Discarded Tardy TPs

The current counter introduced keeps track of the incremental and total number of TPs discarded when exception arise and 'IgnorableDataStoreProblem' is true. In other words, only those associated with TardyTPsDiscarded warning is counted. In terms of code organization, the additional metric is analogous to the already present tps received and written.

### Tests
- passes 'dbt-unittest-summary'
- passes 'integtest/minimal_system_quick_test'