### PR TITLE
For tests that use HSI Fragments, set the size min/max using the TC type

### DIFF
--- a/integtest/hdf5_compression_test.py
+++ b/integtest/hdf5_compression_test.py
@@ -103,12 +103,16 @@ triggerprimitive_frag_params = {
     "min_size_bytes": 72,
     "max_size_bytes": 1032,
 }
+# 03-Jul-2025, KAB: changing the default max size from 72 to 100 to handle cases in which there
+# was a Random or Prescale trigger along with a coincidental HSI event within the readout window.
 hsi_frag_params = {
     "fragment_type_description": "HSI",
     "fragment_type": "Hardware_Signal",
     "expected_fragment_count": 1,
     "min_size_bytes": 72,
     "max_size_bytes": 100,
+    "frag_sizes_by_TC_type": {"kTiming": {"min_size_bytes": 100, "max_size_bytes": 100},
+                              "default": {"min_size_bytes":  72, "max_size_bytes": 100} }
 }
 ignored_logfile_problems = {
     "-controller": [

--- a/integtest/max_file_size_test.py
+++ b/integtest/max_file_size_test.py
@@ -67,12 +67,16 @@ triggerprimitive_frag_params = {
     "min_size_bytes": 72,
     "max_size_bytes": 1032,
 }
+# 03-Jul-2025, KAB: changing the default max size from 72 to 100 to handle cases in which there
+# was a Random or Prescale trigger along with a coincidental HSI event within the readout window.
 hsi_frag_params = {
     "fragment_type_description": "HSI",
     "fragment_type": "Hardware_Signal",
     "expected_fragment_count": 1,
     "min_size_bytes": 72,
     "max_size_bytes": 100,
+    "frag_sizes_by_TC_type": {"kTiming": {"min_size_bytes": 100, "max_size_bytes": 100},
+                              "default": {"min_size_bytes":  72, "max_size_bytes": 100} }
 }
 ignored_logfile_problems = {
     "-controller": [

--- a/integtest/multiple_data_writers_test.py
+++ b/integtest/multiple_data_writers_test.py
@@ -48,16 +48,12 @@ triggerprimitive_frag_params = {
     "min_size_bytes": 72,
     "max_size_bytes": 1032,
 }
-# 03-Jul-2025, KAB: changing the default max size from 72 to 100 to handle cases in which there
-# was a Random or Prescale trigger along with a coincidental HSI event within the readout window.
 hsi_frag_params = {
     "fragment_type_description": "HSI",
     "fragment_type": "Hardware_Signal",
     "expected_fragment_count": 1,
-    "min_size_bytes": 72,
+    "min_size_bytes": 100,
     "max_size_bytes": 100,
-    "frag_sizes_by_TC_type": {"kTiming": {"min_size_bytes": 100, "max_size_bytes": 100},
-                              "default": {"min_size_bytes":  72, "max_size_bytes": 100} }
 }
 ignored_logfile_problems = {
     "-controller": [

--- a/integtest/multiple_data_writers_test.py
+++ b/integtest/multiple_data_writers_test.py
@@ -48,12 +48,16 @@ triggerprimitive_frag_params = {
     "min_size_bytes": 72,
     "max_size_bytes": 1032,
 }
+# 03-Jul-2025, KAB: changing the default max size from 72 to 100 to handle cases in which there
+# was a Random or Prescale trigger along with a coincidental HSI event within the readout window.
 hsi_frag_params = {
     "fragment_type_description": "HSI",
     "fragment_type": "Hardware_Signal",
     "expected_fragment_count": 1,
-    "min_size_bytes": 100,
+    "min_size_bytes": 72,
     "max_size_bytes": 100,
+    "frag_sizes_by_TC_type": {"kTiming": {"min_size_bytes": 100, "max_size_bytes": 100},
+                              "default": {"min_size_bytes":  72, "max_size_bytes": 100} }
 }
 ignored_logfile_problems = {
     "-controller": [


### PR DESCRIPTION
(copied from daqsystemtest)

Resolves #256 