### PR TITLE
Make dfmodules integtests more friendly for computers with limited resources

### DIFF
--- a/integtest/hdf5_compression_test.py
+++ b/integtest/hdf5_compression_test.py
@@ -7,6 +7,7 @@ import urllib.request
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
+import integrationtest.resource_validation as resource_validation
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -57,24 +58,6 @@ daphne_tpset_params = {
 #                                     "default": {"min_size_bytes": 80000, "max_size_bytes": 120000} }
 }
 
-#wibeth_frag_params = {
-#    "fragment_type_description": "WIBEth",
-#    "fragment_type": "WIBEth",
-#    "expected_fragment_count": (number_of_data_producers * number_of_readout_apps),
-#    "min_size_bytes": 7272,
-#    "max_size_bytes": 194472,
-#}
-#wibeth_tpset_params = {
-#    "fragment_type_description": "TP Stream",
-#    "fragment_type": "Trigger_Primitive",
-#    "expected_fragment_count": number_of_readout_apps * 3,
-#    "frag_counts_by_record_ordinal": {"first": {"min_count": 1, "max_count": number_of_readout_apps * 3},
-#                                      "default": {"min_count": number_of_readout_apps * 3, "max_count": number_of_readout_apps * 3} },
-#    "min_size_bytes": 0,  # not checked
-#    "max_size_bytes": 0,  # not checked
-#    "debug_mask": 0x0,
-#}
-
 # sizes: 128 is for one TC with zero TAs inside it (72+56)
 #        208 is for one TC with one TA inside it (72+56+80)
 #        264 is for two TCs with one TA in one of them (72+56+80+56)
@@ -122,6 +105,17 @@ ignored_logfile_problems = {
         "errorlog: -",
     ],
 }
+
+# Determine if the conditions are right for these tests
+resval = resource_validation.ResourceValidator()
+resval.require_cpu_count(15)  # total number of data sources (6RU+3TP) plus several more for everything else
+resval.require_free_memory_gb(10)  # the maximum amount that we observe being used ('free -h')
+resval.require_total_memory_gb(20)  # double what we need; trying to be kind to others
+actual_output_path = "/tmp"
+resval.require_free_disk_space_gb(actual_output_path, 5)  # what we actually use (3) plus margin
+resval.require_total_disk_space_gb(actual_output_path, 10)  # factor of two to reserve some for others
+resval_debug_string = resval.get_debug_string()
+print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -238,19 +232,28 @@ confgen_arguments = {
 }
 
 # The commands to run in nanorc, as a list
-nanorc_command_list = (
-    "boot conf wait 5".split()
-    + "start --run-number 101 wait 1 enable-triggers wait 100".split()
-    + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split()
-    + "start --run-number 102 wait 1 enable-triggers wait 100".split()
-    + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split()
-    + " scrap terminate".split()
+if resval.this_computer_has_sufficient_resources:
+    nanorc_command_list = (
+        "boot conf wait 5".split()
+        + "start --run-number 101 wait 1 enable-triggers wait 100".split()
+        + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split()
+        + "start --run-number 102 wait 1 enable-triggers wait 100".split()
+        + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split()
+        + " scrap terminate".split()
 )
+else:
+    nanorc_command_list = ["wait", "1"]
 
 # The tests themselves
 
 
 def test_nanorc_success(run_nanorc):
+    if not resval.this_computer_has_sufficient_resources:
+        resval_report_string = resval.get_insufficient_resources_report()
+        print(f"{resval_report_string}")
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
+
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_nanorc0\].*", current_test)
     if match_obj:
@@ -264,6 +267,10 @@ def test_nanorc_success(run_nanorc):
 
 
 def test_log_files(run_nanorc):
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
+
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
@@ -272,6 +279,10 @@ def test_log_files(run_nanorc):
 
 
 def test_data_files(run_nanorc):
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
+
     fragment_check_list = [triggercandidate_frag_params, hsi_frag_params, daphne_frag_params]
     fragment_check_list.append(daphne_triggerprimitive_frag_params)
     fragment_check_list.append(triggeractivity_frag_params)
@@ -299,6 +310,10 @@ def test_data_files(run_nanorc):
 
 
 def test_tpstream_files(run_nanorc):
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
+
     tpstream_files = run_nanorc.tpset_files
     fragment_check_list = [daphne_tpset_params]
 
@@ -320,6 +335,10 @@ def test_tpstream_files(run_nanorc):
 
 
 def test_cleanup(run_nanorc):
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
+
     pathlist_string = ""
     filelist_string = ""
     for data_file in run_nanorc.data_files:

--- a/integtest/hdf5_compression_test.py
+++ b/integtest/hdf5_compression_test.py
@@ -217,7 +217,7 @@ conf_dict.config_substitutions.append(
 )
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
-        obj_class="LatencyBuffer", updates={"size": 5592000}
+        obj_class="LatencyBuffer", updates={"size": 200000}
     )
 )
 # 03-Jun-2025, KAB

--- a/integtest/insufficient_disk_space_test.py
+++ b/integtest/insufficient_disk_space_test.py
@@ -68,6 +68,9 @@ ignored_logfile_problems = {
 
 # Determine if the conditions are right for these tests
 resval = resource_validation.ResourceValidator()
+resval.require_cpu_count(45)  # total number of data sources plus 50% more for everything else
+resval.require_free_memory_gb(35)  # the maximum amount that we observe being used ('free -h')
+resval.require_total_memory_gb(70)  # double what we need; trying to be kind to others
 actual_output_path = output_path_parameter
 if output_path_parameter == ".":
     actual_output_path = "/tmp"

--- a/integtest/insufficient_disk_space_test.py
+++ b/integtest/insufficient_disk_space_test.py
@@ -137,6 +137,11 @@ conf_dict.config_substitutions.append(
         obj_class="DFOConf", updates={"busy_threshold": 1, "free_threshold": 0}
     )
 )
+conf_dict.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="LatencyBuffer", updates={"size": 200000}
+    )
+)
 
 confgen_arguments = {
     "Base_System": conf_dict,

--- a/integtest/insufficient_disk_space_test.py
+++ b/integtest/insufficient_disk_space_test.py
@@ -1,12 +1,12 @@
 import pytest
 import os
 import re
-import shutil
 import urllib.request
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
+import integrationtest.resource_validation as resource_validation
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -67,20 +67,13 @@ ignored_logfile_problems = {
 }
 
 # Determine if the conditions are right for these tests
-sufficient_disk_space = True
+resval = resource_validation.ResourceValidator()
 actual_output_path = output_path_parameter
 if output_path_parameter == ".":
     actual_output_path = "/tmp"
-disk_space = shutil.disk_usage(actual_output_path)
-total_disk_space_gb = disk_space.total / (1024 * 1024 * 1024)
-free_disk_space_gb = disk_space.free / (1024 * 1024 * 1024)
-print(
-    f"DEBUG: Space on disk for output path \"{actual_output_path}\": total = {total_disk_space_gb} GB and free = {free_disk_space_gb} GB."
-)
-if (
-    free_disk_space_gb < minimum_free_disk_space_gb
-):
-    sufficient_disk_space = False
+resval.require_free_disk_space_gb(actual_output_path, minimum_free_disk_space_gb)
+resval_debug_string = resval.get_debug_string()
+print(f"{resval_debug_string}")
 
 # We simulate a nearly-full output disk by setting the free-space-safety-factor
 # that the data writer uses to a custom value, based on the free space on disk.
@@ -89,7 +82,7 @@ if (
 # the disk is full when there is still ~< 10 GB of free space.  And, having a
 # 1 GB size for the TRs means that we will write approximately
 # desired_free_disk_space_gb TriggerRecords before appearing to run out of space.
-free_space_safety_factor = int(free_disk_space_gb - desired_size_of_output_disk_gb)
+free_space_safety_factor = int(resval.free_disk_space_gb - desired_size_of_output_disk_gb)
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -142,7 +135,7 @@ confgen_arguments = {
     "Base_System": conf_dict,
 }
 # The commands to run in nanorc, as a list
-if sufficient_disk_space:
+if resval.this_computer_has_sufficient_resources:
     nanorc_command_list = (
         "boot conf wait 5".split()
         + "start --run-number 101 wait 1 enable-triggers wait ".split()
@@ -157,16 +150,17 @@ if sufficient_disk_space:
         + " scrap terminate".split()
     )
 else:
-    nanorc_command_list = ["boot", "terminate"]
+    nanorc_command_list = ["wait", "1"]
 
 # The tests themselves
 
 
 def test_nanorc_success(run_nanorc):
-    if not sufficient_disk_space:
-        pytest.skip(
-            f"The raw data output path ({actual_output_path}) does not have enough space to run this test."
-        )
+    if not resval.this_computer_has_sufficient_resources:
+        resval_report_string = resval.get_insufficient_resources_report()
+        print(f"{resval_report_string}")
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
 
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_nanorc0\].*", current_test)
@@ -181,10 +175,9 @@ def test_nanorc_success(run_nanorc):
 
 
 def test_log_files(run_nanorc):
-    if not sufficient_disk_space:
-        pytest.skip(
-            f"The raw data output path ({actual_output_path}) does not have enough space to run this test."
-        )
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
 
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
@@ -198,16 +191,9 @@ def test_log_files(run_nanorc):
 
 
 def test_data_files(run_nanorc):
-    if not sufficient_disk_space:
-        print(
-            f"The raw data output path ({actual_output_path}) does not have enough space to run this test."
-        )
-        print(
-            f"    (Free space is {free_disk_space_gb} GB and require space is {minimum_free_disk_space_gb} GB.)"
-        )
-        pytest.skip(
-            f"The raw data output path ({actual_output_path}) does not have enough space to run this test."
-        )
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
 
     local_expected_event_count = expected_event_count
     local_event_count_tolerance = expected_event_count_tolerance
@@ -242,10 +228,9 @@ def test_data_files(run_nanorc):
 
 
 def test_cleanup(run_nanorc):
-    if not sufficient_disk_space:
-        pytest.skip(
-            f"The raw data output path ({actual_output_path}) does not have enough space to run this test."
-        )
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
 
     pathlist_string = ""
     filelist_string = ""

--- a/integtest/large_trigger_record_test.py
+++ b/integtest/large_trigger_record_test.py
@@ -9,11 +9,11 @@ import os
 import re
 import urllib.request
 import copy
-import shutil
 
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
+import integrationtest.resource_validation as resource_validation
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -31,8 +31,8 @@ trigger_rate = 0.06  # Hz
 readout_window_time_before = 10000000
 readout_window_time_after = 1000000
 data_rate_slowdown_factor = 1
-minimum_total_disk_space_gb = 33  # 50% more than what we need
-minimum_free_disk_space_gb = 28  # 25% more than what we need
+minimum_total_disk_space_gb = 20  # keep a reasonable amount for other users
+minimum_free_disk_space_gb = 15  # 50% more than what we need
 
 # Default values for validation parameters
 expected_number_of_data_files = 4
@@ -72,21 +72,18 @@ ignored_logfile_problems = {
 }
 
 # Determine if the conditions are right for these tests
-sufficient_disk_space = True
+resval = resource_validation.ResourceValidator()
+resval.require_cpu_count(30)
+resval.require_free_memory_gb(28)
+resval.require_total_memory_gb(56)
 actual_output_path = output_path_parameter
 if output_path_parameter == ".":
     actual_output_path = "/tmp"
-disk_space = shutil.disk_usage(actual_output_path)
-total_disk_space_gb = disk_space.total / (1024 * 1024 * 1024)
-free_disk_space_gb = disk_space.free / (1024 * 1024 * 1024)
-print(
-    f"DEBUG: Space on disk for output path {actual_output_path}: total = {total_disk_space_gb} GB and free = {free_disk_space_gb} GB."
-)
-if (
-    total_disk_space_gb < minimum_total_disk_space_gb
-    or free_disk_space_gb < minimum_free_disk_space_gb
-):
-    sufficient_disk_space = False
+resval.require_free_disk_space_gb(actual_output_path, minimum_free_disk_space_gb)
+resval.require_total_disk_space_gb(actual_output_path, minimum_total_disk_space_gb)
+resval_debug_string = resval.get_debug_string()
+print(f"{resval_debug_string}")
+
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -131,6 +128,11 @@ conf_dict.config_substitutions.append(
         obj_class="DFOConf", updates={"busy_threshold": 1, "free_threshold": 0}
     )
 )
+conf_dict.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="LatencyBuffer", updates={"size": 100000}
+    )
+)
 oversize_conf = copy.deepcopy(conf_dict)  # Copy before setting the readout window
 
 conf_dict.config_substitutions.append(
@@ -159,7 +161,7 @@ confgen_arguments = {
     "TRSize_125PercentOfMaxFileSize": oversize_conf,
 }
 # The commands to run in nanorc, as a list
-if sufficient_disk_space:
+if resval.this_computer_has_sufficient_resources:
     nanorc_command_list = (
         "boot conf wait 5".split()
         + "start --run-number 101 wait 10 enable-triggers wait ".split()
@@ -171,16 +173,17 @@ if sufficient_disk_space:
         + " scrap terminate".split()
     )
 else:
-    nanorc_command_list = ["boot", "terminate"]
+    nanorc_command_list = ["wait", "3"]
 
 # The tests themselves
 
 
 def test_nanorc_success(run_nanorc):
-    if not sufficient_disk_space:
-        pytest.skip(
-            f"The raw data output path ({actual_output_path}) does not have enough space to run this test."
-        )
+    if not resval.this_computer_has_sufficient_resources:
+        resval_report_string = resval.get_insufficient_resources_report()
+        print(f"{resval_report_string}")
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
 
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)\-run_nanorc0].*", current_test)
@@ -195,10 +198,9 @@ def test_nanorc_success(run_nanorc):
 
 
 def test_log_files(run_nanorc):
-    if not sufficient_disk_space:
-        pytest.skip(
-            f"The raw data output path ({actual_output_path}) does not have enough space to run this test."
-        )
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
 
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
@@ -208,19 +210,9 @@ def test_log_files(run_nanorc):
 
 
 def test_data_files(run_nanorc):
-    if not sufficient_disk_space:
-        print(
-            f"The raw data output path ({actual_output_path}) does not have enough space to run this test."
-        )
-        print(
-            f"    (Free and total space are {free_disk_space_gb} GB and {total_disk_space_gb} GB.)"
-        )
-        print(
-            f"    (Minimums are {minimum_free_disk_space_gb} GB and {minimum_total_disk_space_gb} GB.)"
-        )
-        pytest.skip(
-            f"The raw data output path ({actual_output_path}) does not have enough space to run this test."
-        )
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
 
     local_expected_event_count = expected_event_count
     local_event_count_tolerance = expected_event_count_tolerance
@@ -261,10 +253,9 @@ def test_data_files(run_nanorc):
 
 
 def test_cleanup(run_nanorc):
-    if not sufficient_disk_space:
-        pytest.skip(
-            f"The raw data output path ({actual_output_path}) does not have enough space to run this test."
-        )
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
 
     pathlist_string = ""
     filelist_string = ""

--- a/integtest/large_trigger_record_test.py
+++ b/integtest/large_trigger_record_test.py
@@ -131,6 +131,11 @@ conf_dict.config_substitutions.append(
         obj_class="DFOConf", updates={"busy_threshold": 1, "free_threshold": 0}
     )
 )
+conf_dict.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="LatencyBuffer", updates={"size": 200000}
+    )
+)
 oversize_conf = copy.deepcopy(conf_dict)  # Copy before setting the readout window
 
 conf_dict.config_substitutions.append(

--- a/integtest/large_trigger_record_test.py
+++ b/integtest/large_trigger_record_test.py
@@ -84,7 +84,6 @@ resval.require_total_disk_space_gb(actual_output_path, minimum_total_disk_space_
 resval_debug_string = resval.get_debug_string()
 print(f"{resval_debug_string}")
 
-
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
 # to run the config generation and nanorc
@@ -173,7 +172,7 @@ if resval.this_computer_has_sufficient_resources:
         + " scrap terminate".split()
     )
 else:
-    nanorc_command_list = ["wait", "3"]
+    nanorc_command_list = ["wait", "1"]
 
 # The tests themselves
 

--- a/integtest/large_trigger_record_test.py
+++ b/integtest/large_trigger_record_test.py
@@ -30,9 +30,6 @@ number_of_dataflow_apps = 1
 trigger_rate = 0.06  # Hz
 readout_window_time_before = 10000000
 readout_window_time_after = 1000000
-data_rate_slowdown_factor = 1
-minimum_total_disk_space_gb = 20  # keep a reasonable amount for other users
-minimum_free_disk_space_gb = 15  # 50% more than what we need
 
 # Default values for validation parameters
 expected_number_of_data_files = 4
@@ -73,14 +70,19 @@ ignored_logfile_problems = {
 
 # Determine if the conditions are right for these tests
 resval = resource_validation.ResourceValidator()
-resval.require_cpu_count(30)
-resval.require_free_memory_gb(28)
-resval.require_total_memory_gb(56)
+resval.require_cpu_count(45)  # total number of data sources plus 50% more for everything else
+resval.require_free_memory_gb(28)  # the maximum amount that we observe being used ('free -h')
+resval.require_total_memory_gb(56)  # double what we need; trying to be kind to others
 actual_output_path = output_path_parameter
 if output_path_parameter == ".":
     actual_output_path = "/tmp"
-resval.require_free_disk_space_gb(actual_output_path, minimum_free_disk_space_gb)
-resval.require_total_disk_space_gb(actual_output_path, minimum_total_disk_space_gb)
+# The largest data set in this test is four 2.55 GB files.  To handle these four files
+# plus a safety factor of three for the last one, we need 6*2.55 = 15.3.
+# Note that a safety factor of 3 is configured below, over-riding the default value of 5.
+resval.require_free_disk_space_gb(actual_output_path, 16)
+# The value of 19 GB for the total disk space is just to reserve some space beyond what this
+# test needs for others to use, and to be slightly lower than a typical 20 GB full disk size.
+resval.require_total_disk_space_gb(actual_output_path, 19)
 resval_debug_string = resval.get_debug_string()
 print(f"{resval_debug_string}")
 
@@ -100,14 +102,6 @@ conf_dict.n_df_apps = number_of_dataflow_apps
 
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
-        obj_id=conf_dict.session,
-        obj_class="Session",
-        updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
-    )
-)
-
-conf_dict.config_substitutions.append(
-    data_classes.attribute_substitution(
         obj_class="RandomTCMakerConf",
         updates={"trigger_rate_hz": trigger_rate},
     )
@@ -119,6 +113,7 @@ conf_dict.config_substitutions.append(
         updates={
             "max_file_size": 2 * 1024 * 1024 * 1024,
             "directory_path": output_path_parameter,
+            "free_space_safety_factor": 3,
         },
     )
 )
@@ -130,6 +125,14 @@ conf_dict.config_substitutions.append(
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(
         obj_class="LatencyBuffer", updates={"size": 100000}
+    )
+)
+conf_dict.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="TRBConf",
+        updates={
+            "trigger_record_timeout_ms": 1000 / trigger_rate
+        },
     )
 )
 oversize_conf = copy.deepcopy(conf_dict)  # Copy before setting the readout window

--- a/integtest/max_file_size_test.py
+++ b/integtest/max_file_size_test.py
@@ -7,6 +7,7 @@ import urllib.request
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
+import integrationtest.resource_validation as resource_validation
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -86,6 +87,17 @@ ignored_logfile_problems = {
         "errorlog: -",
     ],
 }
+
+# Determine if the conditions are right for these tests
+resval = resource_validation.ResourceValidator()
+resval.require_cpu_count(20)  # number of data sources (6) times 3 threads each  plus a couple more for everything else
+resval.require_free_memory_gb(12)  # the maximum amount that we observe being used ('free -h')
+resval.require_total_memory_gb(24)  # double what we need; trying to be kind to others
+actual_output_path = "/tmp"
+resval.require_free_disk_space_gb(actual_output_path, 5)  # approximately what we use
+resval.require_total_disk_space_gb(actual_output_path, 10)  # factor of two to reserve some for others
+resval_debug_string = resval.get_debug_string()
+print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
@@ -196,19 +208,28 @@ confgen_arguments = {
 }
 
 # The commands to run in nanorc, as a list
-nanorc_command_list = (
-    "boot conf wait 5".split()
-    + "start --run-number 101 wait 1 enable-triggers wait 178".split()
-    + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split()
-    + "start --run-number 102 wait 1 enable-triggers wait 128".split()
-    + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split()
-    + " scrap terminate".split()
-)
+if resval.this_computer_has_sufficient_resources:
+    nanorc_command_list = (
+        "boot conf wait 5".split()
+        + "start --run-number 101 wait 1 enable-triggers wait 178".split()
+        + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split()
+        + "start --run-number 102 wait 1 enable-triggers wait 128".split()
+        + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split()
+        + " scrap terminate".split()
+    )
+else:
+    nanorc_command_list = ["wait", "1"]
 
 # The tests themselves
 
 
 def test_nanorc_success(run_nanorc):
+    if not resval.this_computer_has_sufficient_resources:
+        resval_report_string = resval.get_insufficient_resources_report()
+        print(f"{resval_report_string}")
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
+
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_nanorc0\].*", current_test)
     if match_obj:
@@ -222,6 +243,10 @@ def test_nanorc_success(run_nanorc):
 
 
 def test_log_files(run_nanorc):
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
+
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
@@ -230,6 +255,10 @@ def test_log_files(run_nanorc):
 
 
 def test_data_files(run_nanorc):
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
+
     fragment_check_list = [triggercandidate_frag_params, hsi_frag_params, wibeth_frag_params]
     fragment_check_list.append(triggerprimitive_frag_params)
     fragment_check_list.append(triggeractivity_frag_params)
@@ -257,6 +286,10 @@ def test_data_files(run_nanorc):
 
 
 def test_tpstream_files(run_nanorc):
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
+
     tpstream_files = run_nanorc.tpset_files
     fragment_check_list = [wibeth_tpset_params]  # WIBEth
 
@@ -278,6 +311,10 @@ def test_tpstream_files(run_nanorc):
 
 
 def test_cleanup(run_nanorc):
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
+
     pathlist_string = ""
     filelist_string = ""
     for data_file in run_nanorc.data_files:

--- a/integtest/multiple_data_writers_test.py
+++ b/integtest/multiple_data_writers_test.py
@@ -7,6 +7,7 @@ import urllib.request
 import integrationtest.data_file_checks as data_file_checks
 import integrationtest.log_file_checks as log_file_checks
 import integrationtest.data_classes as data_classes
+import integrationtest.resource_validation as resource_validation
 
 pytest_plugins = "integrationtest.integrationtest_drunc"
 
@@ -64,6 +65,16 @@ ignored_logfile_problems = {
     ],
 }
 
+# Determine if the conditions are right for this testing
+resval = resource_validation.ResourceValidator()
+resval.require_cpu_count(8)  # one per data source, plus a couple spares
+resval.require_free_memory_gb(10)  # approximately what we observe
+resval.require_total_memory_gb(20)  # safety factor of 2
+actual_output_path = "/tmp"
+resval.require_free_disk_space_gb(actual_output_path, 1)  # what we observe
+resval_debug_string = resval.get_debug_string()
+print(f"{resval_debug_string}")
+
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
 # to run the config generation and nanorc
@@ -119,18 +130,27 @@ confgen_arguments = {
 }
 
 # The commands to run in nanorc, as a list
-nanorc_command_list = (
-    "boot conf wait 5".split()
-    + "start --run-number 101 wait 1 enable-triggers wait 30".split()
-    + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split()
-    + "start --run-number 102 wait 1 enable-triggers wait 30".split()
-    + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split()
-    + " scrap terminate".split()
-)
+if resval.this_computer_has_sufficient_resources:
+    nanorc_command_list = (
+        "boot conf wait 5".split()
+        + "start --run-number 101 wait 1 enable-triggers wait 30".split()
+        + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split()
+        + "start --run-number 102 wait 1 enable-triggers wait 30".split()
+        + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split()
+        + " scrap terminate".split()
+    )
+else:
+    nanorc_command_list = ["wait", "1"]
 
 # The tests themselves
 
 def test_nanorc_success(run_nanorc):
+    if not resval.this_computer_has_sufficient_resources:
+        resval_report_string = resval.get_insufficient_resources_report()
+        print(f"{resval_report_string}")
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
+
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_nanorc0\].*", current_test)
     if match_obj:
@@ -144,6 +164,10 @@ def test_nanorc_success(run_nanorc):
 
 
 def test_log_files(run_nanorc):
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
+
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
@@ -152,6 +176,10 @@ def test_log_files(run_nanorc):
 
 
 def test_data_files(run_nanorc):
+    if not resval.this_computer_has_sufficient_resources:
+        resval_summary_string = resval.get_insufficient_resources_summary()
+        pytest.skip(f"{resval_summary_string}")
+
     fragment_check_list = [triggercandidate_frag_params, hsi_frag_params, wibeth_frag_params]
     fragment_check_list.append(triggerprimitive_frag_params)
     fragment_check_list.append(triggeractivity_frag_params)

--- a/integtest/multiple_data_writers_test.py
+++ b/integtest/multiple_data_writers_test.py
@@ -67,7 +67,7 @@ ignored_logfile_problems = {
 
 # Determine if the conditions are right for this testing
 resval = resource_validation.ResourceValidator()
-resval.require_cpu_count(8)  # one per data source, plus a couple spares
+resval.require_cpu_count(10)  # one per data source, plus several spares
 resval.require_free_memory_gb(10)  # approximately what we observe
 resval.require_total_memory_gb(20)  # safety factor of 2
 actual_output_path = "/tmp"


### PR DESCRIPTION
## Description

A few weeks ago, I noticed messages in one or more Slack channels that talked about `dfmodules` integtests consuming all of the memory on np04-srv-016 when the tests were run on that computer.  I believe that the biggest offender was `hdf5_compression_test`.

The first change in this set was to reduce the latency buffer size that is used in the `hdf5_compression_test` from a very large value to a more reasonable value.  I don't remember where that very large value came from, but it was probably left over from a debugging session when the test was first developed.  The test seems to run fine with the new smaller value.

Beyond that, I realized that we could/should make the `dfmodules` tests more user friendly when they are run on computers that have limited resources.  In particular, we should make consistent use of the pattern that we have in other integtests in which we check for sufficient resources and skip the test if insufficient resources are available on the current computer.  

To avoid copy/pasting all of the resource-checking code among all of the integtests, I created a helper class in the `integrationtest` repo that does the work of checking the requested resources and formatting strings that describe any problems that are found.  This means that these changes are dependent on ones in the `integrationtest` repo.

The general pattern for using the helper class is the following:

- create an instance of the class
- set minimum values for the quantities that we want to ensure are sufficient, e.g. one or more of CPU count, free memory, total memory, free disk space, and total disk space.
- skip the running of the usual `drunc` command if insufficient resources are available (run a very simple command like "wait 1" instead)
- in each of the `pytest` tests, check if sufficient resource were found, and use `pytest.skip` to skip the test if not

I've run these changes on `daq.fnal.gov`, `np04-srv-002`, `np04-srv-005`, and `np04-srv-016`, and that all worked (with certain tests being appropriately skipped when resources were limited, and with the understanding that the `hdf5_compression_test` and the `max_file_size_test` currently produce logfile complaints about gRPC ping messages).

## Testing Suggestions

Here are suggested steps for testing these changes:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_251008_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
git clone https://github.com/DUNE-DAQ/dfmodules.git -b kbiery/integtest_resource_protections
cd ..

dbt-workarea-env

git clone https://github.com/DUNE-DAQ/integrationtest.git -b kbiery/integtest_resource_protections
cd integrationtest
pip install -U .
cd ..

dbt-build -j 12
dbt-workarea-env

dfmodules_integtest_bundle.sh

echo
echo " *** Note that the tests worked, except for maybe hdf5_compression_test and max_file_size_test,"
echo " *** which have been reporting a warning message in the logfiles from gRPC."
```

## Correlated Issues and/or PRs

- DUNE-DAQ/Integrationtest#124

A feature branch name of `kbiery/integtest_resource_protections` is used in both repositories.

## Useful coordination

No special coordination will be needed for merging these changes to `develop` branches beyond announcing the merges on the appropriate Slack channel.