### PR TITLE
Limit maximum number of "TriggerRecords" in flight

### DIFF
--- a/plugins/TRBModule.cpp
+++ b/plugins/TRBModule.cpp
@@ -187,6 +187,8 @@ TRBModule::do_conf(const CommandData_t&)
   m_this_trb_source_id.subsystem = daqdataformats::SourceID::Subsystem::kTRBuilder;
   m_this_trb_source_id.id = m_trb_conf->get_source_id();
 
+  m_max_open_trigger_records = m_trb_conf->get_maximum_open_trigger_records();
+
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_conf() method";
 }
 
@@ -448,6 +450,7 @@ TRBModule::extract_trigger_record(const TriggerId& id)
 {
   std::unique_lock<std::mutex> lk(m_trigger_records_mutex);
   auto it = m_trigger_records.extract(id);
+  m_open_trigger_record_cv.notify_one();
   lk.unlock();
 
   if (it.empty())
@@ -542,7 +545,8 @@ TRBModule::create_trigger_records_and_dispatch(const dfmessages::TriggerDecision
     // create the book entry
     TriggerId slice_id(td, sequence);
     {
-      std::lock_guard<std::mutex> lk(m_trigger_records_mutex);
+      std::unique_lock<std::mutex> lk(m_trigger_records_mutex);
+      m_open_trigger_record_cv.wait(lk, [&] { return m_trigger_records.size() < m_max_open_trigger_records; });
       auto it = m_trigger_records.find(slice_id);
       if (it != m_trigger_records.end()) {
         ers::error(DuplicatedTriggerDecision(ERS_HERE, slice_id));

--- a/plugins/TRBModule.hpp
+++ b/plugins/TRBModule.hpp
@@ -234,6 +234,7 @@ private:
   std::chrono::milliseconds m_queue_timeout;
   std::chrono::milliseconds m_loop_sleep;
   std::string m_reply_connection;
+  size_t m_max_open_trigger_records;
   daqdataformats::SourceID m_this_trb_source_id;
 
   // Input Connections
@@ -250,6 +251,7 @@ private:
   std::mutex m_trigger_records_mutex;
   clock_type::time_point m_last_bookkeeping{};
   std::map<TriggerId, std::pair<clock_type::time_point, trigger_record_ptr_t>> m_trigger_records;
+  std::condition_variable m_open_trigger_record_cv;
 
   // Data request properties
   daqdataformats::timestamp_diff_t m_max_time_window;


### PR DESCRIPTION
# Description

Part of https://github.com/DUNE-DAQ/daq-deliverables/issues/186

This PR adds a configurable limit to the number of "open" TriggerRecords/Trigger Record Sequences the TRB will issue data requests for and track timeouts for at one time. This is so that a very large sequenced trigger can be issued in smaller batches, and later sequences do not time out (either in the TRB or in the ReadoutApplication) while the readout is busy with earlier sequences.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

