### PR TITLE
Promoted TLOG message about incomplete TriggerRecords to ers::error

### DIFF
--- a/plugins/TRBModule.cpp
+++ b/plugins/TRBModule.cpp
@@ -477,10 +477,9 @@ TRBModule::extract_trigger_record(const TriggerId& id)
     m_pending_fragment_counter -= missing_fragments;
     temp->get_header_ref().set_error_bit(TriggerRecordErrorBits::kIncomplete, true);
 
-    TLOG() << get_name() << " sending incomplete TriggerRecord downstream "
-           << (m_stop_requested.load() ? "at Stop time " : "") << "(trigger/run_number=" << id << ", "
-           << temp->get_fragments_ref().size() << " of " << temp->get_header_ref().get_num_requested_components()
-           << " fragments included)";
+    ers::error(IncompleteTriggerRecord(ERS_HERE, (m_stop_requested.load() ? "at Stop time " : ""), id,
+                                       temp->get_fragments_ref().size(),
+                                       temp->get_header_ref().get_num_requested_components()));
   }
 
   return temp;

--- a/plugins/TRBModule.hpp
+++ b/plugins/TRBModule.hpp
@@ -151,6 +151,15 @@ ERS_DECLARE_ISSUE(dfmodules,                ///< Namespace
 )
 
 /**
+ * @brief Incomplete TR
+ */
+ERS_DECLARE_ISSUE(dfmodules,                ///< Namespace
+                  IncompleteTriggerRecord , ///< Issue class name
+                  "sending incomplete TriggerRecord downstream " << optional_stop_time_phrase << " (trigger/run_number=" << id << ", " << num_frags_present << " of " << num_components_requested << " fragments included)",
+                  ((std::string)optional_stop_time_phrase)((dfmodules::TriggerId)id)((int)num_frags_present)((int)num_components_requested) ///< Message parameters
+)
+
+/**
  * @brief Missing connection ID
  */
 ERS_DECLARE_ISSUE(dfmodules,           ///< Namespace


### PR DESCRIPTION
# Description

At the SWI&T meeting on 10-Feb-2026, we talked briefly about modifying the `TRBModule` code so that there is an error or warning message that includes the number of expected and present Fragments when an incomplete TriggerRecord is sent to the DataWriter.

This PR covers the proposed changes for this.

Some notes:

- I made the upgraded message an error message (instead of just a warning) because it seems that the occurrence of missing fragments is truly an error.  If others feel differently we can certainly discuss this.
- I did not simply add the number of expected and present Fragments to the existing error message that complains about a timeout in building a TriggerRecord mainly because the existing TLOG message is in a different part of the code.  And, it seemed to me that this different part of the code could be called from somewhere other than the code that enforces the timeout.  So, there seemed (to me) to be value in keeping them separate.

Here are the two messages that are printed out for each timed-out TriggerRecord, when the changes in this PR are included:

```
trigger id: 2-0/202 generate at: 110676539179764645 timed out
sending incomplete TriggerRecord downstream  (trigger/run_number=2-0/202, 6 of 10 fragments included)
```

Here are sample instructions for demonstrating the upgraded message:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260211_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
git clone https://github.com/DUNE-DAQ/dfmodules.git -b develop
git clone https://github.com/DUNE-DAQ/fdreadoutlibs.git -b develop
git clone https://github.com/DUNE-DAQ/fdreadoutmodules.git -b develop
git clone https://github.com/DUNE-DAQ/trigger.git -b develop
git clone https://github.com/DUNE-DAQ/hsilibs.git -b develop
cd ..

cd sourcecode/dfmodules/plugins
sed -i 's,TLOG_DEBUG(27),usleep(300000);\n     TLOG_DEBUG(27),' FragmentAggregatorModule.cpp
cd ../../../

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

daqconf_set_connectivity_service_port local-1x1-config config/daqsystemtest/example-configs.data.xml
daqconf_set_rc_controller_port local-1x1-config config/daqsystemtest/example-configs.data.xml

mkdir -p rundir
cd rundir

drunc-unified-shell ssh-standalone config/daqsystemtest/example-configs.data.xml local-1x1-config ${USER}-local-test boot wait 2 conf wait 2 start --run-number 201 wait 3 enable-triggers wait 10 disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop scrap terminate

egrep -i 'error|warning' log*.txt | egrep 'timed out|sending incomplete'

echo ""
echo -e "\U1F535 \U2705 Note that the existing error messages when the building of a TriggerRecord times out don't include information about the number of fragments received and expected. \U2705 \U1F535"
echo ""
echo ""
sleep 3

cd ../sourcecode/dfmodules
git checkout kbiery/incomplete_TR_error_message
cd ../../

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

cd rundir

drunc-unified-shell ssh-standalone config/daqsystemtest/example-configs.data.xml local-1x1-config ${USER}-local-test boot wait 2 conf wait 2 start --run-number 202 wait 3 enable-triggers wait 10 disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop scrap terminate

egrep -i 'error|warning' log*.txt | egrep 'timed out|sending incomplete'

echo ""
echo -e "\U1F535 \U2705 Note that the new messages do include information about the number of fragments received and expected. \U2705 \U1F535"
echo ""
echo ""
sleep 3

echo ""
echo -e "\U1f7e1 \U1f7e1 Please be careful using this software area for anything other than this special test. \U1f7e1 \U1f7e1 "
echo -e "\U1f7e1 \U1f7e1 It has been modified to include a very atypical extra delay, and it may produce \U1f7e1 \U1f7e1 "
echo -e "\U1f7e1 \U1f7e1 unexpected results when used for normal testing. \U1f7e1 \U1f7e1 "
echo ""
echo ""
```

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
