### PR TITLE
Change stop timeout to milliseconds in DFOModule

### DIFF
--- a/plugins/DFOModule.cpp
+++ b/plugins/DFOModule.cpp
@@ -110,7 +110,7 @@ DFOModule::do_conf(const CommandData_t&)
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_conf() method";
 
   m_queue_timeout = std::chrono::milliseconds(m_dfo_conf->get_general_queue_timeout_ms());
-  m_stop_timeout = std::chrono::microseconds(m_dfo_conf->get_stop_timeout_ms());
+  m_stop_timeout = std::chrono::milliseconds(m_dfo_conf->get_stop_timeout_ms());
   m_busy_threshold = m_dfo_conf->get_busy_threshold();
   m_free_threshold = m_dfo_conf->get_free_threshold();
 


### PR DESCRIPTION
# Description

Following up on the reported error messages in the DFO on trigger decisions not finishing, @bieryAtFnal noted that this stop has a configuration that says it should be in ms, but then is converted to microseconds in the module --> there's a _very_ short timeout there for the DFO, which doesn't give much time for trigger record builders to return.


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

(still haven't run tests ... wanted to get the PR started first ...)

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

