### PR TITLE
Added net_receiver elements in NetworkDetectorToDaqConnection declarations in hdf5write_test_hwmap.data.xml

### DIFF
--- a/test/config/hdf5write_test_hwmap.data.xml
+++ b/test/config/hdf5write_test_hwmap.data.xml
@@ -365,90 +365,114 @@
  <rel name="net_senders">
   <ref class="FakeDataSender" id="det-streams-1-1"/>
  </rel>
+ <rel name="net_receiver" class="FakeDataReceiver" id="dataRec-0"/>
 </obj>
 
 <obj class="NetworkDetectorToDaqConnection" id="det-1-2">
  <rel name="net_senders">
   <ref class="FakeDataSender" id="det-streams-1-2"/>
  </rel>
+ <rel name="net_receiver" class="FakeDataReceiver" id="dataRec-0"/>
 </obj>
 
 <obj class="NetworkDetectorToDaqConnection" id="det-1-3">
  <rel name="net_senders">
   <ref class="FakeDataSender" id="det-streams-1-3"/>
  </rel>
+ <rel name="net_receiver" class="FakeDataReceiver" id="dataRec-0"/>
 </obj>
 
 <obj class="NetworkDetectorToDaqConnection" id="det-1-4">
  <rel name="net_senders">
   <ref class="FakeDataSender" id="det-streams-1-4"/>
  </rel>
+ <rel name="net_receiver" class="FakeDataReceiver" id="dataRec-0"/>
 </obj>
 
 <obj class="NetworkDetectorToDaqConnection" id="det-1-5">
  <rel name="net_senders">
   <ref class="FakeDataSender" id="det-streams-1-5"/>
  </rel>
+ <rel name="net_receiver" class="FakeDataReceiver" id="dataRec-0"/>
 </obj>
 
 <obj class="NetworkDetectorToDaqConnection" id="det-10-1">
  <rel name="net_senders">
   <ref class="FakeDataSender" id="det-streams-10-1"/>
  </rel>
+ <rel name="net_receiver" class="FakeDataReceiver" id="dataRec-0"/>
 </obj>
 
 <obj class="NetworkDetectorToDaqConnection" id="det-10-2">
  <rel name="net_senders">
   <ref class="FakeDataSender" id="det-streams-10-2"/>
  </rel>
+ <rel name="net_receiver" class="FakeDataReceiver" id="dataRec-0"/>
 </obj>
 
 <obj class="NetworkDetectorToDaqConnection" id="det-10-3">
  <rel name="net_senders">
   <ref class="FakeDataSender" id="det-streams-10-3"/>
  </rel>
+ <rel name="net_receiver" class="FakeDataReceiver" id="dataRec-0"/>
 </obj>
 
 <obj class="NetworkDetectorToDaqConnection" id="det-10-4">
  <rel name="net_senders">
   <ref class="FakeDataSender" id="det-streams-10-4"/>
  </rel>
+ <rel name="net_receiver" class="FakeDataReceiver" id="dataRec-0"/>
 </obj>
 
 <obj class="NetworkDetectorToDaqConnection" id="det-10-5">
  <rel name="net_senders">
   <ref class="FakeDataSender" id="det-streams-10-5"/>
  </rel>
+ <rel name="net_receiver" class="FakeDataReceiver" id="dataRec-0"/>
+</obj>
+
+<obj class="FakeDataReceiver" id="dataRec-0">
+ <rel name="uses" class="NetworkInterface" id="nic-0"/>
+</obj>
+
+<obj class="NetworkInterface" id="nic-0">
+ <attr name="mac_address" type="string" val="00:00:00:00:00:00"/>
+ <attr name="network_name" type="enum" val="Control"/>
 </obj>
 
 <obj class="FakeDataSender" id="det-streams-1-1">
  <rel name="streams">
   <ref class="DetectorStream" id="dummyStream-1-1"/>
  </rel>
+ <rel name="uses" class="NetworkInterface" id="nic-0"/>
 </obj>
 
 <obj class="FakeDataSender" id="det-streams-1-2">
  <rel name="streams">
   <ref class="DetectorStream" id="dummyStream-2-1"/>
  </rel>
+ <rel name="uses" class="NetworkInterface" id="nic-0"/>
 </obj>
 
 <obj class="FakeDataSender" id="det-streams-1-3">
  <rel name="streams">
   <ref class="DetectorStream" id="dummyStream-3-1"/>
  </rel>
+ <rel name="uses" class="NetworkInterface" id="nic-0"/>
 </obj>
 
 <obj class="FakeDataSender" id="det-streams-1-4">
  <rel name="streams">
   <ref class="DetectorStream" id="dummyStream-4-1"/>
  </rel>
+ <rel name="uses" class="NetworkInterface" id="nic-0"/>
 </obj>
 
 <obj class="FakeDataSender" id="det-streams-1-5">
  <rel name="streams">
   <ref class="DetectorStream" id="dummyStream-5-1"/>
  </rel>
+ <rel name="uses" class="NetworkInterface" id="nic-0"/>
 </obj>
 
 <obj class="FakeDataSender" id="det-streams-10-1">
@@ -464,6 +488,7 @@
   <ref class="DetectorStream" id="dummyStream-1-9"/>
   <ref class="DetectorStream" id="dummyStream-1-10"/>
  </rel>
+ <rel name="uses" class="NetworkInterface" id="nic-0"/>
 </obj>
 
 <obj class="FakeDataSender" id="det-streams-10-2">
@@ -479,6 +504,7 @@
   <ref class="DetectorStream" id="dummyStream-2-9"/>
   <ref class="DetectorStream" id="dummyStream-2-10"/>
  </rel>
+ <rel name="uses" class="NetworkInterface" id="nic-0"/>
 </obj>
 
 <obj class="FakeDataSender" id="det-streams-10-3">
@@ -494,6 +520,7 @@
   <ref class="DetectorStream" id="dummyStream-3-9"/>
   <ref class="DetectorStream" id="dummyStream-3-10"/>
  </rel>
+ <rel name="uses" class="NetworkInterface" id="nic-0"/>
 </obj>
 
 <obj class="FakeDataSender" id="det-streams-10-4">
@@ -509,6 +536,7 @@
   <ref class="DetectorStream" id="dummyStream-4-9"/>
   <ref class="DetectorStream" id="dummyStream-4-10"/>
  </rel>
+ <rel name="uses" class="NetworkInterface" id="nic-0"/>
 </obj>
 
 <obj class="FakeDataSender" id="det-streams-10-5">
@@ -524,6 +552,7 @@
   <ref class="DetectorStream" id="dummyStream-5-9"/>
   <ref class="DetectorStream" id="dummyStream-5-10"/>
  </rel>
+ <rel name="uses" class="NetworkInterface" id="nic-0"/>
 </obj>
 
 <obj class="GeoId" id="dummyGeoId-1-1">


### PR DESCRIPTION
# Description

Addresses #492 

This fixes the recently observed crash in the `HDF5Write_test` unit test, and it brings the `NetworkDetectorToDaqConnection` declarations more in line with current usage. 

I also added `NetworkInterface` elements in `FakeDataSender` declarations, in the same spirit (trying to stay up-to-date).

Here are suggested instructions for testing this change:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260629_A9 ${DATE_PREFIX}FDDevHDF5WriteTestFix_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevHDF5WriteTestFix_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
git clone https://github.com/DUNE-DAQ/dfmodules.git -b develop
cd ..

. ./env.sh
dbt-build -j 12
dbt-workarea-env

dbt-build -j 12 --unittest dfmodules

echo ""
echo -e "\U1F535 \U2705 Note that the HDF5Write_test unit test failed. \U2705 \U1F535"
echo ""
echo ""
sleep 3

cd sourcecode/dfmodules
git checkout kbiery/test_hwmap_updates
cd ../..

dbt-build -j 12 --unittest dfmodules

echo ""
echo -e "\U1F535 \U2705 Note that the HDF5Write_test unit test works with the updated hdf5write_test_hwmap.data.xml file. \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
