### PR TITLE
JCF: DUNE-DAQ/daqdataformats#79: replace daqdataformats::TriggerRecor…

### DIFF
--- a/plugins/TRBModule.cpp
+++ b/plugins/TRBModule.cpp
@@ -353,7 +353,7 @@ TRBModule::fragments_callback(std::unique_ptr<daqdataformats::Fragment>& temp_fr
 
       for (size_t i = 0; i < header.get_num_requested_components(); ++i) {
 
-        const daqdataformats::ComponentRequest& request = header[i];
+        const daqdataformats::ComponentRequest& request = header.at(i);
         if (request.component == temp_fragment->get_element_id()) {
           requested = true;
           break;


### PR DESCRIPTION
…dHeader::operator[] with daqdataformats::TriggerRecordHeader::at, which performs the identical function and hasn't been removed from the code

# Description

In `TRBModule` a call to `daqdataformats::ComponentRequest::operator[]` is replaced with a call to `daqdataformats::ComponentRequest::at` as the former has been removed for reasons described in DUNE-DAQ/daqdataformats#81. Note `at` does exactly the same thing `operator[]` did. 

To test the changes, make sure the code still builds, alongside `daqdataformats` and `dfmessages` checked out to the branches of the same name, `johnfreeman/daqdataformats_issue79_code_refactoring`. Also confirm for yourself by looking at `daqdataformats::ComponentRequest::at` that it does the same thing `daqdataformats::ComponentRequest::operator[]` did. 


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [X] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

I suppose this is an optimization in the sense that `dfmodules` won't build unless this is merged once https://github.com/DUNE-DAQ/daqdataformats/pull/81 is merged into `daqdataformats`. 

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

