### PR TITLE
Added a regression test to verify that the --run-type=PROD RC argument works

### DIFF
--- a/integtest/README.md
+++ b/integtest/README.md
@@ -17,3 +17,4 @@ For reference, here are the ideas behind the existing tests:
 * `disabled_output_test.py` - verifies that the --disable-data-storage option prevents a raw data file from being produced
 * `insufficient_disk_space_test.py` - verifies that the appropriate errors and warnings are produced when there isn't enough disk space to write additional TriggerRecords
 * `trmonrequestor_test.py` - verifies that the TriggerRecord monitoring functionality successfully writes a subset of the TRs to disk
+* `offline_prod_run_test.py` - verifies that the --run-type=PROD argument to the run control 'start' command has the correct effect in the attributes of the output HDF5 file

--- a/integtest/offline_prod_run_test.py
+++ b/integtest/offline_prod_run_test.py
@@ -1,0 +1,134 @@
+import pytest
+import urllib.request
+
+import integrationtest.data_file_checks as data_file_checks
+import integrationtest.log_file_checks as log_file_checks
+import integrationtest.data_classes as data_classes
+
+pytest_plugins = "integrationtest.integrationtest_drunc"
+
+# Values that help determine the running conditions
+number_of_data_producers = 1
+data_rate_slowdown_factor = 1  # 10 for ProtoWIB/DuneWIB
+run_duration = 5  # seconds
+
+# Default values for validation parameters
+expected_number_of_data_files = 1
+check_for_logfile_errors = True
+expected_event_count = run_duration
+expected_event_count_tolerance = 2
+wibeth_frag_params = {
+    "fragment_type_description": "WIBEth",
+    "fragment_type": "WIBEth",
+    "expected_fragment_count": number_of_data_producers,
+    "min_size_bytes": 14472,
+    "max_size_bytes": 21672,
+}
+triggercandidate_frag_params = {
+    "fragment_type_description": "Trigger Candidate",
+    "fragment_type": "Trigger_Candidate",
+    "expected_fragment_count": 1,
+    "min_size_bytes": 128,
+    "max_size_bytes": 216,
+}
+hsi_frag_params = {
+    "fragment_type_description": "HSI",
+    "fragment_type": "Hardware_Signal",
+    "expected_fragment_count": 1,
+    "min_size_bytes": 100,
+    "max_size_bytes": 100,
+}
+ignored_logfile_problems = {
+    "connectionservice": [
+        "Searching for connections matching uid_regex<errored_frames_q> and data_type Unknown"
+    ],
+    "-controller": [
+        "Worker with pid \\d+ was terminated due to signal 1",
+        "Connection '.*' not found on the application registry",
+    ],
+    "connectivity-service": [
+        "errorlog: -",
+    ],
+}
+
+# The next three variable declarations *must* be present as globals in the test
+# file. They're read by the "fixtures" in conftest.py to determine how
+# to run the config generation and nanorc
+
+# The arguments to pass to the config generator, excluding the json
+# output directory (the test framework handles that)
+
+object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
+
+conf_dict = data_classes.drunc_config()
+conf_dict.dro_map_config.n_streams = number_of_data_producers
+conf_dict.op_env = "integtest"
+conf_dict.session = "smallfootprint"
+conf_dict.tpg_enabled = False
+conf_dict.fake_hsi_enabled = True
+
+conf_dict.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_id=conf_dict.session,
+        obj_class="Session",
+        updates={"data_rate_slowdown_factor": data_rate_slowdown_factor},
+    )
+)
+conf_dict.config_substitutions.append(
+    data_classes.attribute_substitution(obj_class="LatencyBuffer", updates={"size": 50000})
+)
+
+conf_dict.config_substitutions.append(
+    data_classes.attribute_substitution(
+        obj_class="FakeHSIEventGeneratorConf",
+        updates={"trigger_rate": 1.0},
+    )
+)
+
+confgen_arguments = {"SmallFootprint": conf_dict}
+# The commands to run in nanorc, as a list
+nanorc_command_list = (
+    "boot conf start --run-number 101 --run-type PROD wait 1 enable-triggers wait ".split()
+    + [str(run_duration)]
+    + "disable-triggers wait 2 drain-dataflow stop-trigger-sources stop wait 2 scrap terminate".split()
+)
+
+# The tests themselves
+
+
+def test_nanorc_success(run_nanorc):
+    # Check that nanorc completed correctly
+    assert run_nanorc.completed_process.returncode == 0
+
+
+def test_log_files(run_nanorc):
+    if check_for_logfile_errors:
+        # Check that there are no warnings or errors in the log files
+        assert log_file_checks.logs_are_error_free(
+            run_nanorc.log_files, True, True, ignored_logfile_problems
+        )
+
+
+def test_data_files(run_nanorc):
+    # Run some tests on the output data file
+    assert len(run_nanorc.data_files) == expected_number_of_data_files
+
+    fragment_check_list = [triggercandidate_frag_params, hsi_frag_params]
+    fragment_check_list.append(wibeth_frag_params)  # WIBEth
+
+    all_ok = True
+    for idx in range(len(run_nanorc.data_files)):
+        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+        all_ok &= data_file_checks.sanity_check(data_file)
+        all_ok &= data_file_checks.check_file_attributes(data_file, was_test_run="false")
+        all_ok &= data_file_checks.check_event_count(
+            data_file, expected_event_count, expected_event_count_tolerance
+        )
+        for jdx in range(len(fragment_check_list)):
+            all_ok &= data_file_checks.check_fragment_count(
+                data_file, fragment_check_list[jdx]
+            )
+            all_ok &= data_file_checks.check_fragment_sizes(
+                data_file, fragment_check_list[jdx]
+            )
+    assert all_ok

--- a/scripts/dfmodules_integtest_bundle.sh
+++ b/scripts/dfmodules_integtest_bundle.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # 29-Apr-2025, KAB
 
-integtest_list=( "multiple_data_writers_test.py" "insufficient_disk_space_test.py" "large_trigger_record_test.py" "hdf5_compression_test.py" "disabled_output_test.py" "max_file_size_test.py" "trmonrequestor_test.py" )
+integtest_list=( "multiple_data_writers_test.py" "insufficient_disk_space_test.py" "large_trigger_record_test.py" "hdf5_compression_test.py" "disabled_output_test.py" "max_file_size_test.py" "trmonrequestor_test.py" "offline_prod_run_test.py" )
 let last_test_index=${#integtest_list[@]}-1
 
 usage() {


### PR DESCRIPTION
…when passed to the `start` command.

# Description

There seems to be confusion about the role of the `--run-type` argument to the run control `start` command (e.g. [here](https://github.com/DUNE-DAQ/drunc/issues/694)).  This new test, along with the existing ones, verifies that the effect of that command option is simply to change the value stored in one of the HDF5 File Attributes and nothing else.

To test this, one can simply run the new test.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)
