### PR TITLE
Modified large_trigger_record_test.py to correctly compare the names …

### DIFF
--- a/integtest/large_trigger_record_test.py
+++ b/integtest/large_trigger_record_test.py
@@ -219,10 +219,7 @@ def test_data_files(run_nanorc):
     local_event_count_tolerance = expected_event_count_tolerance
     fragment_check_list = [triggercandidate_frag_params]
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
-    match_obj = re.search(r".*\[(.+)-run_nanorc0\].*", current_test)
-    if match_obj:
-        current_test = match_obj.group(1)
-    if current_test == "TRSize_125PercentOfMaxFileSize":
+    if "TRSize_125PercentOfMaxFileSize" in current_test:
         fragment_check_list.append(wibeth_frag_125pct_params)
     else:
         fragment_check_list.append(wibeth_frag_55pct_params)

--- a/integtest/large_trigger_record_test.py
+++ b/integtest/large_trigger_record_test.py
@@ -219,6 +219,11 @@ def test_data_files(run_nanorc):
     local_event_count_tolerance = expected_event_count_tolerance
     fragment_check_list = [triggercandidate_frag_params]
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
+    # 30-Dec-2025, KAB: modified the following "if" statement to check if the desired
+    # configuration name is contained in the current test name (instead of using an "if"
+    # clause that tests if the first part of the current test name is *equal* to the config
+    # name). This change is needed now because current test name has more information
+    # in it, and a simple comparison no longer works.
     if "TRSize_125PercentOfMaxFileSize" in current_test:
         fragment_check_list.append(wibeth_frag_125pct_params)
     else:


### PR DESCRIPTION
…of the configurations with the current test name when determining which datafile validation values to use.

# Description

The recent addition of the process manager type to the name of the current test in our integtests broke an "if" clause in the `large_trigger_record_test`.  This changes fixes that oversight.

The problem was identified when the `large_trigger_record_test` was run, and running it with the fix should now work without any problems.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Full set of integration tests pass (`dfmodules_integtest_bundle.sh`)

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
