### PR TITLE
Modified integtests to use the attribute_substitution data class instead of config_substitution…

### DIFF
--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -89,20 +89,20 @@ conf_dict.tpg_enabled = True
 conf_dict.frame_file = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e"  # WIBEth
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id=conf_dict.session,
         obj_class="Session",
         updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="RandomTCMakerConf",
         updates={"trigger_interval_ticks": 62500000 / trigger_rate},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="LatencyBuffer", updates={"size": 200000}
     )
 )
@@ -110,7 +110,7 @@ conf_dict.config_substitutions.append(
 swtpg_conf = copy.deepcopy(conf_dict)
 swtpg_conf.tpg_enabled = True
 swtpg_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TAMakerPrescaleAlgorithm",
         obj_id="dummy-ta-maker",
         updates={"prescale": 25},

--- a/integtest/hdf5_compression_test.py
+++ b/integtest/hdf5_compression_test.py
@@ -137,7 +137,7 @@ conf_dict.frame_file = "asset://?checksum=a8990a9eb3a505d4ded62dfdfa9e2681"  # r
 #conf_dict.frame_file = "file:///home/nfs/biery/dunedaq/12MayFDv5.3.2DevInstrUpdate/sourcecode/dfmodules/integtest/np02vdcoldbox_run035227_sample_hd_pds.bin"
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TAMakerPrescaleAlgorithm",
         obj_id="dummy-ta-maker",
         updates={"prescale": 2000},
@@ -145,14 +145,14 @@ conf_dict.config_substitutions.append(
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="FakeHSIEventGeneratorConf",
         updates={"trigger_rate": 10.0},
     )
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="HSISignalWindow",
         updates={
             "time_before": 1000,
@@ -161,7 +161,7 @@ conf_dict.config_substitutions.append(
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCReadoutMap",
         obj_id = "def-hsi-tc-map",
         updates={
@@ -171,28 +171,28 @@ conf_dict.config_substitutions.append(
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="DataStoreConf",
         obj_id="default",
         updates={"max_file_size": 400000000},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="DataStoreConf",
         obj_id="default_tp_store_conf",
         updates={"max_file_size": 170000000},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="DataStoreConf",
         obj_id="default",
         updates={"compression_level": 5},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="DataStoreConf",
         obj_id="default_tp_store_conf",
         updates={"compression_level": 1},
@@ -200,19 +200,19 @@ conf_dict.config_substitutions.append(
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="DFOConf", updates={"busy_threshold": 16, "free_threshold": 12}
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCDataProcessor",
         obj_id="def-tc-processor",
         updates={"merge_overlapping_tcs": 0},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="LatencyBuffer", updates={"size": 5592000}
     )
 )
@@ -221,7 +221,7 @@ conf_dict.config_substitutions.append(
 # 67 kHz * 2 DataLinkHandlers per RU * safety factor of 3 seconds ~= 400,000
 # However, this doesn't always seem to be large enough, so we'll use 1e6 for now.
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="QueueDescriptor",
         obj_id="tp-input",
         updates={"capacity": 1000000},

--- a/integtest/insufficient_disk_space_test.py
+++ b/integtest/insufficient_disk_space_test.py
@@ -118,7 +118,7 @@ conf_dict.n_df_apps = number_of_dataflow_apps
 conf_dict.fake_hsi_enabled = True  # FakeHSI must be enabled to set trigger window width!
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id=conf_dict.session,
         obj_class="Session",
         updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
@@ -126,14 +126,14 @@ conf_dict.config_substitutions.append(
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="FakeHSIEventGeneratorConf",
         updates={"trigger_rate": trigger_rate},
     )
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="HSISignalWindow",
         updates={
             "time_before": readout_window_time_before,
@@ -142,7 +142,7 @@ conf_dict.config_substitutions.append(
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="DataStoreConf",
         updates={
             "directory_path": output_path,

--- a/integtest/large_trigger_record_test.py
+++ b/integtest/large_trigger_record_test.py
@@ -104,7 +104,7 @@ conf_dict.tpg_enabled = False
 conf_dict.n_df_apps = number_of_dataflow_apps
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id=conf_dict.session,
         obj_class="Session",
         updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
@@ -112,13 +112,13 @@ conf_dict.config_substitutions.append(
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="RandomTCMakerConf",
         updates={"trigger_rate_hz": trigger_rate},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="DataStoreConf",
         obj_id="default",
         updates={"max_file_size": 2 * 1024 * 1024 * 1024},
@@ -127,7 +127,7 @@ conf_dict.config_substitutions.append(
 oversize_conf = copy.deepcopy(conf_dict)  # Copy before setting the readout window
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCReadoutMap",
         updates={
             "time_before": readout_window_time_before,
@@ -138,7 +138,7 @@ conf_dict.config_substitutions.append(
 
 # Now set the readout window for the over-size case
 oversize_conf.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCReadoutMap",
         updates={
             "time_before": 2.5 * readout_window_time_before,

--- a/integtest/max_file_size_test.py
+++ b/integtest/max_file_size_test.py
@@ -101,19 +101,19 @@ conf_dict.frame_file = (
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_id=conf_dict.session,
         obj_class="Session",
         updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="LatencyBuffer", updates={"size": 200000}
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCDataProcessor",
         obj_id="def-tc-processor",
         updates={"merge_overlapping_tcs": 0},
@@ -121,14 +121,14 @@ conf_dict.config_substitutions.append(
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="FakeHSIEventGeneratorConf",
         updates={"trigger_rate": 10.0},
     )
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="HSISignalWindow",
         updates={
             "time_before": 1000,
@@ -137,7 +137,7 @@ conf_dict.config_substitutions.append(
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCReadoutMap",
         obj_id = "def-hsi-tc-map",
         updates={
@@ -147,21 +147,21 @@ conf_dict.config_substitutions.append(
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="DataStoreConf",
         obj_id="default",
         updates={"max_file_size": 725000000},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="DataStoreConf",
         obj_id="default_tp_store_conf",
         updates={"max_file_size": 275000000},
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="StreamEmulationParameters",
         obj_id="stream-emu",
         updates={"TP_rate_per_channel": 5},
@@ -169,7 +169,7 @@ conf_dict.config_substitutions.append(
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="DFOConf", updates={"busy_threshold": 10, "free_threshold": 7}
     )
 )
@@ -179,7 +179,7 @@ conf_dict.config_substitutions.append(
 # out of each DataLinkHandler is about 3 kHz.  Two DLHs per app and a 5-second safety
 # factor gives a queue size of 30000.
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="QueueDescriptor",
         obj_id="tp-input",
         updates={"capacity": 200000},

--- a/integtest/multiple_data_writers_test.py
+++ b/integtest/multiple_data_writers_test.py
@@ -79,14 +79,14 @@ conf_dict.fake_hsi_enabled = True
 conf_dict.n_data_writers = 3
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="FakeHSIEventGeneratorConf",
         updates={"trigger_rate": 10.0},
     )
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="HSISignalWindow",
         updates={
             "time_before": 1000,
@@ -95,7 +95,7 @@ conf_dict.config_substitutions.append(
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCReadoutMap",
         obj_id = "def-hsi-tc-map",
         updates={
@@ -106,7 +106,7 @@ conf_dict.config_substitutions.append(
 )
 
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="QueueDescriptor",
         obj_id="trigger-records",
         updates={"queue_type": "kFollyMPMCQueue"},


### PR DESCRIPTION
This is part of providing more configuration substitution options in integtests.

## Description

The changes in this PR make use of the new way of specifying configuration substitutions in integration tests, as described in DUNE-DAQ/daq-deliverables#181.

## Testing Suggestions

Please see the suggestions in the parent Issue, DUNE-DAQ/daq-deliverables#181.