### PR TITLE
NanoRC to DuneRC name change

### DIFF
--- a/integtest/README.md
+++ b/integtest/README.md
@@ -6,7 +6,7 @@
 Here is a sample command for invoking a test (feel free to keep or drop the options in brackets, as you prefer):
 
 ```
-pytest -s max_file_size_test.py [--nanorc-option log-level debug]  # this nanorc option is still useful even when using drunc
+pytest -s max_file_size_test.py [--dunerc-option log-level debug]  # this dunerc option is still useful even when using drunc
 ```
 
 For reference, here are the ideas behind the existing tests:

--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -81,7 +81,7 @@ ignored_logfile_problems = {
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and dunerc
 
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
@@ -139,34 +139,34 @@ confgen_arguments = {
     "Software_TPG_System": swtpg_conf,
 }
 
-# The commands to run in nanorc, as a list
-nanorc_command_list = "boot conf".split()
-nanorc_command_list += (
+# The commands to run in dunerc, as a list
+dunerc_command_list = "boot conf".split()
+dunerc_command_list += (
     "start --disable-data-storage true --run-number 101 wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop wait 2".split()
 )
-nanorc_command_list += (
+dunerc_command_list += (
     "start                             --run-number 102  wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop wait 2".split()
 )
-nanorc_command_list += (
+dunerc_command_list += (
     "start --disable-data-storage true --run-number 103  wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop wait 2".split()
 )
-nanorc_command_list += (
+dunerc_command_list += (
     "start                             --run-number 104  wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop wait 2".split()
 )
-nanorc_command_list += "scrap terminate".split()
+dunerc_command_list += "scrap terminate".split()
 
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -177,23 +177,23 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     local_expected_event_count = expected_event_count
     local_event_count_tolerance = expected_event_count_tolerance
     fragment_check_list = [triggercandidate_frag_params]
-    if run_nanorc.confgen_config.tpg_enabled:
+    if run_dunerc.confgen_config.tpg_enabled:
         local_expected_event_count += (
             250 * number_of_data_producers * run_duration / 100
         )
@@ -208,11 +208,11 @@ def test_data_files(run_nanorc):
 
     all_ok = True
     # Run some tests on the output data file
-    all_ok &= len(run_nanorc.data_files) == expected_number_of_data_files
+    all_ok &= len(run_dunerc.data_files) == expected_number_of_data_files
 
     all_ok = True
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/hdf5_compression_test.py
+++ b/integtest/hdf5_compression_test.py
@@ -118,7 +118,7 @@ print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and dunerc
 
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
@@ -230,9 +230,9 @@ confgen_arguments = {
     "DAPHNE_TPG_System": conf_dict,
 }
 
-# The commands to run in nanorc, as a list
+# The commands to run in dunerc, as a list
 if resval.this_computer_has_sufficient_resources:
-    nanorc_command_list = (
+    dunerc_command_list = (
         "boot conf wait 5".split()
         + "start --run-number 101 wait 1 enable-triggers wait 100".split()
         + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split()
@@ -241,12 +241,12 @@ if resval.this_computer_has_sufficient_resources:
         + " scrap terminate".split()
 )
 else:
-    nanorc_command_list = ["wait", "1"]
+    dunerc_command_list = ["wait", "1"]
 
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_report_string = resval.get_insufficient_resources_report()
         print(f"{resval_report_string}")
@@ -263,11 +263,11 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
@@ -275,11 +275,11 @@ def test_log_files(run_nanorc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
@@ -289,15 +289,15 @@ def test_data_files(run_nanorc):
     fragment_check_list.append(triggeractivity_frag_params)
 
     # Run some tests on the output data file
-    all_ok = len(run_nanorc.data_files) == 6  # three for each run
+    all_ok = len(run_dunerc.data_files) == 6  # three for each run
     print("") # Clear potential dot from pytest
     if all_ok:
         print("\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found (6)")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected 6, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected 6, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         for jdx in range(len(fragment_check_list)):
@@ -310,12 +310,12 @@ def test_data_files(run_nanorc):
     assert all_ok, "\N{POLICE CARS REVOLVING LIGHT} One or more raw data file checks failed! \N{POLICE CARS REVOLVING LIGHT}"
 
 
-def test_tpstream_files(run_nanorc):
+def test_tpstream_files(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
 
-    tpstream_files = run_nanorc.tpset_files
+    tpstream_files = run_dunerc.tpset_files
     fragment_check_list = [daphne_tpset_params]
 
     all_ok = len(tpstream_files) == 6  # three for each run
@@ -335,18 +335,18 @@ def test_tpstream_files(run_nanorc):
     assert all_ok, "\N{POLICE CARS REVOLVING LIGHT} One or more TP-stream data file checks failed! \N{POLICE CARS REVOLVING LIGHT}"
 
 
-def test_cleanup(run_nanorc):
+def test_cleanup(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
 
     pathlist_string = ""
     filelist_string = ""
-    for data_file in run_nanorc.data_files:
+    for data_file in run_dunerc.data_files:
         filelist_string += " " + str(data_file)
         if str(data_file.parent) not in pathlist_string:
             pathlist_string += " " + str(data_file.parent)
-    for data_file in run_nanorc.tpset_files:
+    for data_file in run_dunerc.tpset_files:
         filelist_string += " " + str(data_file)
         if str(data_file.parent) not in pathlist_string:
             pathlist_string += " " + str(data_file.parent)
@@ -360,9 +360,9 @@ def test_cleanup(run_nanorc):
         print("--------------------")
         os.system(f"ls -alF {filelist_string}")
 
-        for data_file in run_nanorc.data_files:
+        for data_file in run_dunerc.data_files:
             data_file.unlink()
-        for data_file in run_nanorc.tpset_files:
+        for data_file in run_dunerc.tpset_files:
             data_file.unlink()
 
         print("--------------------")

--- a/integtest/insufficient_disk_space_test.py
+++ b/integtest/insufficient_disk_space_test.py
@@ -89,7 +89,7 @@ free_space_safety_factor = int(resval.free_disk_space_gb - desired_size_of_outpu
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and dunerc
 
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
@@ -138,9 +138,9 @@ conf_dict.config_substitutions.append(
 confgen_arguments = {
     "Base_System": conf_dict,
 }
-# The commands to run in nanorc, as a list
+# The commands to run in dunerc, as a list
 if resval.this_computer_has_sufficient_resources:
-    nanorc_command_list = (
+    dunerc_command_list = (
         "boot conf wait 5".split()
         + "start --run-number 101 wait 1 enable-triggers wait ".split()
         + [str(run_duration)]
@@ -154,12 +154,12 @@ if resval.this_computer_has_sufficient_resources:
         + " scrap terminate".split()
     )
 else:
-    nanorc_command_list = ["wait", "1"]
+    dunerc_command_list = ["wait", "1"]
 
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_report_string = resval.get_insufficient_resources_report()
         print(f"{resval_report_string}")
@@ -176,11 +176,11 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
@@ -188,7 +188,7 @@ def test_log_files(run_nanorc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files,
+            run_dunerc.log_files,
             True,
             True,
             ignored_logfile_problems,
@@ -196,7 +196,7 @@ def test_log_files(run_nanorc):
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
@@ -209,15 +209,15 @@ def test_data_files(run_nanorc):
     fragment_check_list.append(wibeth_frag_hsi_trig_params)  # WIBEth
 
     # Run some tests on the output data file
-    all_ok = len(run_nanorc.data_files) == expected_number_of_data_files or len(run_nanorc.data_files) == (expected_number_of_data_files+1)
+    all_ok = len(run_dunerc.data_files) == expected_number_of_data_files or len(run_dunerc.data_files) == (expected_number_of_data_files+1)
     print("") # Clear potential dot from pytest
     if all_ok:
-        print(f"\N{WHITE HEAVY CHECK MARK} An acceptable number of raw data files was found ({len(run_nanorc.data_files)} in {expected_number_of_data_files}..{expected_number_of_data_files+1})")
+        print(f"\N{WHITE HEAVY CHECK MARK} An acceptable number of raw data files was found ({len(run_dunerc.data_files)} in {expected_number_of_data_files}..{expected_number_of_data_files+1})")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}..{expected_number_of_data_files+1}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}..{expected_number_of_data_files+1}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(
@@ -233,14 +233,14 @@ def test_data_files(run_nanorc):
     assert all_ok
 
 
-def test_cleanup(run_nanorc):
+def test_cleanup(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
 
     pathlist_string = ""
     filelist_string = ""
-    for data_file in run_nanorc.data_files:
+    for data_file in run_dunerc.data_files:
         filelist_string += " " + str(data_file)
         if str(data_file.parent) not in pathlist_string:
             pathlist_string += " " + str(data_file.parent)
@@ -254,7 +254,7 @@ def test_cleanup(run_nanorc):
         print("--------------------")
         os.system(f"ls -alF {filelist_string}")
 
-        for data_file in run_nanorc.data_files:
+        for data_file in run_dunerc.data_files:
             data_file.unlink()
 
         print("--------------------")

--- a/integtest/large_trigger_record_test.py
+++ b/integtest/large_trigger_record_test.py
@@ -87,7 +87,7 @@ print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and dunerc
 
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
@@ -158,9 +158,9 @@ confgen_arguments = {
     "TRSize_55PercentOfMaxFileSize": conf_dict,
     "TRSize_125PercentOfMaxFileSize": oversize_conf,
 }
-# The commands to run in nanorc, as a list
+# The commands to run in dunerc, as a list
 if resval.this_computer_has_sufficient_resources:
-    nanorc_command_list = (
+    dunerc_command_list = (
         "boot conf wait 5".split()
         + "start --run-number 101 wait 10 enable-triggers wait ".split()
         + [str(run_duration)]
@@ -171,12 +171,12 @@ if resval.this_computer_has_sufficient_resources:
         + " scrap terminate".split()
     )
 else:
-    nanorc_command_list = ["wait", "1"]
+    dunerc_command_list = ["wait", "1"]
 
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_report_string = resval.get_insufficient_resources_report()
         print(f"{resval_report_string}")
@@ -193,11 +193,11 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
@@ -205,11 +205,11 @@ def test_log_files(run_nanorc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
@@ -229,15 +229,15 @@ def test_data_files(run_nanorc):
         fragment_check_list.append(wibeth_frag_55pct_params)
 
     # Run some tests on the output data file
-    all_ok = len(run_nanorc.data_files) == expected_number_of_data_files
+    all_ok = len(run_dunerc.data_files) == expected_number_of_data_files
     print("") # Clear potential dot from pytest
     if all_ok:
         print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(
@@ -254,14 +254,14 @@ def test_data_files(run_nanorc):
     assert all_ok
 
 
-def test_cleanup(run_nanorc):
+def test_cleanup(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
 
     pathlist_string = ""
     filelist_string = ""
-    for data_file in run_nanorc.data_files:
+    for data_file in run_dunerc.data_files:
         filelist_string += " " + str(data_file)
         if str(data_file.parent) not in pathlist_string:
             pathlist_string += " " + str(data_file.parent)
@@ -275,7 +275,7 @@ def test_cleanup(run_nanorc):
         print("--------------------")
         os.system(f"ls -alF {filelist_string}")
 
-        for data_file in run_nanorc.data_files:
+        for data_file in run_dunerc.data_files:
             data_file.unlink()
 
         print("--------------------")

--- a/integtest/max_file_size_test.py
+++ b/integtest/max_file_size_test.py
@@ -100,7 +100,7 @@ print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and dunerc
 
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
@@ -206,9 +206,9 @@ confgen_arguments = {
     "WIBEth_TPG_System": conf_dict,
 }
 
-# The commands to run in nanorc, as a list
+# The commands to run in dunerc, as a list
 if resval.this_computer_has_sufficient_resources:
-    nanorc_command_list = (
+    dunerc_command_list = (
         "boot conf wait 5".split()
         + "start --run-number 101 wait 1 enable-triggers wait 178".split()
         + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split()
@@ -217,12 +217,12 @@ if resval.this_computer_has_sufficient_resources:
         + " scrap terminate".split()
     )
 else:
-    nanorc_command_list = ["wait", "1"]
+    dunerc_command_list = ["wait", "1"]
 
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_report_string = resval.get_insufficient_resources_report()
         print(f"{resval_report_string}")
@@ -239,11 +239,11 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
@@ -251,11 +251,11 @@ def test_log_files(run_nanorc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
@@ -265,15 +265,15 @@ def test_data_files(run_nanorc):
     fragment_check_list.append(triggeractivity_frag_params)
 
     # Run some tests on the output data file
-    all_ok = len(run_nanorc.data_files) == 6  # three for each run
+    all_ok = len(run_dunerc.data_files) == 6  # three for each run
     print("") # Clear potential dot from pytest
     if all_ok:
         print("\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found (6)")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected 6, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected 6, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         for jdx in range(len(fragment_check_list)):
@@ -286,12 +286,12 @@ def test_data_files(run_nanorc):
     assert all_ok, "\N{POLICE CARS REVOLVING LIGHT} One or more raw data file checks failed! \N{POLICE CARS REVOLVING LIGHT}"
 
 
-def test_tpstream_files(run_nanorc):
+def test_tpstream_files(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
 
-    tpstream_files = run_nanorc.tpset_files
+    tpstream_files = run_dunerc.tpset_files
     fragment_check_list = [wibeth_tpset_params]  # WIBEth
 
     all_ok = len(tpstream_files) == 6  # three for each run
@@ -311,18 +311,18 @@ def test_tpstream_files(run_nanorc):
     assert all_ok, "\N{POLICE CARS REVOLVING LIGHT} One or more TP-stream data file checks failed! \N{POLICE CARS REVOLVING LIGHT}"
 
 
-def test_cleanup(run_nanorc):
+def test_cleanup(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
 
     pathlist_string = ""
     filelist_string = ""
-    for data_file in run_nanorc.data_files:
+    for data_file in run_dunerc.data_files:
         filelist_string += " " + str(data_file)
         if str(data_file.parent) not in pathlist_string:
             pathlist_string += " " + str(data_file.parent)
-    for data_file in run_nanorc.tpset_files:
+    for data_file in run_dunerc.tpset_files:
         filelist_string += " " + str(data_file)
         if str(data_file.parent) not in pathlist_string:
             pathlist_string += " " + str(data_file.parent)
@@ -336,9 +336,9 @@ def test_cleanup(run_nanorc):
         print("--------------------")
         os.system(f"ls -alF {filelist_string}")
 
-        for data_file in run_nanorc.data_files:
+        for data_file in run_dunerc.data_files:
             data_file.unlink()
-        for data_file in run_nanorc.tpset_files:
+        for data_file in run_dunerc.tpset_files:
             data_file.unlink()
 
         print("--------------------")

--- a/integtest/multiple_data_writers_test.py
+++ b/integtest/multiple_data_writers_test.py
@@ -76,7 +76,7 @@ print(f"{resval_debug_string}")
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and dunerc
 
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
@@ -128,9 +128,9 @@ confgen_arguments = {
     "WIBEth_System": conf_dict,
 }
 
-# The commands to run in nanorc, as a list
+# The commands to run in dunerc, as a list
 if resval.this_computer_has_sufficient_resources:
-    nanorc_command_list = (
+    dunerc_command_list = (
         "boot conf wait 5".split()
         + "start --run-number 101 wait 1 enable-triggers wait 30".split()
         + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split()
@@ -139,11 +139,11 @@ if resval.this_computer_has_sufficient_resources:
         + " scrap terminate".split()
     )
 else:
-    nanorc_command_list = ["wait", "1"]
+    dunerc_command_list = ["wait", "1"]
 
 # The tests themselves
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_report_string = resval.get_insufficient_resources_report()
         print(f"{resval_report_string}")
@@ -160,11 +160,11 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
@@ -172,11 +172,11 @@ def test_log_files(run_nanorc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     if not resval.this_computer_has_sufficient_resources:
         resval_summary_string = resval.get_insufficient_resources_summary()
         pytest.skip(f"{resval_summary_string}")
@@ -186,15 +186,15 @@ def test_data_files(run_nanorc):
     fragment_check_list.append(triggeractivity_frag_params)
 
     # Run some tests on the output data file
-    all_ok = len(run_nanorc.data_files) == 6  # three for each run
+    all_ok = len(run_dunerc.data_files) == 6  # three for each run
     print("") # Clear potential dot from pytest
     if all_ok:
         print("\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found (6)")
     else:
-        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected 6, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected 6, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         for jdx in range(len(fragment_check_list)):

--- a/integtest/offline_prod_run_test.py
+++ b/integtest/offline_prod_run_test.py
@@ -55,7 +55,7 @@ ignored_logfile_problems = {
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and dunerc
 
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
@@ -88,8 +88,8 @@ conf_dict.config_substitutions.append(
 )
 
 confgen_arguments = {"SmallFootprint": conf_dict}
-# The commands to run in nanorc, as a list
-nanorc_command_list = (
+# The commands to run in dunerc, as a list
+dunerc_command_list = (
     "boot conf start --run-number 101 --run-type PROD wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 2 drain-dataflow stop-trigger-sources stop wait 2 scrap terminate".split()
@@ -98,7 +98,7 @@ nanorc_command_list = (
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -109,28 +109,28 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     # Run some tests on the output data file
-    assert len(run_nanorc.data_files) == expected_number_of_data_files
+    assert len(run_dunerc.data_files) == expected_number_of_data_files
 
     fragment_check_list = [triggercandidate_frag_params, hsi_frag_params]
     fragment_check_list.append(wibeth_frag_params)  # WIBEth
 
     all_ok = True
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file, was_test_run="false")
         all_ok &= data_file_checks.check_event_count(

--- a/integtest/trmonrequestor_test.py
+++ b/integtest/trmonrequestor_test.py
@@ -56,7 +56,7 @@ ignored_logfile_problems = {
 
 # The next three variable declarations *must* be present as globals in the test
 # file. They're read by the "fixtures" in conftest.py to determine how
-# to run the config generation and nanorc
+# to run the config generation and dunerc
 
 object_databases = ["config/daqsystemtest/integrationtest-objects.data.xml"]
 
@@ -92,21 +92,21 @@ confgen_arguments = {
     "WIBEth_System": conf_dict,
 }
 
-# The commands to run in nanorc, as a list
+# The commands to run in dunerc, as a list
 def make_run_command_list(runnum):
     return (
         f"start --run-number {runnum} wait 1 enable-triggers wait ".split()
         + [str(run_duration)]
         + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop ".split())
 
-nanorc_command_list = "boot conf wait 5".split()
+dunerc_command_list = "boot conf wait 5".split()
 for ii in range(run_count):
-    nanorc_command_list += make_run_command_list(100 + ii)
-nanorc_command_list += " scrap terminate".split()
-print(f"nanorc_command_list is {nanorc_command_list}")
+    dunerc_command_list += make_run_command_list(100 + ii)
+dunerc_command_list += " scrap terminate".split()
+print(f"dunerc_command_list is {dunerc_command_list}")
 
 # The tests themselves
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -117,37 +117,37 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
 
     # Check that at least some of the expected log files are present
     assert any(
-        f"{run_nanorc.session}_df-01" in str(logname)
-        for logname in run_nanorc.log_files
+        f"{run_dunerc.session}_df-01" in str(logname)
+        for logname in run_dunerc.log_files
     )
     assert any(
-        f"{run_nanorc.session}_dfo" in str(logname) for logname in run_nanorc.log_files
+        f"{run_dunerc.session}_dfo" in str(logname) for logname in run_dunerc.log_files
     )
     assert any(
-        f"{run_nanorc.session}_mlt" in str(logname) for logname in run_nanorc.log_files
+        f"{run_dunerc.session}_mlt" in str(logname) for logname in run_dunerc.log_files
     )
     assert any(
-        f"{run_nanorc.session}_ru" in str(logname) for logname in run_nanorc.log_files
+        f"{run_dunerc.session}_ru" in str(logname) for logname in run_dunerc.log_files
     )
 
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, True, True, ignored_logfile_problems
+            run_dunerc.log_files, True, True, ignored_logfile_problems
         )
 
 
-def test_data_files(run_nanorc):
+def test_data_files(run_dunerc):
     # Run some tests on the output data file
-    all_ok = len(run_nanorc.data_files) == expected_number_of_data_files
+    all_ok = len(run_dunerc.data_files) == expected_number_of_data_files
     print("")  # Clear potential dot from pytest
     if all_ok:
         print(
@@ -155,15 +155,15 @@ def test_data_files(run_nanorc):
         )
     else:
         print(
-            f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_nanorc.data_files)} \N{POLICE CARS REVOLVING LIGHT}"
+            f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}"
         )
 
     fragment_check_list = [triggercandidate_frag_params, hsi_frag_params]
     fragment_check_list.append(wibeth_frag_params)
     nontrig_fragment_check_list = [hsi_frag_params, wibeth_frag_params]
 
-    for idx in range(len(run_nanorc.data_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.data_files[idx])
+    for idx in range(len(run_dunerc.data_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.data_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(
@@ -183,21 +183,21 @@ def test_data_files(run_nanorc):
 
     trmon_low = (run_count * expected_event_count * number_of_dataflow_apps / trmon_prescale) - 1
     trmon_high = (run_count * expected_event_count * number_of_dataflow_apps / trmon_prescale) + 2
-    trmon_ok = len(run_nanorc.trmon_files) > trmon_low
-    trmon_ok &= len(run_nanorc.trmon_files) < trmon_high
+    trmon_ok = len(run_dunerc.trmon_files) > trmon_low
+    trmon_ok &= len(run_dunerc.trmon_files) < trmon_high
 
     print("")  # Add break from Data file printouts
     if trmon_ok:
         print(
-            f"\N{WHITE HEAVY CHECK MARK} The correct number of TRMon data files was found ({trmon_high} > {len(run_nanorc.trmon_files)} > {trmon_low})"
+            f"\N{WHITE HEAVY CHECK MARK} The correct number of TRMon data files was found ({trmon_high} > {len(run_dunerc.trmon_files)} > {trmon_low})"
         )
     else:
         print(
-            f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of TRMon data files was found, expected between {trmon_low} and {trmon_high}, found {len(run_nanorc.trmon_files)} \N{POLICE CARS REVOLVING LIGHT}"
+            f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of TRMon data files was found, expected between {trmon_low} and {trmon_high}, found {len(run_dunerc.trmon_files)} \N{POLICE CARS REVOLVING LIGHT}"
         )
 
-    for idx in range(len(run_nanorc.trmon_files)):
-        data_file = data_file_checks.DataFile(run_nanorc.trmon_files[idx])
+    for idx in range(len(run_dunerc.trmon_files)):
+        data_file = data_file_checks.DataFile(run_dunerc.trmon_files[idx])
         all_ok &= data_file_checks.sanity_check(data_file)
         all_ok &= data_file_checks.check_file_attributes(data_file)
         all_ok &= data_file_checks.check_event_count(data_file, 1, 0)


### PR DESCRIPTION
# Description

These changes follow along with the ones in DUNE-DAQ/integrationtest#147.  They convert the obsolete "nanorc" name in our integration tests to a more generic "dunerc" name.

Other than observing the new "dunerc" name in the integtest output, users should not notice a difference, and all integtests in this repo should continue to work

Here are suggestions for testing the changes:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260311_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
git clone https://github.com/DUNE-DAQ/dfmodules.git -b kbiery/nanorc_to_dunerc_name_change
cd ..

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -r dfmodules --concise

echo ""
echo -e "\U1F535 \U2705 Note that all of the modified integtests passed, modulo any problems with inserting TAs into latency buffers, which are unrelated. \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
