### PR TITLE
removed problematic candidate_window config updates in the trmonrequestor_test

### DIFF
--- a/integtest/trmonrequestor_test.py
+++ b/integtest/trmonrequestor_test.py
@@ -75,8 +75,6 @@ substitution = data_classes.attribute_substitution(
     updates={
         "trigger_rate_hz": trigger_rate,
         "candidate_backshift_ts": 0,
-        "candidate_window_before_ts": readout_window_time_before,
-        "candidate_window_after_ts": readout_window_time_after
     },
 )
 conf_dict.config_substitutions.append(substitution)
@@ -103,7 +101,6 @@ nanorc_command_list = "boot conf wait 5".split()
 for ii in range(run_count):
     nanorc_command_list += make_run_command_list(100 + ii)
 nanorc_command_list += " scrap terminate".split()
-print(f"nanorc_command_list is {nanorc_command_list}")
 
 # The tests themselves
 def test_nanorc_success(run_nanorc):


### PR DESCRIPTION
# Description

I noticed that there seems to have been a copy/paste error introduced into the `trmonrequestor_test` recently.  `readout_window_time_before` and `readout_window_time_after` local variables are referenced but are not defined in that test.

The changes in this PR remove the problematic configuration updates, and remove a possibly left-over print statement.

To test these changes, here are some suggested steps:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260301_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
cd daqsystemtest ; git checkout kbiery/colorize_error_in_bundle_script; cd ..
git clone https://github.com/DUNE-DAQ/dfmodules.git -b develop
cd ..

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -r dfmodules -k trmon

echo ""
echo -e "\U1F535 \U2705 Note that the trmon integtest failed. \U2705 \U1F535"
echo ""
echo ""
sleep 3

cd sourcecode/dfmodules
git checkout kbiery/trmon_test_fix
cd ../..

dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -r dfmodules -k trmon

echo ""
echo -e "\U1F535 \U2705 Note that the trmon integtest now works. \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
