### PR TITLE
Updated the use of the TimeSync message in FakeDataProdModule to use …

### DIFF
--- a/plugins/FakeDataProdModule.cpp
+++ b/plugins/FakeDataProdModule.cpp
@@ -48,8 +48,6 @@ FakeDataProdModule::FakeDataProdModule(const std::string& name)
   register_command("conf", &FakeDataProdModule::do_conf);
   register_command("start", &FakeDataProdModule::do_start);
   register_command("stop", &FakeDataProdModule::do_stop);
-
-  m_pid_of_current_process = getpid();
 }
 
 void
@@ -148,10 +146,10 @@ FakeDataProdModule::do_timesync(std::atomic<bool>& running_flag)
     ++msg_seqno;
     timesyncmsg.run_number = m_run_number;
     timesyncmsg.sequence_number = msg_seqno;
-    timesyncmsg.source_pid = m_pid_of_current_process;
+    timesyncmsg.source_id = m_sourceid.id;
     TLOG_DEBUG(TLVL_TIME_SYNCS) << "New timesync: daq=" << timesyncmsg.daq_time << " wall=" << timesyncmsg.system_time
                                 << " run=" << timesyncmsg.run_number << " seqno=" << timesyncmsg.sequence_number
-                                << " pid=" << timesyncmsg.source_pid;
+                                << " source_id=" << timesyncmsg.source_id;
     try {
       sender_ptr->send(std::move(timesyncmsg), std::chrono::milliseconds(500));
       ++sent_count;

--- a/plugins/FakeDataProdModule.hpp
+++ b/plugins/FakeDataProdModule.hpp
@@ -87,7 +87,6 @@ private:
   uint64_t m_response_delay; // NOLINT (build/unsigned)
   daqdataformats::FragmentType m_fragment_type;
   std::string m_timesync_topic_name;
-  uint32_t m_pid_of_current_process; // NOLINT (build/unsigned)
 
   std::string m_data_request_id;
   std::string m_timesync_id;


### PR DESCRIPTION
…SourceID::id instead of the process ID.

## Description

These changes are part of a set of changes that are described in DUNE-DAQ/daq-deliverables#188.  Overall, the goal is to eliminate the use of Linux process IDs in identifying the source of TimeSync messages (to avoid problems with their use in certain environments) and use DAQ SourceID information instead.

Please see the `daq-deliverables` Issue for more details, including the full set of repositories that have correlated changes.

## Testing Suggestions

Please see DUNE-DAQ/daq-deliverables#188.
