### PR TITLE
Several additional contributions to help get all dfmodules integtests working

### DIFF
--- a/integtest/README.md
+++ b/integtest/README.md
@@ -1,4 +1,4 @@
-* 29-Apr-2025, KAB, ELF, and others: notes on existing integtests
+* 11-Sep-2025, KAB, ELF, and others: notes on existing integtests
 
 "integtests" are intended to be automated integration and/or system tests that make use of the
 "pytest" framework to validate the operation of the DAQ system in various scenarios.
@@ -11,9 +11,9 @@ pytest -s max_file_size_test.py [--nanorc-option log-level debug]  # this nanorc
 
 For reference, here are the ideas behind the existing tests:
 * `max_file_size_test.py` - verifies that data files are closed when they reach a specified maximum file size (approximately)
-* `multiple_data_writers_test.py` - verifies that we can run multiple DataWriters for a single TriggerRecordBuilder
+* `multiple_data_writers_test.py` - verifies that we can run multiple DataWriters with a single TriggerRecordBuilder
 * `hdf5_compression_test.py` - verifies that HDF5 compression is working as expected by writing several data files of known size
-
-* `large_trigger_record_test.py` - verify that TriggerRecords that are close to the size of a whole file get written to disk correctly
-* `disabled_output_test.py` - verify that the --disable-data-storage option works
-* `insufficient_disk_space_test.py` - verify that the appropriate errors and warnings are produced when there isn't enough disk space to write data
+* `large_trigger_record_test.py` - verifies that TriggerRecords that have sizes that are 55% and 125% of the configured maximum file size each get written to their own HDF5 file
+* `disabled_output_test.py` - verifies that the --disable-data-storage option prevents a raw data file from being produced
+* `insufficient_disk_space_test.py` - verifies that the appropriate errors and warnings are produced when there isn't enough disk space to write additional TriggerRecords
+* `trmonrequestor_test.py` - verifies that the TriggerRecord monitoring functionality successfully writes a subset of the TRs to disk

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -42,7 +42,7 @@ triggercandidate_frag_params = {
     "max_size_bytes": 264,
     "debug_mask": 0x0,
     "frag_sizes_by_TC_type": {"kPrescale": {"min_size_bytes": 208, "max_size_bytes": 264},
-                                "kRandom": {"min_size_bytes": 128, "max_size_bytes": 264},
+                                "kRandom": {"min_size_bytes": 128, "max_size_bytes": 128},
                                 "default": {"min_size_bytes": 128, "max_size_bytes": 264} }
 }
 # sizes:  72 is for an empty TA fragment
@@ -106,7 +106,7 @@ conf_dict.config_substitutions.append(
     )
 )
 conf_dict.config_substitutions.append(
-    data_classes.config_substitution(
+    data_classes.attribute_substitution(
         obj_class="TCDataProcessor",
         obj_id="def-tc-processor",
         updates={"merge_overlapping_tcs": 0},

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -42,7 +42,7 @@ triggercandidate_frag_params = {
     "max_size_bytes": 264,
     "debug_mask": 0x0,
     "frag_sizes_by_TC_type": {"kPrescale": {"min_size_bytes": 208, "max_size_bytes": 264},
-                                "kRandom": {"min_size_bytes": 128, "max_size_bytes": 128},
+                                "kRandom": {"min_size_bytes": 128, "max_size_bytes": 264},
                                 "default": {"min_size_bytes": 128, "max_size_bytes": 264} }
 }
 # sizes:  72 is for an empty TA fragment

--- a/integtest/insufficient_disk_space_test.py
+++ b/integtest/insufficient_disk_space_test.py
@@ -15,44 +15,27 @@ import functools
 print = functools.partial(print, flush=True)
 
 # 21-Jul-2022, KAB:
-# --> changes that are needed in this script include the following:
-# * add intelligence to verify that the output disk is small enough
-#
 # --> problems in the C++ code that this script currently highlights
 # * the crash of the DF App in the second run
 # * the need for the HDF5DataStore to stop retrying writes at stop (drain-dataflow?) time
 
-# 08-May-2023, ELF:
-# Tested script by creating a tmpfs ramdisk (as root):
-# mkdir /mnt/tmp
-# mount -t tmpfs -o size=5g tmpfs /mnt/tmp
-# chmod 777 /mnt/tmp
-# After testing, umount -lf /mnt/tmp to release memory
-
-# check how much free space there is on the configured output disk
-output_path = f"/mnt/tmp"
-disk_space = shutil.disk_usage(output_path)
-gb_space = disk_space.free / (1024 * 1024 * 1024)
-gb_limit = 6.0
-hostname = os.uname().nodename
-print(f"DEBUG: {gb_space} GB free in {output_path}")
-
 # Values that help determine the running conditions
+output_path_parameter = "."
+desired_size_of_output_disk_gb = 5
+minimum_free_disk_space_gb = desired_size_of_output_disk_gb + 5  # leave 5 GB free for other users/integtests/etc
 number_of_data_producers = 10
 run_duration = 20  # seconds
 number_of_readout_apps = 3
 number_of_dataflow_apps = 1
 trigger_rate = 0.2  # Hz
-data_rate_slowdown_factor = 10
-token_count = 1
 readout_window_time_before = 9000000
 readout_window_time_after = 1000000
 
 # Default values for validation parameters
-expected_number_of_data_files = 1
+expected_number_of_data_files = 2
 check_for_logfile_errors = True
-expected_event_count = int(gb_space - 5)
-expected_event_count_tolerance = 1
+expected_event_count = 2 # files can have 1 to 4 TriggerRecords, so we allow 2 +- 2
+expected_event_count_tolerance = 2
 
 wibeth_frag_hsi_trig_params = {
     "fragment_type_description": "WIBEth",
@@ -72,21 +55,41 @@ required_logfile_problems = {
     "df-01": [
         "A problem was encountered when writing TriggerRecord number",
         "A problem was encountered when writing a trigger record to file",
-        r"There are \d+ bytes free, and the required minimum is \d+ bytes based on a safety factor of 5 times the trigger record size",
-        "An invalid run number was received in a TriggerRecord message"
+        r"There are \d+ bytes free, and the required minimum is \d+ bytes based on a safety factor of \d+ times the trigger record size",
     ],
     "mlt": [r"Trigger is inhibited in run \d+"],
     "dfo": [r"TriggerDecision \d+ didn't complete within timeout in run \d+"],
 }
 ignored_logfile_problems = {
-    "-controller": [
-        "Worker with pid \\d+ was terminated due to signal 1",
-        "Connection '.*' not found on the application registry",
-    ],
     "connectivity-service": [
         "errorlog: -",
     ],
 }
+
+# Determine if the conditions are right for these tests
+sufficient_disk_space = True
+actual_output_path = output_path_parameter
+if output_path_parameter == ".":
+    actual_output_path = "/tmp"
+disk_space = shutil.disk_usage(actual_output_path)
+total_disk_space_gb = disk_space.total / (1024 * 1024 * 1024)
+free_disk_space_gb = disk_space.free / (1024 * 1024 * 1024)
+print(
+    f"DEBUG: Space on disk for output path \"{actual_output_path}\": total = {total_disk_space_gb} GB and free = {free_disk_space_gb} GB."
+)
+if (
+    free_disk_space_gb < minimum_free_disk_space_gb
+):
+    sufficient_disk_space = False
+
+# We simulate a nearly-full output disk by setting the free-space-safety-factor
+# that the data writer uses to a custom value, based on the free space on disk.
+# The size of each TriggerRecord in this test is tuned to be about 1 GB, so if
+# the free-space-safety-factor is calculated to be 10, then it will appear that
+# the disk is full when there is still ~< 10 GB of free space.  And, having a
+# 1 GB size for the TRs means that we will write approximately
+# desired_free_disk_space_gb TriggerRecords before appearing to run out of space.
+free_space_safety_factor = 1 + round(0.5 + free_disk_space_gb - desired_size_of_output_disk_gb)
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -102,14 +105,6 @@ conf_dict.session = "insufficient"
 conf_dict.tpg_enabled = False
 conf_dict.n_df_apps = number_of_dataflow_apps
 conf_dict.fake_hsi_enabled = False
-
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
-        obj_id=conf_dict.session,
-        obj_class="Session",
-        updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
-    )
-)
 
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
@@ -130,18 +125,24 @@ conf_dict.config_substitutions.append(
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="DataStoreConf",
+        obj_id="default",
         updates={
-            "directory_path": output_path,
+            "directory_path": output_path_parameter,
+            "free_space_safety_factor": free_space_safety_factor,
         },
     )
 )
-
+conf_dict.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="DFOConf", updates={"busy_threshold": 1, "free_threshold": 0}
+    )
+)
 
 confgen_arguments = {
     "Base_System": conf_dict,
 }
 # The commands to run in nanorc, as a list
-if gb_space < gb_limit:
+if sufficient_disk_space:
     nanorc_command_list = (
         "boot conf wait 5".split()
         + "start --run-number 101 wait 1 enable-triggers wait ".split()
@@ -162,9 +163,9 @@ else:
 
 
 def test_nanorc_success(run_nanorc):
-    if gb_space >= gb_limit:
+    if not sufficient_disk_space:
         pytest.skip(
-            f"This computer ({hostname}) has too much available space in {output_path}.\n    (There is {gb_space} GB of space in {output_path}, limit is {gb_limit} GB)"
+            f"The raw data output path ({actual_output_path}) does not have enough space to run this test."
         )
 
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
@@ -180,9 +181,9 @@ def test_nanorc_success(run_nanorc):
 
 
 def test_log_files(run_nanorc):
-    if gb_space >= gb_limit:
+    if not sufficient_disk_space:
         pytest.skip(
-            f"This computer ({hostname}) has too much available space in {output_path}.\n    (There is {gb_space} GB of space in {output_path}, limit is {gb_limit} GB)"
+            f"The raw data output path ({actual_output_path}) does not have enough space to run this test."
         )
 
     if check_for_logfile_errors:
@@ -197,12 +198,15 @@ def test_log_files(run_nanorc):
 
 
 def test_data_files(run_nanorc):
-    if gb_space >= gb_limit:
+    if not sufficient_disk_space:
         print(
-            f"This computer ({hostname}) has too much available space in {output_path}.\n    (There is {gb_space} GB of space in {output_path}, limit is {gb_limit} GB)"
+            f"The raw data output path ({actual_output_path}) does not have enough space to run this test."
+        )
+        print(
+            f"    (Free space is {free_disk_space_gb} GB and require space is {minimum_free_disk_space_gb} GB.)"
         )
         pytest.skip(
-            f"This computer ({hostname}) has too much available space in {output_path}.\n    (There is {gb_space} GB of space in {output_path}, limit is {gb_limit} GB)"
+            f"The raw data output path ({actual_output_path}) does not have enough space to run this test."
         )
 
     local_expected_event_count = expected_event_count
@@ -213,10 +217,13 @@ def test_data_files(run_nanorc):
     fragment_check_list.append(wibeth_frag_hsi_trig_params)  # WIBEth
 
     # Run some tests on the output data file
-    all_ok = True
-    all_ok &= len(run_nanorc.data_files) == expected_number_of_data_files
+    all_ok = len(run_nanorc.data_files) == expected_number_of_data_files
+    print("") # Clear potential dot from pytest
+    if all_ok:
+        print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
+    else:
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
-    all_ok = True
     for idx in range(len(run_nanorc.data_files)):
         data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
@@ -233,13 +240,11 @@ def test_data_files(run_nanorc):
             )
     assert all_ok
 
-    assert all_ok
-
 
 def test_cleanup(run_nanorc):
-    if gb_space >= gb_limit:
+    if not sufficient_disk_space:
         pytest.skip(
-            f"This computer ({hostname}) has too much available space in {output_path}.\n    (There is {gb_space} GB of space in {output_path}, limit is {gb_limit} GB)"
+            f"The raw data output path ({actual_output_path}) does not have enough space to run this test."
         )
 
     pathlist_string = ""

--- a/integtest/insufficient_disk_space_test.py
+++ b/integtest/insufficient_disk_space_test.py
@@ -21,7 +21,7 @@ print = functools.partial(print, flush=True)
 
 # Values that help determine the running conditions
 output_path_parameter = "."
-desired_size_of_output_disk_gb = 5
+desired_size_of_output_disk_gb = 6
 minimum_free_disk_space_gb = desired_size_of_output_disk_gb + 5  # leave 5 GB free for other users/integtests/etc
 number_of_data_producers = 10
 run_duration = 20  # seconds

--- a/integtest/insufficient_disk_space_test.py
+++ b/integtest/insufficient_disk_space_test.py
@@ -89,7 +89,7 @@ if (
 # the disk is full when there is still ~< 10 GB of free space.  And, having a
 # 1 GB size for the TRs means that we will write approximately
 # desired_free_disk_space_gb TriggerRecords before appearing to run out of space.
-free_space_safety_factor = 1 + round(0.5 + free_disk_space_gb - desired_size_of_output_disk_gb)
+free_space_safety_factor = int(free_disk_space_gb - desired_size_of_output_disk_gb)
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -217,12 +217,12 @@ def test_data_files(run_nanorc):
     fragment_check_list.append(wibeth_frag_hsi_trig_params)  # WIBEth
 
     # Run some tests on the output data file
-    all_ok = len(run_nanorc.data_files) == expected_number_of_data_files
+    all_ok = len(run_nanorc.data_files) == expected_number_of_data_files or len(run_nanorc.data_files) == (expected_number_of_data_files+1)
     print("") # Clear potential dot from pytest
     if all_ok:
-        print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
+        print(f"\N{WHITE HEAVY CHECK MARK} An acceptable number of raw data files was found ({len(run_nanorc.data_files)} in {expected_number_of_data_files}..{expected_number_of_data_files+1})")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}..{expected_number_of_data_files+1}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
     for idx in range(len(run_nanorc.data_files)):
         data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])

--- a/integtest/large_trigger_record_test.py
+++ b/integtest/large_trigger_record_test.py
@@ -28,7 +28,6 @@ run_duration = 32  # seconds
 number_of_readout_apps = 3
 number_of_dataflow_apps = 1
 trigger_rate = 0.06  # Hz
-token_count = 1
 readout_window_time_before = 10000000
 readout_window_time_after = 1000000
 data_rate_slowdown_factor = 1
@@ -121,7 +120,15 @@ conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="DataStoreConf",
         obj_id="default",
-        updates={"max_file_size": 2 * 1024 * 1024 * 1024},
+        updates={
+            "max_file_size": 2 * 1024 * 1024 * 1024,
+            "directory_path": output_path_parameter,
+        },
+    )
+)
+conf_dict.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="DFOConf", updates={"busy_threshold": 1, "free_threshold": 0}
     )
 )
 oversize_conf = copy.deepcopy(conf_dict)  # Copy before setting the readout window

--- a/integtest/trmonrequestor_test.py
+++ b/integtest/trmonrequestor_test.py
@@ -69,14 +69,14 @@ conf_dict.trmon_app_enabled = True
 conf_dict.n_df_apps = number_of_dataflow_apps
 
 
-substitution = data_classes.config_substitution(
+substitution = data_classes.attribute_substitution(
     obj_id="random-tc-generator",
     obj_class="RandomTCMakerConf",
     updates={"trigger_rate_hz": trigger_rate},
 )
 conf_dict.config_substitutions.append(substitution)
 
-substitution = data_classes.config_substitution(
+substitution = data_classes.attribute_substitution(
     obj_id="tr_mon_dw-01",
     obj_class="DataWriterConf",
     updates={"data_storage_prescale": trmon_prescale},

--- a/scripts/dfmodules_integtest_bundle.sh
+++ b/scripts/dfmodules_integtest_bundle.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 # 29-Apr-2025, KAB
 
-integtest_list=( "max_file_size_test.py" "multiple_data_writers_test.py" "hdf5_compression_test.py" )
-#integtest_list=( "large_trigger_record_test.py" "disabled_output_test.py" "multi_output_file_test.py" "insufficient_disk_space_test.py" )
+integtest_list=( "multiple_data_writers_test.py" "insufficient_disk_space_test.py" "large_trigger_record_test.py" "hdf5_compression_test.py" "disabled_output_test.py" "max_file_size_test.py" )
 let last_test_index=${#integtest_list[@]}-1
 
 usage() {

--- a/scripts/dfmodules_integtest_bundle.sh
+++ b/scripts/dfmodules_integtest_bundle.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # 29-Apr-2025, KAB
 
-integtest_list=( "multiple_data_writers_test.py" "insufficient_disk_space_test.py" "large_trigger_record_test.py" "hdf5_compression_test.py" "disabled_output_test.py" "max_file_size_test.py" )
+integtest_list=( "multiple_data_writers_test.py" "insufficient_disk_space_test.py" "large_trigger_record_test.py" "hdf5_compression_test.py" "disabled_output_test.py" "max_file_size_test.py" "trmonrequestor_test.py" )
 let last_test_index=${#integtest_list[@]}-1
 
 usage() {


### PR DESCRIPTION
## Description

To help get all of the `dfmodules` integtests working, I have made a few changes.  These changes are based on Eric's `eflumerf/IntegrationTestUpdates` branch.

- I fixed a use of `config_substitution` in `disabled_output_test`.  It now needs to be `attribute_substitution`.  I'm not sure how I missed that before.  I also reduced the maximum expected size of TriggerCandidate fragments in kRandom triggers.  For those triggers, TC fragments should always have size 128.
- I added explicit setting of the `directory_path`, `busy_threshold`, and `free_threshold` in the `large_trigger_record_test`.  These were minor oversights, and I don't expect the behavior of this test to change.
- I re-worked the `insufficient_disk_space_test` to use the `free_space_safety_factor` to simulate the use of a nearly full disk.  This will allow this test to be run more easily, without requiring users to create temporary disks of limited size.
- I fixed the use of `attribute_substitution` instead of `config_substitution` in `trmonrequestor_test.py`.
- I updated the list of tests in the `dfmodules_integtest_bundle.sh` script to include the recently-fixed tests, and to run the shorter tests first.

## Testing Suggestions

With these changes, one should see 7 available tests when we run 

```
dfmodules_integtest_bundle.sh --help
```

and when we run all of the tests in the bundle script, all of them should pass (modulo the problem reported in [drunc Issue #568](https://github.com/DUNE-DAQ/drunc/issues/568) that affects the `maximum_file_size_test` and `hdf5_compression_test`).

Also, when we run `dbt-build --integtest dfmodules`, all `dfmodules` integtests should pass (modulo the `drunc` issue).
