### PR TITLE
Separate queues_timeout config parameter in TRBModule into

### DIFF
--- a/plugins/FragmentAggregatorModule.cpp
+++ b/plugins/FragmentAggregatorModule.cpp
@@ -11,6 +11,7 @@
 #include "dfmodules/opmon/FragmentAggregatorModule.pb.h"
 
 #include "appmodel/FragmentAggregatorModule.hpp"
+#include "appmodel/FragmentAggregatorConf.hpp"
 #include "confmodel/Connection.hpp"
 #include "confmodel/QueueWithSourceId.hpp"
 #include "daqdataformats/FragmentHeader.hpp"
@@ -66,7 +67,7 @@ FragmentAggregatorModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcf
   auto iom = iomanager::IOManager::get();
   iom->get_receiver<dfmessages::DataRequest>(m_data_req_input);
 
-  m_fragment_send_timeout = std::chrono::milliseconds(mdal->get_fragment_send_timeout_ms());
+  m_fragment_send_timeout = std::chrono::milliseconds(mdal->get_configuration()->get_fragment_send_timeout_ms());
 }
 
 void

--- a/plugins/FragmentAggregatorModule.cpp
+++ b/plugins/FragmentAggregatorModule.cpp
@@ -27,6 +27,7 @@ namespace dfmodules {
 
 FragmentAggregatorModule::FragmentAggregatorModule(const std::string& name)
   : DAQModule(name)
+  , m_fragment_send_timeout(1000)
 {
   register_command("start", &FragmentAggregatorModule::do_start);
   register_command("stop_trigger_sources", &FragmentAggregatorModule::do_stop);
@@ -64,6 +65,8 @@ FragmentAggregatorModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcf
   // this is just to get the data request receiver registered early (before Start)
   auto iom = iomanager::IOManager::get();
   iom->get_receiver<dfmessages::DataRequest>(m_data_req_input);
+
+  m_fragment_send_timeout = std::chrono::milliseconds(mdal->get_fragment_send_timeout_ms());
 }
 
 void
@@ -237,7 +240,7 @@ FragmentAggregatorModule::process_fragment(std::unique_ptr<daqdataformats::Fragm
                    << "." << fragment->get_sequence_number() << " and SourceID " << fragment->get_element_id() << " to "
                    << trb_identifier;
     auto sender = get_iom_sender<std::unique_ptr<daqdataformats::Fragment>>(trb_identifier);
-    sender->send(std::move(fragment), iomanager::Sender::s_no_block);
+    sender->send(std::move(fragment), m_fragment_send_timeout);
 
     m_fragments_processed++;
     auto timestamp_total = get_current_time_us() - m_timestamp_before_frag;

--- a/plugins/FragmentAggregatorModule.hpp
+++ b/plugins/FragmentAggregatorModule.hpp
@@ -78,6 +78,8 @@ private:
   std::map<int, std::string> m_producer_conn_ids;
   std::vector<std::string> m_trb_conn_ids;
 
+  std::chrono::milliseconds m_fragment_send_timeout;
+
   // Opmon
   uint64_t get_current_time_us();
   uint64_t m_timestamp_before_dr;

--- a/plugins/TRBModule.cpp
+++ b/plugins/TRBModule.cpp
@@ -60,7 +60,8 @@ using daqdataformats::TriggerRecordErrorBits;
 TRBModule::TRBModule(const std::string& name)
   : dunedaq::appfwk::DAQModule(name)
   , m_stop_requested(true)
-  , m_queue_timeout(100)
+  , m_tr_queue_timeout(100)
+  , m_dreq_queue_timeout(100)
 {
 
   register_command("conf", &TRBModule::do_conf);
@@ -178,11 +179,13 @@ TRBModule::do_conf(const CommandData_t&)
 
   m_trigger_timeout = std::chrono::milliseconds(m_trb_conf->get_trigger_record_timeout_ms());
 
-  m_loop_sleep = m_queue_timeout = std::chrono::milliseconds(m_trb_conf->get_queues_timeout());
+  m_tr_queue_timeout = std::chrono::milliseconds(m_trb_conf->get_tr_queue_timeout());
+  m_dreq_queue_timeout = std::chrono::milliseconds(m_trb_conf->get_request_queue_timeout());
 
-  TLOG() << get_name() << ": timeouts (ms): queue = " << m_queue_timeout.count() << ", loop = " << m_loop_sleep.count();
-  m_max_time_window = m_trb_conf->get_max_time_window();
-  TLOG() << get_name() << ": Max time window is " << m_max_time_window;
+  TLOG() << get_name() << ": timeouts (ms): TR = " << m_tr_queue_timeout.count()
+         << ", DReq = " << m_dreq_queue_timeout.count();
+  m_max_sequence_length = m_trb_conf->get_max_sequence_length_ticks();
+  TLOG() << get_name() << ": Max time window is " << m_max_sequence_length;
 
   m_this_trb_source_id.subsystem = daqdataformats::SourceID::Subsystem::kTRBuilder;
   m_this_trb_source_id.id = m_trb_conf->get_source_id();
@@ -499,7 +502,7 @@ TRBModule::create_trigger_records_and_dispatch(const dfmessages::TriggerDecision
 
   daqdataformats::timestamp_diff_t tot_width = end - begin;
   daqdataformats::sequence_number_t max_sequence_number =
-    (m_max_time_window > 0 && tot_width > 0) ? ((tot_width - 1) / m_max_time_window) : 0;
+    (m_max_sequence_length > 0 && tot_width > 0) ? ((tot_width - 1) / m_max_sequence_length) : 0;
 
   TLOG_DEBUG(TLVL_WORK_STEPS) << get_name() << ": trig_number " << td.trigger_number << ": run_number " << td.run_number
                               << ": trig_timestamp " << td.trigger_timestamp << " will have " << max_sequence_number + 1
@@ -510,9 +513,9 @@ TRBModule::create_trigger_records_and_dispatch(const dfmessages::TriggerDecision
   // create the trigger records
   for (daqdataformats::sequence_number_t sequence = 0; sequence <= max_sequence_number; ++sequence) {
 
-    daqdataformats::timestamp_t slice_begin = begin + sequence * m_max_time_window;
+    daqdataformats::timestamp_t slice_begin = begin + sequence * m_max_sequence_length;
     daqdataformats::timestamp_t slice_end =
-      m_max_time_window > 0 ? std::min(slice_begin + m_max_time_window, end) : end;
+      m_max_sequence_length > 0 ? std::min(slice_begin + m_max_sequence_length, end) : end;
 
     TLOG_DEBUG(TLVL_WORK_STEPS) << get_name() << ": trig_number " << td.trigger_number << ", sequence " << sequence
                                 << " ts=" << slice_begin << ":" << slice_end << " (TR " << begin << ":" << end << ")";
@@ -634,7 +637,7 @@ TRBModule::dispatch_data_requests(dfmessages::DataRequest dr, const daqdataforma
 
     // send data request into the corresponding connection
     try {
-      sender->send(std::move(dr), m_queue_timeout);
+      sender->send(std::move(dr), m_dreq_queue_timeout);
       wasSentSuccessfully = true;
       ++m_generated_data_requests;
     } catch (const ers::Issue& excpt) {
@@ -677,7 +680,7 @@ TRBModule::send_trigger_record(const TriggerId& id)
             auto trigger_record_bytes =
               serialization::serialize(temp_record, serialization::SerializationType::kMsgPack);
             trigger_record_ptr_t record_copy = serialization::deserialize<trigger_record_ptr_t>(trigger_record_bytes);
-            iom->get_sender<trigger_record_ptr_t>(it->data_destination)->send(std::move(record_copy), m_queue_timeout);
+            iom->get_sender<trigger_record_ptr_t>(it->data_destination)->send(std::move(record_copy), m_tr_queue_timeout);
             ++m_trmon_sent_counter;
             wasSentSuccessfully = true;
           } catch (const ers::Issue& excpt) {
@@ -697,7 +700,7 @@ TRBModule::send_trigger_record(const TriggerId& id)
   bool wasSentSuccessfully = false;
   do {
     try {
-      m_trigger_record_output->send(std::move(temp_record), m_queue_timeout);
+      m_trigger_record_output->send(std::move(temp_record), m_tr_queue_timeout);
       wasSentSuccessfully = true;
       ++m_generated_trigger_records;
     } catch (const ers::Issue& excpt) {

--- a/plugins/TRBModule.hpp
+++ b/plugins/TRBModule.hpp
@@ -231,8 +231,8 @@ private:
 
   // Configuration
   const appmodel::TRBConf* m_trb_conf;
-  std::chrono::milliseconds m_queue_timeout;
-  std::chrono::milliseconds m_loop_sleep;
+  std::chrono::milliseconds m_tr_queue_timeout;
+  std::chrono::milliseconds m_dreq_queue_timeout;
   std::string m_reply_connection;
   daqdataformats::SourceID m_this_trb_source_id;
 
@@ -252,7 +252,7 @@ private:
   std::map<TriggerId, std::pair<clock_type::time_point, trigger_record_ptr_t>> m_trigger_records;
 
   // Data request properties
-  daqdataformats::timestamp_diff_t m_max_time_window;
+  daqdataformats::timestamp_diff_t m_max_sequence_length;
 
   // Run information
   std::unique_ptr<const daqdataformats::run_number_t> m_run_number = nullptr;


### PR DESCRIPTION
tr_queue_timeout and data_request_queue_timeout. Rename max_time_window to max_sequence_length_ticks to clarify purpose of parameter (and units).

Add fragment_send_timeout to FragmentAggregator.

# Description

Addresses issue #453, adding configurable timeout to FragmentAggregator. Addresses some confusion which has arisen during dataflow performance testing on configuration parameters.

Testing involves setting the parameter (previous default value was 0 ms for FA timeout), and observing that the system does not report failure to send fragments in high rate situations.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Changes were tested for non-destructive interference via the integration test suite.

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

## Correlated Changes

* DUNE-DAQ/daqsystemtest#256
* DUNE-DAQ/appmodel#253
* DUNE-DAQ/dfmodules#455 (this PR)
* DUNE-DAQ/daqconf#609