### PR TITLE
Fixed the disabling of the data writing in the TPStreamWriterModule

### DIFF
--- a/integtest/disabled_output_test.py
+++ b/integtest/disabled_output_test.py
@@ -203,8 +203,12 @@ def test_data_files(run_dunerc):
     all_ok = True
     # Run some tests on the output data file
     all_ok &= len(run_dunerc.data_files) == expected_number_of_data_files
+    if all_ok:
+        if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+            print(f"\N{WHITE HEAVY CHECK MARK} The correct number of raw data files was found ({expected_number_of_data_files})")
+    else:
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of raw data files was found, expected {expected_number_of_data_files}, found {len(run_dunerc.data_files)} \N{POLICE CARS REVOLVING LIGHT}")
 
-    all_ok = True
     for idx in range(len(run_dunerc.data_files)):
         data_file = data_file_checks.DataFile(run_dunerc.data_files[idx], run_dunerc.verbosity_helper)
         all_ok &= data_file_checks.sanity_check(data_file)
@@ -219,4 +223,21 @@ def test_data_files(run_dunerc):
             all_ok &= data_file_checks.check_fragment_sizes(
                 data_file, fragment_check_list[jdx]
             )
+    assert all_ok
+
+
+def test_tpstream_files(run_dunerc):
+    tpstream_files = run_dunerc.tpset_files
+    expected_number_of_tpstream_files = expected_number_of_data_files
+    if not run_dunerc.confgen_config.tpg_enabled:
+        expected_number_of_tpstream_files = 0
+
+    print("")
+    all_ok = len(tpstream_files) == expected_number_of_tpstream_files
+    if all_ok:
+        if run_dunerc.verbosity_helper.compare_level(IntegtestVerbosityLevels.drunc_transitions):
+            print(f"\N{WHITE HEAVY CHECK MARK} The correct number of TP-stream data files was found ({expected_number_of_tpstream_files})")
+    else:
+        print(f"\N{POLICE CARS REVOLVING LIGHT} An incorrect number of TP-stream data files was found, expected {expected_number_of_tpstream_files}, found {len(tpstream_files)} \N{POLICE CARS REVOLVING LIGHT}")
+
     assert all_ok

--- a/plugins/TPStreamWriterModule.cpp
+++ b/plugins/TPStreamWriterModule.cpp
@@ -43,6 +43,7 @@ TPStreamWriterModule::TPStreamWriterModule(const std::string& name)
   : dunedaq::appfwk::DAQModule(name)
   , m_thread(std::bind(&TPStreamWriterModule::do_work, this, std::placeholders::_1))
   , m_queue_timeout(100)
+  , m_data_storage_is_enabled(true)
 {
   register_command("conf", &TPStreamWriterModule::do_conf);
   register_command("start", &TPStreamWriterModule::do_start);
@@ -119,6 +120,7 @@ TPStreamWriterModule::do_start(const CommandData_t& payload)
 {
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_start() method";
   rcif::cmd::StartParams start_params = payload.get<rcif::cmd::StartParams>();
+  m_data_storage_is_enabled = (!start_params.disable_data_storage);
   m_run_number = start_params.run;
   m_total_tps_received.store(0);
   m_total_tps_written.store(0);
@@ -128,10 +130,12 @@ TPStreamWriterModule::do_start(const CommandData_t& payload)
   // I've put this call fairly early in this method because it could throw an
   // exception and abort the run start.  And, it seems sensible to avoid starting
   // threads, etc. if we throw an exception.
-  try {
-    m_data_writer->prepare_for_run(m_run_number, (start_params.production_vs_test == "TEST"));
-  } catch (const ers::Issue& excpt) {
-    throw UnableToStart(ERS_HERE, get_name(), m_run_number, excpt);
+  if (m_data_storage_is_enabled) {
+    try {
+      m_data_writer->prepare_for_run(m_run_number, (start_params.production_vs_test == "TEST"));
+    } catch (const ers::Issue& excpt) {
+      throw UnableToStart(ERS_HERE, get_name(), m_run_number, excpt);
+    }
   }
 
   m_thread.start_working_thread(get_name());
@@ -149,10 +153,12 @@ TPStreamWriterModule::do_stop(const CommandData_t& /*payload*/)
   // 06-Mar-2022, KAB: added this call to allow DataStore to finish up with this run.
   // I've put this call fairly late in this method so that any draining of queues
   // (or whatever) can take place before we finalize things in the DataStore.
-  try {
-    m_data_writer->finish_with_run(m_run_number);
-  } catch (const std::exception& excpt) {
-    ers::error(ProblemDuringStop(ERS_HERE, get_name(), m_run_number, excpt));
+  if (m_data_storage_is_enabled) {
+    try {
+      m_data_writer->finish_with_run(m_run_number);
+    } catch (const std::exception& excpt) {
+      ers::error(ProblemDuringStop(ERS_HERE, get_name(), m_run_number, excpt));
+    }
   }
 
   TLOG() << get_name() << " successfully stopped for run number " << m_run_number;
@@ -243,57 +249,60 @@ TPStreamWriterModule::do_work(std::atomic<bool>& running_flag)
       daqdataformats::SourceID sid(daqdataformats::SourceID::Subsystem::kTRBuilder, m_source_id);
       timeslice_ptr->set_element_id(sid);
 
-      // write the TSH and the fragments as a set of data blocks
-      bool should_retry = true;
-      size_t retry_wait_usec = 1000;
-      do {
-        should_retry = false;
-        size_t number_of_tps = (timeslice_ptr->get_sum_of_fragment_payload_sizes() / sizeof(trgdataformats::TriggerPrimitive));
-        try {
-          m_data_writer->write(*timeslice_ptr);
-          ++m_timeslices_written;
-          m_bytes_output += timeslice_ptr->get_total_size_bytes();
-          m_tps_written += number_of_tps;
-          m_total_tps_written += number_of_tps;
-        } catch (const RetryableDataStoreProblem& excpt) {
-          should_retry = true;
-          ers::error(DataWritingProblem(ERS_HERE,
-                                        get_name(),
-                                        timeslice_ptr->get_header().timeslice_number,
-                                        timeslice_ptr->get_header().run_number,
-                                        excpt));
-          usleep(retry_wait_usec);
-          retry_wait_usec = std::min(retry_wait_usec * 2, 1000000UL);
-        } catch (const IgnorableDataStoreProblem& excpt) {
-          int timeslice_number_diff = largest_timeslice_number - timeslice_ptr->get_header().timeslice_number;
-          double seconds_too_late = m_accumulation_interval_seconds * timeslice_number_diff;
-          m_tardy_timeslice_max_seconds = std::max(m_tardy_timeslice_max_seconds.load(), seconds_too_late);
-          m_tps_discarded += number_of_tps;
-          m_total_tps_discarded += number_of_tps;
-          if (m_warn_user_when_tardy_tps_are_discarded) {
-            std::ostringstream sid_list;
-            bool first_frag = true;
-            for (auto const& frag_ptr : timeslice_ptr->get_fragments_ref()) {
-              if (first_frag) {first_frag = false;}
-              else {sid_list << ",";}
-              sid_list << frag_ptr->get_element_id().to_string();
+      if (m_data_storage_is_enabled) {
+
+        // write the TSH and the fragments as a set of data blocks
+        bool should_retry = true;
+        size_t retry_wait_usec = 1000;
+        do {
+          should_retry = false;
+          size_t number_of_tps = (timeslice_ptr->get_sum_of_fragment_payload_sizes() / sizeof(trgdataformats::TriggerPrimitive));
+          try {
+            m_data_writer->write(*timeslice_ptr);
+            ++m_timeslices_written;
+            m_bytes_output += timeslice_ptr->get_total_size_bytes();
+            m_tps_written += number_of_tps;
+            m_total_tps_written += number_of_tps;
+          } catch (const RetryableDataStoreProblem& excpt) {
+            should_retry = true;
+            ers::error(DataWritingProblem(ERS_HERE,
+                                          get_name(),
+                                          timeslice_ptr->get_header().timeslice_number,
+                                          timeslice_ptr->get_header().run_number,
+                                          excpt));
+            usleep(retry_wait_usec);
+            retry_wait_usec = std::min(retry_wait_usec * 2, 1000000UL);
+          } catch (const IgnorableDataStoreProblem& excpt) {
+            int timeslice_number_diff = largest_timeslice_number - timeslice_ptr->get_header().timeslice_number;
+            double seconds_too_late = m_accumulation_interval_seconds * timeslice_number_diff;
+            m_tardy_timeslice_max_seconds = std::max(m_tardy_timeslice_max_seconds.load(), seconds_too_late);
+            m_tps_discarded += number_of_tps;
+            m_total_tps_discarded += number_of_tps;
+            if (m_warn_user_when_tardy_tps_are_discarded) {
+              std::ostringstream sid_list;
+              bool first_frag = true;
+              for (auto const& frag_ptr : timeslice_ptr->get_fragments_ref()) {
+                if (first_frag) {first_frag = false;}
+                else {sid_list << ",";}
+                sid_list << frag_ptr->get_element_id().to_string();
+              }
+              ers::warning(TardyTPsDiscarded(ERS_HERE,
+                                             get_name(),
+                                             sid_list.str(),
+                                             timeslice_ptr->get_header().timeslice_number,
+                                             seconds_too_late));
             }
-            ers::warning(TardyTPsDiscarded(ERS_HERE,
-                                           get_name(),
-                                           sid_list.str(),
-                                           timeslice_ptr->get_header().timeslice_number,
-                                           seconds_too_late));
+          } catch (const std::exception& excpt) {
+            m_tps_discarded += number_of_tps;
+            m_total_tps_discarded += number_of_tps;
+            ers::error(DataWritingProblem(ERS_HERE,
+                                          get_name(),
+                                          timeslice_ptr->get_header().timeslice_number,
+                                          timeslice_ptr->get_header().run_number,
+                                          excpt));
           }
-        } catch (const std::exception& excpt) {
-          m_tps_discarded += number_of_tps;
-          m_total_tps_discarded += number_of_tps;
-          ers::error(DataWritingProblem(ERS_HERE,
-                                        get_name(),
-                                        timeslice_ptr->get_header().timeslice_number,
-                                        timeslice_ptr->get_header().run_number,
-                                        excpt));
-        }
-      } while (should_retry && running_flag.load());
+        } while (should_retry && running_flag.load());
+      }  // if (m_data_storage_is_enabled) {
     }
 
     if (first_timestamp == 0) {

--- a/plugins/TPStreamWriterModule.hpp
+++ b/plugins/TPStreamWriterModule.hpp
@@ -70,6 +70,7 @@ private:
   bool m_warn_user_when_tardy_tps_are_discarded;
   double m_accumulation_interval_seconds;
   std::string m_writer_identifier;
+  bool m_data_storage_is_enabled;
 
   // Queue sources and sinks
   using source_t = iomanager::ReceiverConcept<trigger::TPSet>;


### PR DESCRIPTION
# Description

Some time ago, Michal reported that the `--disable-data-storage` option that is part of the run control `start` command was **_not_** causing TPStream file writing to be disabled (even though it disables the writing of raw data files).

It turns out that the "output disable" logic had not been included in the `TPStreamWriterModule`.  This PR fixes that.

In addition, the change in this PR add the checking of the number of TPStream files written in the `disabled_output_test.py` regression test, which was another oversight.  With the changes in this PR, this regression test runs successfully *and* verifies that there are no TPStream files written to disk when the `--disable-data-storage` flag is used.

Here are suggested instructions for testing these changes:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260716_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
git clone https://github.com/DUNE-DAQ/dfmodules.git -b kbiery/tpsw_output_disable

cd ..

. ./env.sh
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -r dfmodules -k disable

echo ""
echo -e "\U1F535 \U2705 Note that the disabled_output_test ran successfully, including the correct number of TPStream files. \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)

## Further checks

I will `clang-format` the TPStreamWriter code as a separate step...