### PR TITLE
Fixed parts of hdf5write_test_hwmap.data.xml…

### DIFF
--- a/test/config/hdf5write_test_hwmap.data.xml
+++ b/test/config/hdf5write_test_hwmap.data.xml
@@ -91,9 +91,9 @@
 </obj>
 
 <obj class="AVXThresholdProcessor" id="tpg-threshold-proc">
- <attr name="plane0" type="u16" val="100"/>
- <attr name="plane1" type="u16" val="100"/>
- <attr name="plane2" type="u16" val="100"/>
+ <attr name="plane0" type="s16" val="100"/>
+ <attr name="plane1" type="s16" val="100"/>
+ <attr name="plane2" type="s16" val="100"/>
 </obj>
 
 <obj class="DPDKReaderConf" id="def-emu-nic-receiver-conf">
@@ -899,6 +899,12 @@
  </attr>
 </obj>
 
+<obj class="SamplesOverThresholdMinima" id="def-sot-minima">
+ <attr name="sot_minimum_plane0" type="u16" val="1"/>
+ <attr name="sot_minimum_plane1" type="u16" val="1"/>
+ <attr name="sot_minimum_plane2" type="u16" val="1"/>
+</obj>
+
 <obj class="TPCRawDataProcessor" id="def-wib-processor">
  <attr name="queue_sizes" type="u32" val="10000"/>
  <attr name="thread_names_prefix" type="string" val="postproc-"/>
@@ -908,6 +914,16 @@
   <ref class="AVXFrugalPedestalSubtractProcessor" id="tpg-pedsub-proc"/>
   <ref class="AVXThresholdProcessor" id="tpg-threshold-proc"/>
  </rel>
+ <rel name="sot_minima" class="SamplesOverThresholdMinima" id="def-sot-minima"/>
+</obj>
+
+<obj class="FragmentAggregatorConf" id="frag-agg-01">
+ <attr name="fragment_send_timeout_ms" type="u32" val="1000"/>
+</obj>
+
+<obj class="DataMoveCallbackDescriptor" id="wib-eth-raw-input">
+ <attr name="uid_base" type="string" val="raw_input_"/>
+ <attr name="data_type" type="string" val="WIBEthFrame"/>
 </obj>
 
 <obj class="ReadoutApplication" id="ru-3-1">
@@ -924,6 +940,8 @@
  <rel name="uses" class="RoHwConfig" id="rohw-1"/>
  <rel name="link_handler" class="DataHandlerConf" id="def-link-handler"/>
  <rel name="data_reader" class="DPDKReaderConf" id="def-emu-nic-receiver-conf"/>
+ <rel name="fragment_aggregator" class="FragmentAggregatorConf" id="frag-agg-01"/>
+ <rel name="callback_desc" class="DataMoveCallbackDescriptor" id="wib-eth-raw-input"/>
 </obj>
 
 <obj class="ReadoutApplication" id="ru-5-1">
@@ -942,6 +960,8 @@
  <rel name="uses" class="RoHwConfig" id="rohw-1"/>
  <rel name="link_handler" class="DataHandlerConf" id="def-link-handler"/>
  <rel name="data_reader" class="DPDKReaderConf" id="def-emu-nic-receiver-conf"/>
+ <rel name="fragment_aggregator" class="FragmentAggregatorConf" id="frag-agg-01"/>
+ <rel name="callback_desc" class="DataMoveCallbackDescriptor" id="wib-eth-raw-input"/>
 </obj>
 
 <obj class="ReadoutApplication" id="ru-5-10">
@@ -960,6 +980,8 @@
  <rel name="uses" class="RoHwConfig" id="rohw-1"/>
  <rel name="link_handler" class="DataHandlerConf" id="def-link-handler"/>
  <rel name="data_reader" class="DPDKReaderConf" id="def-emu-nic-receiver-conf"/>
+ <rel name="fragment_aggregator" class="FragmentAggregatorConf" id="frag-agg-01"/>
+ <rel name="callback_desc" class="DataMoveCallbackDescriptor" id="wib-eth-raw-input"/>
 </obj>
 
 <obj class="RequestHandler" id="def-data-request-handler">


### PR DESCRIPTION
…based on the results of running 'oks_check_schema -f hdf5write_test.data.xml'

# Description

Recently, Marco pointed out that parts of the `hdf5write_test_hwmap.data.xml` configuration file have become out-of-date.  Running `oks_check_schema -f hdf5write_test.data.xml` showed several problems.  The changes in this PR fix those problems.

One question that I have is whether it is appropriate to have quotes around integer values in OKS configuration files such as this.  For example, in the AVXThresholdProcessor values on lines 94-96.  Is that OK?

Here are suggested instructions for testing these changes:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260705_A9 ${DATE_PREFIX}FDDevConfigFixes_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevConfigFixes_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b kbiery/test_config_fixes
git clone https://github.com/DUNE-DAQ/dfmodules.git -b kbiery/test_config_fixes
cd ..

. ./env.sh
dbt-build -j 12
dbt-workarea-env

oks_check_schema -f sourcecode/dfmodules/test/config/hdf5write_test.data.xml

echo ""
echo -e "\U1F535 \U2705 Note that the schema check didn't report any problems when run on the modified dfmodules code. \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
