### PR TITLE
Updated the WIBEth binary file used in the disabled_output_test.

### DIFF
--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -90,7 +90,7 @@ conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.op_env = "integtest"
 conf_dict.session = "disabled"
 conf_dict.tpg_enabled = False
-conf_dict.frame_file = "asset://?checksum=e96fd6efd3f98a9a3bfaba32975b476e"  # WIBEth
+conf_dict.frame_file = "asset://?checksum=370df564205290d27cab47e44ae4ca47"  # WIBEth
 
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -90,7 +90,10 @@ conf_dict.dro_map_config.n_streams = number_of_data_producers
 conf_dict.op_env = "integtest"
 conf_dict.session = "disabled"
 conf_dict.tpg_enabled = False
-conf_dict.frame_file = "asset://?checksum=370df564205290d27cab47e44ae4ca47"  # WIBEth
+# We accept the default values for all of the other fields in the drunc_config data structure
+# (defined in integrationtest/src/integrationtest/data_classes.py), including the "frame_file",
+# which is the data file that is used to emulated the data. The current default for that field
+# specifies a set of WIBEth frames from a relatively recent run at EHN1.)
 
 conf_dict.config_substitutions.append(
     data_classes.attribute_substitution(


### PR DESCRIPTION
## Description

DUNE-DAQ/daqsystemtest#245 requests that we update our regression tests, etc. to use recent data-replay files from the _assets_ system.

In this repo, that translated to changing the checksum of the asset file that is used in the `disabled_output_test`.  The new file is `wib_link_67.bin`, which was recently created by Eric.

*** Please note that we changed the intention of this PR.  Instead of updating the default frames file, we removed the specification of the frames file in favor of a comment that talks about default values.

## Testing Suggestions

There are suggestions in DUNE-DAQ/daqsystemtest#245 for testing all of the asset-file-update changes together.  In addition, the change in this repo could be tested independently by including the `kbiery/asset_file_refresh` branch of this repo in a software area created from a recently nightly build, and running the `disabled_output_test`.
