### PR TITLE
Add ANSI filter when redirecting log output files

### DIFF
--- a/scripts/dfmodules_integtest_bundle.sh
+++ b/scripts/dfmodules_integtest_bundle.sh
@@ -29,6 +29,10 @@ Options:
     echo ""
 }
 
+logtee() {
+    tee -a >(sed -u 's/\x1b\[[0-9;]*m//g' >> "$1")
+}
+
 TEMP=`getopt -o hs:f:l:k:n:N: --long help,stop-on-failure,stop-on-skip -- "$@"`
 eval set -- "$TEMP"
 
@@ -122,19 +126,19 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
                 while [[ ${individual_loop_count} -lt ${individual_test_requested_iterations} ]]; do
                     let overall_test_index=${overall_test_index}+1
                     echo ""
-                    echo -e "\U0001F535 \033[0;34mStarting test ${overall_test_index} of ${total_number_of_tests}...\033[0m \U0001F535" | tee -a ${ITGRUNNER_LOG_FILE}
+                    echo -e "\U0001F535 \033[0;34mStarting test ${overall_test_index} of ${total_number_of_tests}...\033[0m \U0001F535" | logtee ${ITGRUNNER_LOG_FILE}
 
-                    echo -e "\u2B95 \033[0;1mRunning ${TEST_NAME}\033[0m \u2B05" | tee -a ${ITGRUNNER_LOG_FILE}
+                    echo -e "\u2B95 \033[0;1mRunning ${TEST_NAME}\033[0m \u2B05" | logtee ${ITGRUNNER_LOG_FILE}
                     if [[ -e "./${TEST_NAME}" ]]; then
-                        pytest -s ./${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
+                        pytest -s ./${TEST_NAME} | logtee ${ITGRUNNER_LOG_FILE}
                     elif [[ -e "${DBT_AREA_ROOT}/sourcecode/dfmodules/integtest/${TEST_NAME}" ]]; then
                         if [[ -w "${DBT_AREA_ROOT}" ]]; then
-                            pytest -s ${DBT_AREA_ROOT}/sourcecode/dfmodules/integtest/${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
+                            pytest -s ${DBT_AREA_ROOT}/sourcecode/dfmodules/integtest/${TEST_NAME} | logtee ${ITGRUNNER_LOG_FILE}
                         else
-                            pytest -s -p no:cacheprovider ${DBT_AREA_ROOT}/sourcecode/dfmodules/integtest/${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
+                            pytest -s -p no:cacheprovider ${DBT_AREA_ROOT}/sourcecode/dfmodules/integtest/${TEST_NAME} | logtee ${ITGRUNNER_LOG_FILE}
                         fi
                     else
-                        pytest -s -p no:cacheprovider ${DFMODULES_SHARE}/integtest/${TEST_NAME} | tee -a ${ITGRUNNER_LOG_FILE}
+                        pytest -s -p no:cacheprovider ${DFMODULES_SHARE}/integtest/${TEST_NAME} | logtee ${ITGRUNNER_LOG_FILE}
                     fi
                     let pytest_return_code=${PIPESTATUS[0]}
 
@@ -162,27 +166,27 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
 done
 
 # print out summary information
-echo ""                                                   | tee -a ${ITGRUNNER_LOG_FILE}
-echo ""                                                   | tee -a ${ITGRUNNER_LOG_FILE}
-echo "+++++++++++++++++++++++++++++++++++++++++++++++++"  | tee -a ${ITGRUNNER_LOG_FILE}
-echo "++++++++++++++++++++ SUMMARY ++++++++++++++++++++"  | tee -a ${ITGRUNNER_LOG_FILE}
-echo "+++++++++++++++++++++++++++++++++++++++++++++++++"  | tee -a ${ITGRUNNER_LOG_FILE}
-echo ""                                                   | tee -a ${ITGRUNNER_LOG_FILE}
-date                                                      | tee -a ${ITGRUNNER_LOG_FILE}
-echo "Log file is: ${ITGRUNNER_LOG_FILE}"                 | tee -a ${ITGRUNNER_LOG_FILE}
-echo ""                                                   | tee -a ${ITGRUNNER_LOG_FILE}
-egrep $'=====|\u2B95' ${ITGRUNNER_LOG_FILE} | egrep ' in |Running' | tee -a ${ITGRUNNER_LOG_FILE}
+echo ""                                                   | logtee ${ITGRUNNER_LOG_FILE}
+echo ""                                                   | logtee ${ITGRUNNER_LOG_FILE}
+echo "+++++++++++++++++++++++++++++++++++++++++++++++++"  | logtee ${ITGRUNNER_LOG_FILE}
+echo "++++++++++++++++++++ SUMMARY ++++++++++++++++++++"  | logtee ${ITGRUNNER_LOG_FILE}
+echo "+++++++++++++++++++++++++++++++++++++++++++++++++"  | logtee ${ITGRUNNER_LOG_FILE}
+echo ""                                                   | logtee ${ITGRUNNER_LOG_FILE}
+date                                                      | logtee ${ITGRUNNER_LOG_FILE}
+echo "Log file is: ${ITGRUNNER_LOG_FILE}"                 | logtee ${ITGRUNNER_LOG_FILE}
+echo ""                                                   | logtee ${ITGRUNNER_LOG_FILE}
+egrep $'=====|\u2B95' ${ITGRUNNER_LOG_FILE} | egrep ' in |Running' | logtee ${ITGRUNNER_LOG_FILE}
 
 # check again if the numad daemon is running
 numad_grep_output=`ps -ef | grep numad | grep -v grep`
 if [[ "${numad_grep_output}" != "" ]]; then
-    echo ""                                                                                 | tee -a ${ITGRUNNER_LOG_FILE}
-    echo "********************************************************************************" | tee -a ${ITGRUNNER_LOG_FILE}
-    echo "*** WARNING: 'numad' appears to be running on this computer!"                     | tee -a ${ITGRUNNER_LOG_FILE}
-    echo "*** 'ps' output:  ${numad_grep_output}"                                           | tee -a ${ITGRUNNER_LOG_FILE}
-    echo "*** This daemon can adversely affect the running of these tests, especially ones" | tee -a ${ITGRUNNER_LOG_FILE}
-    echo "*** that are resource intensive in the Readout Apps. This is because numad moves" | tee -a ${ITGRUNNER_LOG_FILE}
-    echo "*** processes (threads?) to different cores/numa nodes periodically, and that"    | tee -a ${ITGRUNNER_LOG_FILE}
-    echo "*** context switch can disrupt the stable running of the DAQ processes."          | tee -a ${ITGRUNNER_LOG_FILE}
-    echo "********************************************************************************" | tee -a ${ITGRUNNER_LOG_FILE}
+    echo ""                                                                                 | logtee ${ITGRUNNER_LOG_FILE}
+    echo "********************************************************************************" | logtee ${ITGRUNNER_LOG_FILE}
+    echo "*** WARNING: 'numad' appears to be running on this computer!"                     | logtee ${ITGRUNNER_LOG_FILE}
+    echo "*** 'ps' output:  ${numad_grep_output}"                                           | logtee ${ITGRUNNER_LOG_FILE}
+    echo "*** This daemon can adversely affect the running of these tests, especially ones" | logtee ${ITGRUNNER_LOG_FILE}
+    echo "*** that are resource intensive in the Readout Apps. This is because numad moves" | logtee ${ITGRUNNER_LOG_FILE}
+    echo "*** processes (threads?) to different cores/numa nodes periodically, and that"    | logtee ${ITGRUNNER_LOG_FILE}
+    echo "*** context switch can disrupt the stable running of the DAQ processes."          | logtee ${ITGRUNNER_LOG_FILE}
+    echo "********************************************************************************" | logtee ${ITGRUNNER_LOG_FILE}
 fi

--- a/scripts/dfmodules_integtest_bundle.sh
+++ b/scripts/dfmodules_integtest_bundle.sh
@@ -29,8 +29,13 @@ Options:
     echo ""
 }
 
-logtee() {
+# Removes the ANSI characters associated with formatting, including color coding and font styling
+CaptureOutputNoANSI() {
     tee -a >(sed -u 's/\x1b\[[0-9;]*m//g' >> "$1")
+}
+# Captures the output to the specified file, without changing the output
+CaptureOutput() {
+    tee -a 
 }
 
 TEMP=`getopt -o hs:f:l:k:n:N: --long help,stop-on-failure,stop-on-skip -- "$@"`
@@ -126,19 +131,19 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
                 while [[ ${individual_loop_count} -lt ${individual_test_requested_iterations} ]]; do
                     let overall_test_index=${overall_test_index}+1
                     echo ""
-                    echo -e "\U0001F535 \033[0;34mStarting test ${overall_test_index} of ${total_number_of_tests}...\033[0m \U0001F535" | logtee ${ITGRUNNER_LOG_FILE}
+                    echo -e "\U0001F535 \033[0;34mStarting test ${overall_test_index} of ${total_number_of_tests}...\033[0m \U0001F535" | CaptureOutput ${ITGRUNNER_LOG_FILE}
 
-                    echo -e "\u2B95 \033[0;1mRunning ${TEST_NAME}\033[0m \u2B05" | logtee ${ITGRUNNER_LOG_FILE}
+                    echo -e "\u2B95 \033[0;1mRunning ${TEST_NAME}\033[0m \u2B05" | CaptureOutput ${ITGRUNNER_LOG_FILE}
                     if [[ -e "./${TEST_NAME}" ]]; then
-                        pytest -s ./${TEST_NAME} | logtee ${ITGRUNNER_LOG_FILE}
+                        pytest -s ./${TEST_NAME} | CaptureOutputNoANSI ${ITGRUNNER_LOG_FILE}
                     elif [[ -e "${DBT_AREA_ROOT}/sourcecode/dfmodules/integtest/${TEST_NAME}" ]]; then
                         if [[ -w "${DBT_AREA_ROOT}" ]]; then
-                            pytest -s ${DBT_AREA_ROOT}/sourcecode/dfmodules/integtest/${TEST_NAME} | logtee ${ITGRUNNER_LOG_FILE}
+                            pytest -s ${DBT_AREA_ROOT}/sourcecode/dfmodules/integtest/${TEST_NAME} | CaptureOutputNoANSI ${ITGRUNNER_LOG_FILE}
                         else
-                            pytest -s -p no:cacheprovider ${DBT_AREA_ROOT}/sourcecode/dfmodules/integtest/${TEST_NAME} | logtee ${ITGRUNNER_LOG_FILE}
+                            pytest -s -p no:cacheprovider ${DBT_AREA_ROOT}/sourcecode/dfmodules/integtest/${TEST_NAME} | CaptureOutputNoANSI ${ITGRUNNER_LOG_FILE}
                         fi
                     else
-                        pytest -s -p no:cacheprovider ${DFMODULES_SHARE}/integtest/${TEST_NAME} | logtee ${ITGRUNNER_LOG_FILE}
+                        pytest -s -p no:cacheprovider ${DFMODULES_SHARE}/integtest/${TEST_NAME} | CaptureOutputNoANSI ${ITGRUNNER_LOG_FILE}
                     fi
                     let pytest_return_code=${PIPESTATUS[0]}
 
@@ -166,27 +171,27 @@ while [[ ${full_set_loop_count} -lt ${full_set_requested_interations} ]]; do
 done
 
 # print out summary information
-echo ""                                                   | logtee ${ITGRUNNER_LOG_FILE}
-echo ""                                                   | logtee ${ITGRUNNER_LOG_FILE}
-echo "+++++++++++++++++++++++++++++++++++++++++++++++++"  | logtee ${ITGRUNNER_LOG_FILE}
-echo "++++++++++++++++++++ SUMMARY ++++++++++++++++++++"  | logtee ${ITGRUNNER_LOG_FILE}
-echo "+++++++++++++++++++++++++++++++++++++++++++++++++"  | logtee ${ITGRUNNER_LOG_FILE}
-echo ""                                                   | logtee ${ITGRUNNER_LOG_FILE}
-date                                                      | logtee ${ITGRUNNER_LOG_FILE}
-echo "Log file is: ${ITGRUNNER_LOG_FILE}"                 | logtee ${ITGRUNNER_LOG_FILE}
-echo ""                                                   | logtee ${ITGRUNNER_LOG_FILE}
-egrep $'=====|\u2B95' ${ITGRUNNER_LOG_FILE} | egrep ' in |Running' | logtee ${ITGRUNNER_LOG_FILE}
+echo ""                                                   | CaptureOutput ${ITGRUNNER_LOG_FILE}
+echo ""                                                   | CaptureOutput ${ITGRUNNER_LOG_FILE}
+echo "+++++++++++++++++++++++++++++++++++++++++++++++++"  | CaptureOutput ${ITGRUNNER_LOG_FILE}
+echo "++++++++++++++++++++ SUMMARY ++++++++++++++++++++"  | CaptureOutput ${ITGRUNNER_LOG_FILE}
+echo "+++++++++++++++++++++++++++++++++++++++++++++++++"  | CaptureOutput ${ITGRUNNER_LOG_FILE}
+echo ""                                                   | CaptureOutput ${ITGRUNNER_LOG_FILE}
+date                                                      | CaptureOutput ${ITGRUNNER_LOG_FILE}
+echo "Log file is: ${ITGRUNNER_LOG_FILE}"                 | CaptureOutput ${ITGRUNNER_LOG_FILE}
+echo ""                                                   | CaptureOutput ${ITGRUNNER_LOG_FILE}
+egrep $'=====|\u2B95' ${ITGRUNNER_LOG_FILE} | egrep ' in |Running' | CaptureOutput ${ITGRUNNER_LOG_FILE}
 
 # check again if the numad daemon is running
 numad_grep_output=`ps -ef | grep numad | grep -v grep`
 if [[ "${numad_grep_output}" != "" ]]; then
-    echo ""                                                                                 | logtee ${ITGRUNNER_LOG_FILE}
-    echo "********************************************************************************" | logtee ${ITGRUNNER_LOG_FILE}
-    echo "*** WARNING: 'numad' appears to be running on this computer!"                     | logtee ${ITGRUNNER_LOG_FILE}
-    echo "*** 'ps' output:  ${numad_grep_output}"                                           | logtee ${ITGRUNNER_LOG_FILE}
-    echo "*** This daemon can adversely affect the running of these tests, especially ones" | logtee ${ITGRUNNER_LOG_FILE}
-    echo "*** that are resource intensive in the Readout Apps. This is because numad moves" | logtee ${ITGRUNNER_LOG_FILE}
-    echo "*** processes (threads?) to different cores/numa nodes periodically, and that"    | logtee ${ITGRUNNER_LOG_FILE}
-    echo "*** context switch can disrupt the stable running of the DAQ processes."          | logtee ${ITGRUNNER_LOG_FILE}
-    echo "********************************************************************************" | logtee ${ITGRUNNER_LOG_FILE}
+    echo ""                                                                                 | CaptureOutput ${ITGRUNNER_LOG_FILE}
+    echo "********************************************************************************" | CaptureOutput ${ITGRUNNER_LOG_FILE}
+    echo "*** WARNING: 'numad' appears to be running on this computer!"                     | CaptureOutput ${ITGRUNNER_LOG_FILE}
+    echo "*** 'ps' output:  ${numad_grep_output}"                                           | CaptureOutput ${ITGRUNNER_LOG_FILE}
+    echo "*** This daemon can adversely affect the running of these tests, especially ones" | CaptureOutput ${ITGRUNNER_LOG_FILE}
+    echo "*** that are resource intensive in the Readout Apps. This is because numad moves" | CaptureOutput ${ITGRUNNER_LOG_FILE}
+    echo "*** processes (threads?) to different cores/numa nodes periodically, and that"    | CaptureOutput ${ITGRUNNER_LOG_FILE}
+    echo "*** context switch can disrupt the stable running of the DAQ processes."          | CaptureOutput ${ITGRUNNER_LOG_FILE}
+    echo "********************************************************************************" | CaptureOutput ${ITGRUNNER_LOG_FILE}
 fi


### PR DESCRIPTION
# Description

**Depends on the following** 
https://github.com/DUNE-DAQ/daqpytools/pull/32
https://github.com/DUNE-DAQ/drunc/pull/690

**See also the following**
https://github.com/DUNE-DAQ/daqsystemtest/pull/268
https://github.com/DUNE-DAQ/asiolibs/pull/31

The above repositories add daqpytools into drunc, which has good quality of life improvements, including rich handling and colors in the terminal outputs. 
However, the int tests `tee` the terminal output directly into the log files. This has the unfortunate side effect that the ANSI characters used to define the colors are also copied into the log texts, resulting in lines such as the following:
```
[2;34m[2025/11/17 14:21:32 UTC][0m [1;32mINFO      [0m [2;37mprocess_manager.py:116                  [0m [2;37mdrunc.process_manager                             [0m process_manager communicating through address [1;92m10.73.136.38[0m[1;32m:[0m[1;36m46575[0m
```

This PR modifies the `tee` command in the int tests to pipe into a `sed` that strips only the ANSI color markers from the logs, which should result in much clearer logs while keeping the core color functionality in the terminal. 





## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [x] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

### Testing instructions 

- In a clean terminal, obtain latest nightly and check out the dependencies listed above (do _not_ check out this branch just yet)
- Run the full integration suite (`daqsystemtest_integtest_bundle.sh --stop-on-failure`)
- Save and review logs in the usual places
- Now checkout this PR and the latest in the dependency PRs and build as usual
- Run the full integration suite
- Compare the two log files. They should  match aside from the now-stripped ANSI characters. 


## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

